### PR TITLE
Fix a bug of reference return type

### DIFF
--- a/fficxx/fficxx.cabal
+++ b/fficxx/fficxx.cabal
@@ -1,5 +1,5 @@
 Name:           fficxx
-Version:        0.4
+Version:        0.4.0
 Synopsis:       automatic C++ binding generation
 Description:    automatic C++ binding generation
 License:        BSD3

--- a/fficxx/lib/FFICXX/Generate/Code/MethodDef.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/MethodDef.hs
@@ -30,7 +30,7 @@ returnCpp b ret callstr =
     Void                    -> callstr <> ";"
     SelfType                -> "return to_nonconst<Type ## _t, Type>((Type *)"
                                 <> callstr <> ") ;"
-    CT (CRef _) _           -> "return ((*)"<>callstr<>");"
+    CT (CRef _) _           -> "return (&("<>callstr<>"));"
     CT _ _                  -> "return "<>callstr<>";" 
     CPT (CPTClass c') _     -> "return to_nonconst<"<>str<>"_t,"<>str
                                <>">(("<>str<>"*)"<>callstr<>");"

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -5,7 +5,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      : FFICXX.Generate.Type.Class
--- Copyright   : (c) 2011-2017 Ian-Woo Kim
+-- Copyright   : (c) 2011-2018 Ian-Woo Kim
 --
 -- License     : BSD3
 -- Maintainer  : Ian-Woo Kim <ianwookim@gmail.com>
@@ -165,6 +165,8 @@ intref_ = CT (CRef CTInt) NoConst
 charpp_ :: Types
 charpp_ = CT CTCharStarStar NoConst
 
+ref_ :: CTypes -> Types
+ref_ t = CT (CRef t) NoConst
 
 star_ :: CTypes -> Types
 star_ t = CT (CPointer t) NoConst
@@ -234,6 +236,9 @@ intref var = (intref_, var)
 
 charpp :: String -> (Types, String)
 charpp var = (charpp_, var)
+
+ref :: CTypes -> String -> (Types,String)
+ref t var = (ref_ t, var)
 
 star :: CTypes -> String -> (Types, String)
 star t var = (star_ t, var)


### PR DESCRIPTION
change `(*)..` to `&(..)`
