### PR TITLE
fix cabal file fields; reduce boilerplate

### DIFF
--- a/fficxx/fficxx.cabal
+++ b/fficxx/fficxx.cabal
@@ -1,7 +1,7 @@
 Name:		fficxx
 Version:	0.2.0
 Synopsis:	automatic C++ binding generation
-Description: 	automatic C++ binding generation 
+Description: 	automatic C++ binding generation
 License:        BSD3
 License-file:	LICENSE
 Author:		Ian-Woo Kim
@@ -32,27 +32,28 @@ Library
   hs-source-dirs: lib
   ghc-options: 	-Wall -funbox-strict-fields -fno-warn-unused-do-bind
   ghc-prof-options: -caf-all -auto-all
-  Build-Depends: base == 4.* , 
-                 mtl>2, 
-                 containers, 
-                 filepath>1, 
-                 directory, 
-                 HStringTemplate, 
+  Build-Depends: base == 4.* ,
+                 data-default,
+                 mtl>2,
+                 containers,
+                 filepath>1,
+                 directory,
+                 HStringTemplate,
                  split,
                  process,
-                 transformers >= 0.3, 
-                 template-haskell,  
+                 transformers >= 0.3,
+                 template-haskell,
                  hashable,
                  unordered-containers,
                  lens > 3,
-                 either, 
+                 either,
                  errors < 2.0,
                  bytestring,
-                 pureMD5,  
+                 pureMD5,
                  Cabal
 
-  Exposed-Modules: 
-                   FFICXX.Generate.Builder 
+  Exposed-Modules:
+                   FFICXX.Generate.Builder
                    FFICXX.Generate.Type.Class
                    FFICXX.Generate.Type.Module
                    FFICXX.Generate.Type.PackageInterface

--- a/fficxx/lib/FFICXX/Generate/Builder.hs
+++ b/fficxx/lib/FFICXX/Generate/Builder.hs
@@ -2,7 +2,7 @@
 
 -----------------------------------------------------------------------------
 -- |
--- Module      : FFICXX.Generate.Builder 
+-- Module      : FFICXX.Generate.Builder
 -- Copyright   : (c) 2011-2013 Ian-Woo Kim
 --
 -- License     : BSD3
@@ -12,7 +12,7 @@
 --
 -----------------------------------------------------------------------------
 
-module FFICXX.Generate.Builder where 
+module FFICXX.Generate.Builder where
 
 import          Data.Char (toUpper)
 import          Data.Monoid (mempty)
@@ -28,134 +28,145 @@ import           FFICXX.Generate.Config
 import           FFICXX.Generate.Code.Cpp
 import           FFICXX.Generate.Code.Dependency
 import           FFICXX.Generate.Config
-import           FFICXX.Generate.Generator.ContentMaker 
+import           FFICXX.Generate.Generator.ContentMaker
 import           FFICXX.Generate.Generator.Driver
 import           FFICXX.Generate.Type.Annotate
-import           FFICXX.Generate.Type.Class
+import           FFICXX.Generate.Type.Class ( Cabal(..)
+                                            , Class
+                                            , ClassModule
+                                            , Namespace(NS)
+                                            , TopLevelFunction
+                                            , TopLevelImportHeader
+                                            , cabal_license
+                                            , cabal_licensefile
+                                            )
 import           FFICXX.Generate.Type.PackageInterface
 import           FFICXX.Generate.Util
--- 
+--
 import qualified FFICXX.Paths_fficxx as F
 
--- | 
-cabalTemplate :: String 
+-- |
+cabalTemplate :: String
 cabalTemplate = "Pkg.cabal"
 
 
--- | 
+-- |
 mkCabalFile :: FFICXXConfig
-            -> STGroup String  
+            -> STGroup String
             -> Cabal
             -> (TopLevelImportHeader,[ClassModule])
-            -> FilePath  
-            -> IO () 
-mkCabalFile config templates cabal (tih,classmodules) cabalfile = do 
-  cpath <- getCurrentDirectory 
- 
-  let str = renderTemplateGroup 
-              templates 
-              [ ("pkgname", cabal_pkgname cabal) 
-              , ("version",  "0.0") 
-              , ("license", "mit" )
-	      , ("licensefile", "LICENSE" )
-              , ("buildtype", "Simple")
-              , ("deps", "" ) 
-              , ("csrcFiles", genCsrcFiles (tih,classmodules))
-              , ("includeFiles", genIncludeFiles (cabal_pkgname cabal) classmodules) 
-              , ("cppFiles", genCppFiles (tih,classmodules))
-              , ("exposedModules", genExposedModules (cabal_pkgname cabal) classmodules) 
-              , ("otherModules", genOtherModules classmodules)
-              , ("extralibdirs", "" )  
-              , ("extraincludedirs", "" )  
-              , ("extralib", ", snappy")
-              , ("cabalIndentation", cabalIndentation)
-              ]
-              cabalTemplate 
+            -> FilePath
+            -> IO ()
+mkCabalFile config templates cabal (tih, classmodules) cabalfile = do
+  cpath <- getCurrentDirectory
+
+  let str = renderTemplateGroup
+              templates
+              ( [ ("licenseField", "license: " ++ license)
+                  | Just license <- [cabal_license cabal] ] ++
+                [ ("licenseFileField", "license-file: " ++ licensefile)
+                  | Just licensefile <- [cabal_licensefile cabal] ] ++
+                [ ("pkgname", cabal_pkgname cabal)
+                , ("version",  "0.0")
+                , ("buildtype", "Simple")
+                , ("deps", "")
+                , ("csrcFiles", genCsrcFiles (tih,classmodules))
+                , ("includeFiles", genIncludeFiles (cabal_pkgname cabal) classmodules)
+                , ("cppFiles", genCppFiles (tih,classmodules))
+                , ("exposedModules", genExposedModules (cabal_pkgname cabal) classmodules)
+                , ("otherModules", genOtherModules classmodules)
+                , ("extralibdirs", "")
+                , ("extraincludedirs", "")
+                , ("extralib", ", snappy")
+                , ("cabalIndentation", cabalIndentation)
+                ]
+              )
+              cabalTemplate
   writeFile cabalfile str
 
 
-macrofy :: String -> String 
+macrofy :: String -> String
 macrofy = map ((\x->if x=='-' then '_' else x) . toUpper)
 
 simpleBuilder :: (Cabal,[Class],[TopLevelFunction]) ->  IO ()
-simpleBuilder (cabal,myclasses, toplevelfunctions) = do 
-  putStrLn "generate snappy" 
-  cwd <- getCurrentDirectory 
+simpleBuilder (cabal,myclasses, toplevelfunctions) = do
+  putStrLn "generate snappy"
+  cwd <- getCurrentDirectory
 
-  let cfg =  FFICXXConfig { fficxxconfig_scriptBaseDir = cwd 
+  let cfg =  FFICXXConfig { fficxxconfig_scriptBaseDir = cwd
                           , fficxxconfig_workingDir = cwd </> "working"
                           , fficxxconfig_installBaseDir = cwd </> (cabal_pkgname cabal)
-                          } 
+                          }
       workingDir = fficxxconfig_workingDir cfg
-      installDir = fficxxconfig_installBaseDir cfg 
-      pkgname = "Snappy" 
-      (mods,cihs,tih) = mkAll_ClassModules_CIH_TIH 
-                          ("Snappy", (const ([NS "snappy"],["snappy-sinksource.h","snappy.h"]))) 
+      installDir = fficxxconfig_installBaseDir cfg
+      pkgname = "Snappy"
+      (mods,cihs,tih) = mkAll_ClassModules_CIH_TIH
+                          ("Snappy", (const ([NS "snappy"],["snappy-sinksource.h","snappy.h"])))
                           (myclasses, toplevelfunctions)
-      hsbootlst = mkHSBOOTCandidateList mods 
-      cglobal = mkGlobal myclasses 
-      summarymodule = "Snappy" 
+      hsbootlst = mkHSBOOTCandidateList mods
+      cglobal = mkGlobal myclasses
+      summarymodule = "Snappy"
       cabalFileName = "Snappy.cabal"
   templateDir <- F.getDataDir >>= return . (</> "template")
-  (templates :: STGroup String) <- directoryGroup templateDir 
-  -- 
+  (templates :: STGroup String) <- directoryGroup templateDir
+  --
   notExistThenCreate workingDir
-  notExistThenCreate installDir 
-  notExistThenCreate (installDir </> "src") 
+  notExistThenCreate installDir
+  notExistThenCreate (installDir </> "src")
   notExistThenCreate (installDir </> "csrc")
-  -- 
-  putStrLn "cabal file generation" 
+  --
+  putStrLn "cabal file generation"
   mkCabalFile cfg templates cabal (tih,mods) (workingDir </> cabalFileName)
-  -- 
+  --
   putStrLn "header file generation"
   let typmacro = TypMcro ("__"  ++ macrofy (cabal_pkgname cabal) ++ "__")  {- "__SNAPPY__" -}
   writeTypeDeclHeaders templates workingDir typmacro pkgname cihs
   mapM_ (writeDeclHeaders templates workingDir typmacro pkgname) cihs
   writeTopLevelFunctionHeaders templates workingDir typmacro pkgname tih
-  -- 
-  putStrLn "cpp file generation" 
+  --
+  putStrLn "cpp file generation"
   mapM_ (writeCppDef templates workingDir) cihs
   writeTopLevelFunctionCppDef templates workingDir typmacro pkgname tih
-  -- 
-  putStrLn "RawType.hs file generation" 
-  mapM_ (writeRawTypeHs templates workingDir) mods 
-  -- 
+  --
+  putStrLn "RawType.hs file generation"
+  mapM_ (writeRawTypeHs templates workingDir) mods
+  --
   putStrLn "FFI.hsc file generation"
   mapM_ (writeFFIHsc templates workingDir) mods
-  -- 
-  putStrLn "Interface.hs file generation" 
+  --
+  putStrLn "Interface.hs file generation"
   mapM_ (writeInterfaceHs mempty templates workingDir) mods
-  -- 
+  --
   putStrLn "Cast.hs file generation"
   mapM_ (writeCastHs templates workingDir) mods
-  -- 
+  --
   putStrLn "Implementation.hs file generation"
   mapM_ (writeImplementationHs mempty templates workingDir) mods
-  -- 
-  putStrLn "hs-boot file generation" 
-  mapM_ (writeInterfaceHSBOOT templates workingDir) hsbootlst  
-  -- 
-  putStrLn "module file generation" 
+  --
+  putStrLn "hs-boot file generation"
+  mapM_ (writeInterfaceHSBOOT templates workingDir) hsbootlst
+  --
+  putStrLn "module file generation"
   mapM_ (writeModuleHs templates workingDir) mods
-  -- 
+  --
   putStrLn "summary module generation generation"
   writePkgHs summarymodule templates workingDir mods tih
-  -- 
+  --
   putStrLn "copying"
-  touch (workingDir </> "LICENSE")  
+  touch (workingDir </> "LICENSE")
   copyFileWithMD5Check (workingDir </> cabalFileName)  (installDir </> cabalFileName)
   copyFileWithMD5Check (workingDir </> "LICENSE") (installDir </> "LICENSE")
   -- copyPredefined templateDir (srcDir ibase) pkgname
-   
+
   copyCppFiles workingDir (csrcDir installDir) pkgname (tih,cihs)
-  mapM_ (copyModule workingDir (srcDir installDir) summarymodule) mods 
+  mapM_ (copyModule workingDir (srcDir installDir) summarymodule) mods
 
 
--- | some dirty hack. later, we will do it with more proper approcah. 
+-- | some dirty hack. later, we will do it with more proper approcah.
 
 touch :: FilePath -> IO ()
 touch fp = do
     readProcess "touch" [fp] ""
     return ()
-  
+
 

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -17,78 +17,79 @@ module FFICXX.Generate.Type.Class where
 
 import Control.Applicative ((<$>),(<*>))
 import Data.Char
-import Data.List 
-import Data.Monoid 
+import Data.Default (Default(def))
+import Data.List
+import Data.Monoid
 import qualified Data.Map as M
-import System.FilePath 
--- 
+import System.FilePath
+--
 import FFICXX.Generate.Util
 
 -- | C types
-data CTypes = CTString 
-            | CTChar 
-            | CTInt 
+data CTypes = CTString
+            | CTChar
+            | CTInt
             | CTUInt
             | CTLong
             | CTULong
-            | CTDouble 
-            | CTBool 
-            | CTDoubleStar 
-            | CTVoidStar 
-            | CTIntStar 
-            | CTCharStarStar 
-            | CPointer CTypes 
-            deriving Show 
+            | CTDouble
+            | CTBool
+            | CTDoubleStar
+            | CTVoidStar
+            | CTIntStar
+            | CTCharStarStar
+            | CPointer CTypes
+            deriving Show
 
--- | C++ types 
-data CPPTypes = CPTClass Class 
-              | CPTClassRef Class 
+-- | C++ types
+data CPPTypes = CPTClass Class
+              | CPTClassRef Class
               deriving Show
 
 -- | const flag
 data IsConst = Const | NoConst
              deriving Show
 
-data Types = Void 
+data Types = Void
            | SelfType
-           | CT  CTypes IsConst 
+           | CT  CTypes IsConst
            | CPT CPPTypes IsConst
            deriving Show
 
 cvarToStr :: CTypes -> IsConst -> String -> String
-cvarToStr ctyp isconst varname = (ctypToStr ctyp isconst) `connspace` varname 
+cvarToStr ctyp isconst varname = (ctypToStr ctyp isconst) `connspace` varname
 
 ctypToStr :: CTypes -> IsConst -> String
-ctypToStr ctyp isconst = 
-  let typword = case ctyp of 
+ctypToStr ctyp isconst =
+  let typword = case ctyp of
         CTString -> "char*"
-        CTChar   -> "char" 
-        CTInt    -> "int" 
+        CTChar   -> "char"
+        CTInt    -> "int"
         CTUInt   -> "unsigned int"
         CTLong   -> "signed long"
         CTULong  -> "long unsigned int"
-        CTDouble -> "double" 
+        CTDouble -> "double"
         CTBool   -> "int"              -- Currently available solution
         CTDoubleStar -> "double *"
         CTVoidStar -> "void*"
         CTIntStar -> "int*"
         CTCharStarStar -> "char**"
-        CPointer s -> ctypToStr s NoConst ++ "*"  
-  in case isconst of 
-        Const   -> "const" `connspace` typword 
-        NoConst -> typword 
+        CPointer s -> ctypToStr s NoConst ++ "*"
+  in case isconst of
+        Const   -> "const" `connspace` typword
+        NoConst -> typword
 
 
-self_ :: Types 
+self_ :: Types
 self_ = SelfType
 
 cstring_ :: Types
-cstring_ = CT CTString Const 
+cstring_ = CT CTString Const
 
 cint_ :: Types
 cint_    = CT CTInt    Const
 
-int_ :: Types 
+int_ :: Types
 int_     = CT CTInt    NoConst
 
 uint_ :: Types
@@ -106,11 +107,11 @@ culong_ = CT CTULong Const
 clong_ :: Types
 clong_ = CT CTLong Const
 
-cchar_ :: Types 
+cchar_ :: Types
 cchar_ = CT CTChar Const
 
 char_ :: Types
-char_ = CT CTChar NoConst 
+char_ = CT CTChar NoConst
 
 short_ :: Types
 short_ = int_
@@ -127,39 +128,39 @@ doublep_ = CT CTDoubleStar NoConst
 float_ :: Types
 float_ = double_
 
-bool_ :: Types 
-bool_    = CT CTBool   NoConst 
+bool_ :: Types
+bool_    = CT CTBool   NoConst
 
 void_ :: Types
-void_ = Void 
+void_ = Void
 
-voidp_ :: Types 
+voidp_ :: Types
 voidp_ = CT CTVoidStar NoConst
 
-intp_ :: Types 
+intp_ :: Types
 intp_ = CT CTIntStar NoConst
 
 charpp_ :: Types
 charpp_ = CT CTCharStarStar NoConst
 
 
-star_ :: CTypes -> Types 
+star_ :: CTypes -> Types
 star_ t = CT (CPointer t) NoConst
 
-cstar_ :: CTypes -> Types 
-cstar_ t = CT (CPointer t) Const  
+cstar_ :: CTypes -> Types
+cstar_ t = CT (CPointer t) Const
 
 self :: String -> (Types, String)
 self var = (self_, var)
 
-voidp :: String -> (Types,String) 
+voidp :: String -> (Types,String)
 voidp var = (voidp_ , var)
 
 cstring :: String -> (Types,String)
 cstring var = (cstring_ , var)
 
 cint :: String -> (Types,String)
-cint    var = (cint_    , var) 
+cint    var = (cint_    , var)
 
 int :: String -> (Types,String)
 int     var = (int_     , var)
@@ -180,7 +181,7 @@ culong :: String -> (Types,String)
 culong var = (culong_ , var)
 
 cchar :: String -> (Types,String)
-cchar var = (cchar_ , var) 
+cchar var = (cchar_ , var)
 
 char :: String -> (Types,String)
 char var = (char_ , var)
@@ -203,17 +204,17 @@ float = double
 bool :: String -> (Types,String)
 bool    var = (bool_    , var)
 
-intp :: String -> (Types, String) 
+intp :: String -> (Types, String)
 intp var = (intp_ , var)
 
 charpp :: String -> (Types, String)
 charpp var = (charpp_, var)
 
 star :: CTypes -> String -> (Types, String)
-star t var = (star_ t, var) 
+star t var = (star_ t, var)
 
 cstar :: CTypes -> String -> (Types, String)
-cstar t var = (cstar_ t, var) 
+cstar t var = (cstar_ t, var)
 
 
 cppclass_ :: Class -> Types
@@ -222,30 +223,30 @@ cppclass_ c =  CPT (CPTClass c) NoConst
 cppclass :: Class -> String -> (Types, String)
 cppclass c vname = ( cppclass_ c, vname)
 
-cppclassconst :: Class -> String -> (Types, String) 
+cppclassconst :: Class -> String -> (Types, String)
 cppclassconst c vname = ( CPT (CPTClass c) Const, vname)
 
-cppclassref_ :: Class -> Types 
-cppclassref_ c = CPT (CPTClassRef c) NoConst 
+cppclassref_ :: Class -> Types
+cppclassref_ c = CPT (CPTClassRef c) NoConst
 
-cppclassref :: Class -> String -> (Types, String) 
+cppclassref :: Class -> String -> (Types, String)
 cppclassref c vname = (cppclassref_ c, vname)
 
 
-hsCTypeName :: CTypes -> String 
-hsCTypeName CTString = "CString" 
-hsCTypeName CTChar   = "CChar" 
+hsCTypeName :: CTypes -> String
+hsCTypeName CTString = "CString"
+hsCTypeName CTChar   = "CChar"
 hsCTypeName CTInt    = "CInt"
 hsCTypeName CTUInt   = "CUInt"
-hsCTypeName CTLong   = "CLong" 
-hsCTypeName CTULong  = "CULong" 
+hsCTypeName CTLong   = "CLong"
+hsCTypeName CTULong  = "CULong"
 hsCTypeName CTDouble = "CDouble"
 hsCTypeName CTDoubleStar = "(Ptr CDouble)"
 hsCTypeName CTBool   = "CInt"
 hsCTypeName CTVoidStar = "(Ptr ())"
 hsCTypeName CTIntStar = "(Ptr CInt)"
 hsCTypeName CTCharStarStar = "(Ptr (CString))"
-hsCTypeName (CPointer t) = "(Ptr " ++ hsCTypeName t ++ ")" 
+hsCTypeName (CPointer t) = "(Ptr " ++ hsCTypeName t ++ ")"
 
 
 hsCppTypeName :: CPPTypes -> String
@@ -256,109 +257,109 @@ hsCppTypeName (CPTClassRef c) = "(Ptr "++rawname++")" where rawname = snd (hsCla
 
 type Args = [(Types,String)]
 
-data Function = Constructor { func_args :: Args 
-                            , func_alias :: Maybe String 
-                            } 
+data Function = Constructor { func_args :: Args
+                            , func_alias :: Maybe String
+                            }
               | Virtual { func_ret :: Types
                         , func_name :: String
-                        , func_args :: Args 
-                        , func_alias :: Maybe String 
-                        } 
-              | NonVirtual { func_ret :: Types 
+                        , func_args :: Args
+                        , func_alias :: Maybe String
+                        }
+              | NonVirtual { func_ret :: Types
                            , func_name :: String
-                           , func_args :: Args 
-                           , func_alias :: Maybe String 
+                           , func_args :: Args
+                           , func_alias :: Maybe String
                            }
-              | Static     { func_ret :: Types 
+              | Static     { func_ret :: Types
                            , func_name :: String
-                           , func_args :: Args 
-                           , func_alias :: Maybe String 
+                           , func_args :: Args
+                           , func_alias :: Maybe String
                            }
-              | Destructor  { func_alias :: Maybe String } 
+              | Destructor  { func_alias :: Maybe String }
               deriving Show
 
 
-data TopLevelFunction = TopLevelFunction { toplevelfunc_ret :: Types 
+data TopLevelFunction = TopLevelFunction { toplevelfunc_ret :: Types
                                          , toplevelfunc_name :: String
-                                         , toplevelfunc_args :: Args 
-                                         , toplevelfunc_alias :: Maybe String 
+                                         , toplevelfunc_args :: Args
+                                         , toplevelfunc_alias :: Maybe String
                                          }
                       | TopLevelVariable { toplevelvar_ret :: Types
-                                         , toplevelvar_name :: String 
+                                         , toplevelvar_name :: String
                                          , toplevelvar_alias :: Maybe String }
-                      deriving Show 
+                      deriving Show
 
-hsFrontNameForTopLevelFunction :: TopLevelFunction -> String 
-hsFrontNameForTopLevelFunction tfn = 
-    let (x:xs) = case tfn of 
+hsFrontNameForTopLevelFunction :: TopLevelFunction -> String
+hsFrontNameForTopLevelFunction tfn =
+    let (x:xs) = case tfn of
                    TopLevelFunction {..} -> maybe toplevelfunc_name id toplevelfunc_alias
-                   TopLevelVariable {..} -> maybe toplevelvar_name id toplevelvar_alias 
-    in toLower x : xs 
+                   TopLevelVariable {..} -> maybe toplevelvar_name id toplevelvar_alias
+    in toLower x : xs
 
 
-data TopLevelImportHeader = TopLevelImportHeader { tihHeaderFileName :: String 
-                                                 , tihClassDep :: [ClassImportHeader] 
-                                                 , tihFuncs :: [TopLevelFunction] 
-                                                 } 
+data TopLevelImportHeader = TopLevelImportHeader { tihHeaderFileName :: String
+                                                 , tihClassDep :: [ClassImportHeader]
+                                                 , tihFuncs :: [TopLevelFunction]
+                                                 }
 
 
-  
-isNewFunc :: Function -> Bool 
-isNewFunc (Constructor _ _) = True 
+
+isNewFunc :: Function -> Bool
+isNewFunc (Constructor _ _) = True
 isNewFunc _ = False
 
-isDeleteFunc :: Function -> Bool 
-isDeleteFunc (Destructor _) = True 
+isDeleteFunc :: Function -> Bool
+isDeleteFunc (Destructor _) = True
 isDeleteFunc _ = False
-       
-isVirtualFunc :: Function -> Bool 
-isVirtualFunc (Destructor _)           = True
-isVirtualFunc (Virtual _ _ _ _)        = True 
-isVirtualFunc _ = False 
 
-isStaticFunc :: Function -> Bool 
+isVirtualFunc :: Function -> Bool
+isVirtualFunc (Destructor _)           = True
+isVirtualFunc (Virtual _ _ _ _)        = True
+isVirtualFunc _ = False
+
+isStaticFunc :: Function -> Bool
 isStaticFunc (Static _ _ _ _) = True
 isStaticFunc _ = False
 
-virtualFuncs :: [Function] -> [Function] 
-virtualFuncs = filter isVirtualFunc 
+virtualFuncs :: [Function] -> [Function]
+virtualFuncs = filter isVirtualFunc
 
 constructorFuncs :: [Function] -> [Function]
 constructorFuncs = filter isNewFunc
 
 nonVirtualNotNewFuncs :: [Function] -> [Function]
-nonVirtualNotNewFuncs = 
+nonVirtualNotNewFuncs =
   filter (\x -> (not.isVirtualFunc) x && (not.isNewFunc) x && (not.isDeleteFunc) x && (not.isStaticFunc) x )
 
-staticFuncs :: [Function] -> [Function] 
+staticFuncs :: [Function] -> [Function]
 staticFuncs = filter isStaticFunc
 
-argToString :: (Types,String) -> String 
-argToString (CT ctyp isconst, varname) = cvarToStr ctyp isconst varname 
+argToString :: (Types,String) -> String
+argToString (CT ctyp isconst, varname) = cvarToStr ctyp isconst varname
 argToString (SelfType, varname) = "Type ## _p " ++ varname
-argToString (CPT (CPTClass c) isconst, varname) = case isconst of 
-    Const   -> "const_" ++ cname ++ "_p " ++ varname 
+argToString (CPT (CPTClass c) isconst, varname) = case isconst of
+    Const   -> "const_" ++ cname ++ "_p " ++ varname
     NoConst -> cname ++ "_p " ++ varname
-  where cname = class_name c 
-argToString (CPT (CPTClassRef c) isconst, varname) = case isconst of 
-    Const   -> "const_" ++ cname ++ "_p " ++ varname 
+  where cname = class_name c
+argToString (CPT (CPTClassRef c) isconst, varname) = case isconst of
+    Const   -> "const_" ++ cname ++ "_p " ++ varname
     NoConst -> cname ++ "_p " ++ varname
-  where cname = class_name c  
+  where cname = class_name c
 argToString _ = error "undefined argToString"
 
-argsToString :: Args -> String 
-argsToString args = 
-  let args' = (SelfType, "p") : args 
+argsToString :: Args -> String
+argsToString args =
+  let args' = (SelfType, "p") : args
   in  intercalateWith conncomma argToString args'
 
-argsToStringNoSelf :: Args -> String 
-argsToStringNoSelf = intercalateWith conncomma argToString 
+argsToStringNoSelf :: Args -> String
+argsToStringNoSelf = intercalateWith conncomma argToString
 
 
 argToCallString :: (Types,String) -> String
-argToCallString (CPT (CPTClass c) _,varname) = 
+argToCallString (CPT (CPTClass c) _,varname) =
     "to_nonconst<"++str++","++str++"_t>("++varname++")" where str = class_name c
-argToCallString (CPT (CPTClassRef c) _,varname) = 
+argToCallString (CPT (CPTClassRef c) _,varname) =
     "to_nonconstref<"++str++","++str++"_t>(*"++varname++")" where str = class_name c
 argToCallString (_,varname) = varname
 
@@ -366,73 +367,86 @@ argsToCallString :: Args -> String
 argsToCallString = intercalateWith conncomma argToCallString
 
 
-rettypeToString :: Types -> String 
+rettypeToString :: Types -> String
 rettypeToString (CT ctyp isconst) = ctypToStr ctyp isconst
 rettypeToString Void = "void"
 rettypeToString SelfType = "Type ## _p"
 rettypeToString (CPT (CPTClass c) _) = str ++ "_p"
-  where str = class_name c 
-rettypeToString (CPT (CPTClassRef c) _) = str ++ "_p" 
-  where str = class_name c 
+  where str = class_name c
+rettypeToString (CPT (CPTClassRef c) _) = str ++ "_p"
+  where str = class_name c
 
 --------
 
-newtype ProtectedMethod = Protected { unProtected :: [String] } 
-    deriving (Monoid) 
+newtype ProtectedMethod = Protected { unProtected :: [String] }
+    deriving (Monoid)
 
-data Cabal = Cabal { cabal_pkgname :: String
-                   , cabal_cheaderprefix :: String
-                   , cabal_moduleprefix :: String } 
+data Cabal = Cabal  { cabal_pkgname :: String
+                    , cabal_cheaderprefix :: String
+                    , cabal_moduleprefix :: String
+                    , cabal_attr :: CabalAttr
+                    }
 
+data CabalAttr = CabalAttr  { cabal_attr_license :: Maybe String
+                            , cabal_attr_licensefile :: Maybe String
+                            }
 
-data Class = Class { class_cabal :: Cabal 
+cabal_license = cabal_attr_license . cabal_attr
+cabal_licensefile = cabal_attr_licensefile . cabal_attr
+
+instance Default CabalAttr where
+    def = CabalAttr { cabal_attr_license = Nothing
+                    , cabal_attr_licensefile = Nothing
+                    }
+
+data Class = Class { class_cabal :: Cabal
                    , class_name :: String
-                   , class_parents :: [Class] 
+                   , class_parents :: [Class]
                    , class_protected :: ProtectedMethod
-                   , class_alias :: Maybe String 
-                   , class_funcs :: [Function] 
+                   , class_alias :: Maybe String
+                   , class_funcs :: [Function]
                    }
-           | AbstractClass { class_cabal :: Cabal 
+           | AbstractClass { class_cabal :: Cabal
                            , class_name :: String
                            , class_parents :: [Class]
                            , class_protected :: ProtectedMethod
-                           , class_alias :: Maybe String 
-                           , class_funcs :: [Function] 
+                           , class_alias :: Maybe String
+                           , class_funcs :: [Function]
                            }
 
 
 newtype Namespace = NS { unNamespace :: String } deriving (Show)
 
 data ClassImportHeader = ClassImportHeader
-                       { cihClass :: Class 
-                       , cihSelfHeader :: String 
-                       , cihNamespace :: [Namespace] 
+                       { cihClass :: Class
+                       , cihSelfHeader :: String
+                       , cihNamespace :: [Namespace]
                        , cihSelfCpp :: String
-                       , cihIncludedHPkgHeadersInH :: [String] 
-                       , cihIncludedHPkgHeadersInCPP :: [String] 
-                       , cihIncludedCPkgHeaders :: [String] 
+                       , cihIncludedHPkgHeadersInH :: [String]
+                       , cihIncludedHPkgHeadersInCPP :: [String]
+                       , cihIncludedCPkgHeaders :: [String]
                        } deriving (Show)
 
-data ClassModule = ClassModule 
+data ClassModule = ClassModule
                    { cmModule :: String
-                   , cmClass :: [Class] 
-                   , cmCIH :: [ClassImportHeader] 
+                   , cmClass :: [Class]
+                   , cmCIH :: [ClassImportHeader]
                    , cmImportedModulesHighNonSource :: [String]
-                   , cmImportedModulesRaw :: [String] 
+                   , cmImportedModulesRaw :: [String]
                    , cmImportedModulesHighSource :: [String]
                    , cmImportedModulesForFFI :: [String]
                    } deriving (Show)
 
-data ClassGlobal = ClassGlobal 
-                   { cgDaughterSelfMap :: DaughterMap 
+data ClassGlobal = ClassGlobal
+                   { cgDaughterSelfMap :: DaughterMap
                    , cgDaughterMap :: DaughterMap
-                   } 
+                   }
 
 -- | Check abstract class
 
-isAbstractClass :: Class -> Bool 
-isAbstractClass (Class _ _ _ _ _ _) = False 
-isAbstractClass (AbstractClass _ _ _ _ _ _) = True            
+isAbstractClass :: Class -> Bool
+isAbstractClass (Class _ _ _ _ _ _) = False
+isAbstractClass (AbstractClass _ _ _ _ _ _) = True
 
 instance Show Class where
   show x = show (class_name x)
@@ -443,58 +457,58 @@ instance Eq Class where
 instance Ord Class where
   compare x y = compare (class_name x) (class_name y)
 
-type DaughterMap = M.Map String [Class] 
+type DaughterMap = M.Map String [Class]
 
-class_allparents :: Class -> [Class] 
+class_allparents :: Class -> [Class]
 class_allparents c = let ps = class_parents c
-                     in  if null ps 
+                     in  if null ps
                            then []
                            else nub (ps ++ (concatMap class_allparents ps))
 
 
-getClassModuleBase :: Class -> String 
+getClassModuleBase :: Class -> String
 getClassModuleBase = (<.>) <$> (cabal_moduleprefix.class_cabal) <*> (fst.hsClassName)
 
 
 
 -- | Daughter map not including itself
-mkDaughterMap :: [Class] -> DaughterMap 
-mkDaughterMap = foldl mkDaughterMapWorker M.empty  
+mkDaughterMap :: [Class] -> DaughterMap
+mkDaughterMap = foldl mkDaughterMapWorker M.empty
   where mkDaughterMapWorker m c = let ps = map getClassModuleBase (class_allparents c)
-                                  in  foldl (addmeToYourDaughterList c) m ps 
+                                  in  foldl (addmeToYourDaughterList c) m ps
         addmeToYourDaughterList c m p = let f Nothing = Just [c]
-                                            f (Just cs)  = Just (c:cs)    
+                                            f (Just cs)  = Just (c:cs)
                                         in  M.alter f p m
 
 
 
 -- | Daughter Map including itself as a daughter
 mkDaughterSelfMap :: [Class] -> DaughterMap
-mkDaughterSelfMap = foldl worker M.empty  
+mkDaughterSelfMap = foldl worker M.empty
   where worker m c = let ps = map getClassModuleBase (c:class_allparents c)
-                     in  foldl (addToList c) m ps 
+                     in  foldl (addToList c) m ps
         addToList c m p = let f Nothing = Just [c]
-                              f (Just cs)  = Just (c:cs)    
+                              f (Just cs)  = Just (c:cs)
                           in  M.alter f p m
 
--- | 
+-- |
 ctypToHsTyp :: Maybe Class -> Types -> String
-ctypToHsTyp _c Void = "()" 
+ctypToHsTyp _c Void = "()"
 ctypToHsTyp (Just c) SelfType = (fst.hsClassName) c
-ctypToHsTyp Nothing SelfType = error "ctypToHsTyp : SelfType but no class " 
+ctypToHsTyp Nothing SelfType = error "ctypToHsTyp : SelfType but no class "
 ctypToHsTyp _c (CT CTString _) = "CString"
-ctypToHsTyp _c (CT CTInt _) = "CInt" 
+ctypToHsTyp _c (CT CTInt _) = "CInt"
 ctypToHsTyp _c (CT CTUInt _) = "CUInt"
 ctypToHsTyp _c (CT CTChar _) = "CChar"
 ctypToHsTyp _c (CT CTLong _) = "CLong"
-ctypToHsTyp _c (CT CTULong _) = "CULong" 
+ctypToHsTyp _c (CT CTULong _) = "CULong"
 ctypToHsTyp _c (CT CTDouble _) = "CDouble"
 ctypToHsTyp _c (CT CTBool _ ) = "CInt"
 ctypToHsTyp _c (CT CTDoubleStar _) = "(Ptr CDouble)"
 ctypToHsTyp _c (CT CTVoidStar _) = "(Ptr ())"
-ctypToHsTyp _c (CT CTIntStar _) = "(Ptr CInt)" 
+ctypToHsTyp _c (CT CTIntStar _) = "(Ptr CInt)"
 ctypToHsTyp _c (CT CTCharStarStar _) = "(Ptr CString)"
-ctypToHsTyp _c (CT (CPointer t) _) = hsCTypeName (CPointer t) 
+ctypToHsTyp _c (CT (CPointer t) _) = hsCTypeName (CPointer t)
 ctypToHsTyp _c (CPT (CPTClass c') _) = class_name c'
 ctypToHsTyp _c (CPT (CPTClassRef c') _) = class_name c'
 
@@ -502,118 +516,118 @@ ctypToHsTyp _c (CPT (CPTClassRef c') _) = class_name c'
 typeclassName :: Class -> String
 typeclassName c = 'I' : fst (hsClassName c)
 
-typeclassNameFromStr :: String -> String 
+typeclassNameFromStr :: String -> String
 typeclassNameFromStr = ('I':)
 
 hsClassName :: Class -> (String, String)  -- ^ High-level, 'Raw'-level
-hsClassName c = 
+hsClassName c =
   let cname = maybe (class_name c) id (class_alias c)
-  in (cname, "Raw" ++ cname) 
+  in (cname, "Raw" ++ cname)
 
-existConstructorName :: Class -> String 
-existConstructorName c = 'E' : (fst.hsClassName) c 
+existConstructorName :: Class -> String
+existConstructorName c = 'E' : (fst.hsClassName) c
 
 -- | this is for FFI type.
 hsFuncTyp :: Class -> Function -> String
-hsFuncTyp c f = let args = genericFuncArgs f 
-                    ret  = genericFuncRet f 
-                in  selfstr ++ " -> " ++ concatMap ((++ " -> ") . hsargtype . fst) args ++ hsrettype ret 
-                    
+hsFuncTyp c f = let args = genericFuncArgs f
+                    ret  = genericFuncRet f
+                in  selfstr ++ " -> " ++ concatMap ((++ " -> ") . hsargtype . fst) args ++ hsrettype ret
+
   where (_hcname,rcname) = hsClassName c
-        selfstr = "(Ptr " ++ rcname ++ ")" 
+        selfstr = "(Ptr " ++ rcname ++ ")"
 
         hsargtype (CT ctype _) = hsCTypeName ctype
-        hsargtype (CPT x _) = hsCppTypeName x 
-        hsargtype SelfType = selfstr 
+        hsargtype (CPT x _) = hsCppTypeName x
+        hsargtype SelfType = selfstr
         hsargtype _ = error "undefined hsargtype"
-        
+
         hsrettype Void = "IO ()"
         hsrettype SelfType = "IO " ++ selfstr
         hsrettype (CT ctype _) = "IO " ++ hsCTypeName ctype
-        hsrettype (CPT x _ ) = "IO " ++ hsCppTypeName x 
+        hsrettype (CPT x _ ) = "IO " ++ hsCppTypeName x
 
 -- | this is for FFI
 hsFuncTypNoSelf :: Class -> Function -> String
-hsFuncTypNoSelf c f = let args = genericFuncArgs f 
-                          ret  = genericFuncRet f 
-                      in  intercalateWith connArrow id $ map (hsargtype . fst) args ++ [hsrettype ret]  
-                          
+hsFuncTypNoSelf c f = let args = genericFuncArgs f
+                          ret  = genericFuncRet f
+                      in  intercalateWith connArrow id $ map (hsargtype . fst) args ++ [hsrettype ret]
+
   where (_hcname,rcname) = hsClassName c
-        selfstr = "(Ptr " ++ rcname ++ ")" 
+        selfstr = "(Ptr " ++ rcname ++ ")"
 
         hsargtype (CT ctype _) = hsCTypeName ctype
-        hsargtype (CPT x _) = hsCppTypeName x 
+        hsargtype (CPT x _) = hsCppTypeName x
         hsargtype SelfType = selfstr
         hsargtype _ = error "undefined hsargtype"
-        
+
         hsrettype Void = "IO ()"
         hsrettype SelfType = "IO " ++ selfstr
         hsrettype (CT ctype _) = "IO " ++ hsCTypeName ctype
-        hsrettype (CPT x _ ) = "IO " ++ hsCppTypeName x 
+        hsrettype (CPT x _ ) = "IO " ++ hsCppTypeName x
 
 
-hscFuncName :: Class -> Function -> String         
+hscFuncName :: Class -> Function -> String
 hscFuncName c f = "c_" ++ toLowers (class_name c) ++ "_" ++ toLowers (aliasedFuncName c f)
-        
-hsFuncName :: Class -> Function -> String 
-hsFuncName c f = let (x:xs) = aliasedFuncName c f 
+
+hsFuncName :: Class -> Function -> String
+hsFuncName c f = let (x:xs) = aliasedFuncName c f
                  in (toLower x) : xs
-                  
-hsFuncXformer :: Function -> String 
-hsFuncXformer func@(Constructor _ _) = let len = length (genericFuncArgs func) 
+
+hsFuncXformer :: Function -> String
+hsFuncXformer func@(Constructor _ _) = let len = length (genericFuncArgs func)
                                        in if len > 0
                                           then "xform" ++ show (len - 1)
-                                          else "xformnull" 
-hsFuncXformer func@(Static _ _ _ _) = 
-  let len = length (genericFuncArgs func) 
+                                          else "xformnull"
+hsFuncXformer func@(Static _ _ _ _) =
+  let len = length (genericFuncArgs func)
   in if len > 0
      then "xform" ++ show (len - 1)
-     else "xformnull" 
-hsFuncXformer func = let len = length (genericFuncArgs func) 
+     else "xformnull"
+hsFuncXformer func = let len = length (genericFuncArgs func)
                      in "xform" ++ show len
 
 
-genericFuncRet :: Function -> Types 
-genericFuncRet f = 
-  case f of                        
-    Constructor _ _ -> self_ 
-    Virtual t _ _ _ -> t 
+genericFuncRet :: Function -> Types
+genericFuncRet f =
+  case f of
+    Constructor _ _ -> self_
+    Virtual t _ _ _ -> t
     NonVirtual t _ _ _-> t
     Static t _ _ _ -> t
     -- AliasVirtual t _ _ _ -> t
     Destructor _ -> void_
 
-genericFuncArgs :: Function -> Args 
+genericFuncArgs :: Function -> Args
 genericFuncArgs (Destructor _) = []
 genericFuncArgs f = func_args f
-                        
-aliasedFuncName :: Class -> Function -> String 
-aliasedFuncName c f = 
-  case f of 
-    Constructor _ a -> maybe (constructorName c) id a 
+
+aliasedFuncName :: Class -> Function -> String
+aliasedFuncName c f =
+  case f of
+    Constructor _ a -> maybe (constructorName c) id a
     Virtual _ str _ a -> maybe str id a
     NonVirtual _ str _ a-> maybe (nonvirtualName c str) id a
     Static _ str _ a -> maybe (nonvirtualName c str) id a
-    -- AliasVirtual _ _  _ alias -> alias 
+    -- AliasVirtual _ _  _ alias -> alias
     Destructor a -> maybe destructorName id a
 
-cppStaticName :: Class -> Function -> String 
+cppStaticName :: Class -> Function -> String
 cppStaticName c f = class_name c ++ "::" ++ func_name f
 
-cppFuncName :: Class -> Function -> String 
-cppFuncName c f =   case f of 
+cppFuncName :: Class -> Function -> String
+cppFuncName c f =   case f of
     Constructor _ _ -> "new"
-    Virtual _ _  _ _ -> func_name f 
-    NonVirtual _ _ _ _-> func_name f  
-    Static _ _ _ _-> cppStaticName c f 
-    -- AliasVirtual _ _  _ _ _ -> func_name f 
+    Virtual _ _  _ _ -> func_name f
+    NonVirtual _ _ _ _-> func_name f
+    Static _ _ _ _-> cppStaticName c f
+    -- AliasVirtual _ _  _ _ _ -> func_name f
     Destructor _ -> destructorName
 
 constructorName :: Class -> String
-constructorName c = "new" ++ (fst.hsClassName) c 
- 
-nonvirtualName :: Class -> String -> String
-nonvirtualName c str = (firstLower.fst.hsClassName) c ++ str 
+constructorName c = "new" ++ (fst.hsClassName) c
 
-destructorName :: String 
-destructorName = "delete" 
+nonvirtualName :: Class -> String -> String
+nonvirtualName c str = (firstLower.fst.hsClassName) c ++ str
+
+destructorName :: String
+destructorName = "delete"

--- a/fficxx/sample/mysample-generator/MySampleGen.hs
+++ b/fficxx/sample/mysample-generator/MySampleGen.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
-import Data.Monoid (mempty)
-import System.FilePath ((</>))
-import System.Directory (getCurrentDirectory)
+import           Data.Default (def)
+import           Data.Monoid (mempty)
+import           System.FilePath ((</>))
+import           System.Directory (getCurrentDirectory)
 import           Text.StringTemplate hiding (render)
--- 
+--
+import           FFICXX.Generate.Builder (mkCabalFile)
 import           FFICXX.Generate.Code.Cabal
 import           FFICXX.Generate.Code.Cpp
 import           FFICXX.Generate.Code.Dependency
@@ -12,141 +14,105 @@ import           FFICXX.Generate.Config
 import           FFICXX.Generate.Code.Cpp
 import           FFICXX.Generate.Code.Dependency
 import           FFICXX.Generate.Config
-import           FFICXX.Generate.Generator.ContentMaker 
+import           FFICXX.Generate.Generator.ContentMaker
 import           FFICXX.Generate.Generator.Driver
 import           FFICXX.Generate.Type.Annotate
 import           FFICXX.Generate.Type.Class
 import           FFICXX.Generate.Type.PackageInterface
-import           FFICXX.Generate.Util
--- 
+--
 import qualified FFICXX.Paths_fficxx as F
 
-mysampleclasses = [ ] 
+mysampleclasses = [ ]
 
-mycabal = Cabal { cabal_pkgname = "MySample" 
+mycabal = Cabal { cabal_pkgname = "MySample"
                 , cabal_cheaderprefix = "MySample"
-                , cabal_moduleprefix = "MySample" }
+                , cabal_moduleprefix = "MySample"
+                , cabal_attr = def
+                }
 
-myclass = Class mycabal 
+myclass = Class mycabal
 
-a :: Class 
-a = myclass "A" [] mempty Nothing 
+a :: Class
+a = myclass "A" [] mempty Nothing
     [ Constructor [] Nothing
     , Virtual void_ "Foo" [ ] Nothing
     , Virtual void_ "Foo2" [ long "t" ] Nothing
-    ] 
+    ]
 
-b :: Class 
+b :: Class
 b = myclass "B" [a] mempty Nothing
     [ Constructor [] Nothing
     , Virtual void_ "Bar" [] Nothing
-    ] 
+    ]
 
-myclasses = [ a, b] 
+myclasses = [ a, b]
 
-toplevelfunctions = [ ] 
-
-
--- | 
-cabalTemplate :: String 
-cabalTemplate = "Pkg.cabal"
-
-
--- | 
-mkCabalFile :: FFICXXConfig
-            -> STGroup String  
-            -> (TopLevelImportHeader,[ClassModule])
-            -> FilePath  
-            -> IO () 
-mkCabalFile config templates (tih,classmodules) cabalfile = do 
-  cpath <- getCurrentDirectory 
-
-  let str = renderTemplateGroup 
-              templates 
-              [ ("pkgname", "MySample") 
-              , ("version",  "0.0") 
-              , ("license", "" ) 
-              , ("buildtype", "Simple")
-              , ("deps", "" ) 
-              , ("csrcFiles", genCsrcFiles (tih,classmodules))
-              , ("includeFiles", genIncludeFiles "MySample" classmodules) 
-              , ("cppFiles", genCppFiles (tih,classmodules))
-              , ("exposedModules", genExposedModules "MySample" classmodules) 
-              , ("otherModules", genOtherModules classmodules)
-              , ("extralibdirs", cpath </> ".." </> "cxxlib" </> "lib" )  -- this need to be changed 
-              , ("extraincludedirs", cpath </> ".." </> "cxxlib" </> "include" )  -- this need to be changed 
-              , ("extralib", ", mysample")
-              , ("cabalIndentation", cabalIndentation)
-              ]
-              cabalTemplate 
-  writeFile cabalfile str
-
-
+toplevelfunctions = [ ]
 
 
 main :: IO ()
-main = do 
-  putStrLn "generate mysample" 
-  cwd <- getCurrentDirectory 
+main = do
+  putStrLn "generate mysample"
+  cwd <- getCurrentDirectory
 
-  let cfg =  FFICXXConfig { fficxxconfig_scriptBaseDir = cwd 
+  let cfg =  FFICXXConfig { fficxxconfig_scriptBaseDir = cwd
                           , fficxxconfig_workingDir = cwd </> "working"
-                          , fficxxconfig_installBaseDir = cwd </> "MySample"  
-                          } 
+                          , fficxxconfig_installBaseDir = cwd </> "MySample"
+                          }
       workingDir = fficxxconfig_workingDir cfg
-      installDir = fficxxconfig_installBaseDir cfg 
-      pkgname = "MySample" 
+      installDir = fficxxconfig_installBaseDir cfg
+      pkgname = "MySample"
       (mods,cihs,tih) = mkAll_ClassModules_CIH_TIH ("MySample", (\c->([],[class_name c ++ ".h"]))) (myclasses,toplevelfunctions)
-      hsbootlst = mkHSBOOTCandidateList mods 
-      cglobal = mkGlobal myclasses 
-      summarymodule = "MySample" 
+      hsbootlst = mkHSBOOTCandidateList mods
+      cglobal = mkGlobal myclasses
+      summarymodule = "MySample"
       cabalFileName = "MySample.cabal"
   templateDir <- F.getDataDir >>= return . (</> "template")
-  (templates :: STGroup String) <- directoryGroup templateDir 
-  -- 
+  (templates :: STGroup String) <- directoryGroup templateDir
+  --
   notExistThenCreate workingDir
-  notExistThenCreate installDir 
-  notExistThenCreate (installDir </> "src") 
+  notExistThenCreate installDir
+  notExistThenCreate (installDir </> "src")
   notExistThenCreate (installDir </> "csrc")
-  -- 
-  putStrLn "cabal file generation" 
-  mkCabalFile cfg templates (tih,mods) (workingDir </> cabalFileName)
-  -- 
+  --
+  putStrLn "cabal file generation"
+  mkCabalFile cfg templates mycabal (tih,mods) (workingDir </> cabalFileName)
+  --
   putStrLn "header file generation"
   writeTypeDeclHeaders templates workingDir (TypMcro "__MYSAMPLE__") pkgname cihs
   mapM_ (writeDeclHeaders templates workingDir (TypMcro "__MYSAMPLE__") pkgname) cihs
-  -- 
-  putStrLn "cpp file generation" 
+  --
+  putStrLn "cpp file generation"
   mapM_ (writeCppDef templates workingDir) cihs
-  -- 
-  putStrLn "RawType.hs file generation" 
-  mapM_ (writeRawTypeHs templates workingDir) mods 
-  -- 
+  --
+  putStrLn "RawType.hs file generation"
+  mapM_ (writeRawTypeHs templates workingDir) mods
+  --
   putStrLn "FFI.hsc file generation"
   mapM_ (writeFFIHsc templates workingDir) mods
-  -- 
-  putStrLn "Interface.hs file generation" 
+  --
+  putStrLn "Interface.hs file generation"
   mapM_ (writeInterfaceHs mempty templates workingDir) mods
-  -- 
+  --
   putStrLn "Cast.hs file generation"
   mapM_ (writeCastHs templates workingDir) mods
-  -- 
+  --
   putStrLn "Implementation.hs file generation"
   mapM_ (writeImplementationHs mempty templates workingDir) mods
-  -- 
-  putStrLn "hs-boot file generation" 
-  mapM_ (writeInterfaceHSBOOT templates workingDir) hsbootlst  
-  -- 
-  putStrLn "module file generation" 
+  --
+  putStrLn "hs-boot file generation"
+  mapM_ (writeInterfaceHSBOOT templates workingDir) hsbootlst
+  --
+  putStrLn "module file generation"
   mapM_ (writeModuleHs templates workingDir) mods
-  -- 
+  --
   putStrLn "summary module generation generation"
   writePkgHs summarymodule templates workingDir mods tih
-  -- 
+  --
   putStrLn "copying"
-  copyFileWithMD5Check (workingDir </> cabalFileName)  (installDir </> cabalFileName) 
+  copyFileWithMD5Check (workingDir </> cabalFileName)  (installDir </> cabalFileName)
   -- copyPredefined templateDir (srcDir ibase) pkgname
   copyCppFiles workingDir (csrcDir installDir) pkgname (tih,cihs)
-  mapM_ (copyModule workingDir (srcDir installDir) summarymodule) mods 
+  mapM_ (copyModule workingDir (srcDir installDir) summarymodule) mods
 
 

--- a/fficxx/sample/mysample-generator/build.sh
+++ b/fficxx/sample/mysample-generator/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+
+sandbox="$(pwd)/../../../.cabal-sandbox/"
+package_db="$sandbox/*-ghc-*-packages.conf.d/"
+
+rm -rf MySampleGen
+ghc -package-db $package_db MySampleGen.hs
+
+rm -rf working/ MySample/
+./MySampleGen
+
+(   cd ./MySample/
+    cabal sandbox --sandbox=$sandbox init
+    cabal build
+)

--- a/fficxx/template/Pkg.cabal.st
+++ b/fficxx/template/Pkg.cabal.st
@@ -3,15 +3,15 @@ Version:	$version$
 Synopsis:	$synopsis$
 Description: 	$description$
 Homepage:       $homepage$
-License:        $license$
-License-file:   $licensefile$
+$licenseField$
+$licenseFileField$
 Author:		$author$
 Maintainer: 	$maintainer$
 Category:       $category$
 Tested-with:    GHC >= 7.6
 Build-Type: 	$buildtype$
 cabal-version:  >=1.10
-Extra-source-files: 
+Extra-source-files:
 $cabalIndentation$CHANGES
 $cabalIndentation$Config.hs
 $csrcFiles$
@@ -26,17 +26,17 @@ Library
   cc-options: $ccOptions$
   Build-Depends:      base>4 && < 5, fficxx-runtime >= 0.2 $deps$
   Exposed-Modules:
-$exposedModules$  
+$exposedModules$
   Other-Modules:
 $otherModules$
   extra-lib-dirs: $extralibdirs$
   extra-libraries:    stdc++ $extralib$
-  Include-dirs:       csrc $extraincludedirs$ 
-  Install-includes:   
+  Include-dirs:       csrc $extraincludedirs$
+  Install-includes:
 $includeFiles$
-  C-sources:          
+  C-sources:
 $cppFiles$
 
-   
+
 
 


### PR DESCRIPTION
Fixed cabal error with empty "license" and "license-file" fields.

Unfortunately, I still get
```
csrc/MySampleA.cpp:3:15:
     fatal error: A.h: No such file or directory
     #include "A.h"
```