### PR TITLE
Support external package dependencies, generator for stdc++ for shared dep

### DIFF
--- a/fficxx/lib/FFICXX/Generate/Builder.hs
+++ b/fficxx/lib/FFICXX/Generate/Builder.hs
@@ -41,7 +41,8 @@ import           FFICXX.Generate.Util
 macrofy :: String -> String
 macrofy = map ((\x->if x=='-' then '_' else x) . toUpper)
 
-simpleBuilder :: String -> [(String,([Namespace],[HeaderName]))]
+simpleBuilder :: String
+              -> [(String,([Namespace],[HeaderName]))]
               -> (Cabal, CabalAttr, [Class], [TopLevelFunction], [(TemplateClass,HeaderName)])
               -> [String] -- ^ extra libs
               -> [(String,[String])] -- ^ extra module

--- a/fficxx/lib/FFICXX/Generate/Code/Cabal.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Cabal.hs
@@ -3,7 +3,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      : FFICXX.Generate.Code.Cabal
--- Copyright   : (c) 2011-2016 Ian-Woo Kim
+-- Copyright   : (c) 2011-2018 Ian-Woo Kim
 --
 -- License     : BSD3
 -- Maintainer  : Ian-Woo Kim <ianwookim@gmail.com>
@@ -109,6 +109,10 @@ genExposedModules summarymod (cmods,tmods) =
 genOtherModules :: [ClassModule] -> String 
 genOtherModules _cmods = "" 
 
+-- | generate additional package dependencies.
+genPkgDeps :: [CabalName] -> String
+genPkgDeps cs = intercalate " " (map (\(CabalName c) -> ", " <> c) cs)
+
 
 -- |
 cabalTemplate :: Text
@@ -183,7 +187,7 @@ buildCabalFile (cabal, cabalattr) summarymodule pkgconfig extralibs cabalfile = 
                         , ("category","")
                         , ("sourcerepository","")
                         , ("ccOptions","-std=c++14")
-                        , ("deps", "")
+                        , ("deps", genPkgDeps (cabal_additional_pkgdeps cabal))
                         , ("extraFiles", concatMap (\x -> cabalIndentation <> x <> "\n") extrafiles)
                         , ("csrcFiles", genCsrcFiles (tih,classmodules) acincs acsrcs)
                         , ("includeFiles", genIncludeFiles (cabal_pkgname cabal) (cih,tcih) acincs)

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -4,7 +4,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      : FFICXX.Generate.ContentMaker
--- Copyright   : (c) 2011-2017 Ian-Woo Kim
+-- Copyright   : (c) 2011-2018 Ian-Woo Kim
 --
 -- License     : BSD3
 -- Maintainer  : Ian-Woo Kim <ianwookim@gmail.com>

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -1,0 +1,67 @@
+module Main where
+
+import Data.Monoid (mempty)
+--
+import FFICXX.Generate.Builder
+import FFICXX.Generate.Type.Class
+import FFICXX.Generate.Type.Module
+import FFICXX.Generate.Type.PackageInterface
+
+
+cabal = Cabal { cabal_pkgname = "stdcxx"
+              , cabal_cheaderprefix = "STD"
+              , cabal_moduleprefix = "STD"
+              , cabal_additional_c_incs = []
+              , cabal_additional_c_srcs = []
+              , cabal_additional_pkgdeps = []
+              }
+
+extraDep = [ ]
+
+cabalattr =
+    CabalAttr
+    { cabalattr_license = Just "BSD3"
+    , cabalattr_licensefile = Just "LICENSE"
+    , cabalattr_extraincludedirs = [ ]
+    , cabalattr_extralibdirs = []
+    , cabalattr_extrafiles = []
+    }
+
+
+deletable :: Class
+deletable =
+  AbstractClass cabal "Deletable" [] mempty Nothing
+  [ Destructor Nothing
+  ]
+
+string :: Class
+string =
+  Class cabal "string" [ deletable ] mempty  (Just "CppString")
+  [ Constructor [ cstring "p" ] Nothing
+  , NonVirtual cstring_ "c_str" [] Nothing
+  , NonVirtual (cppclassref_ string) "append" [cppclassref string "str"] Nothing
+  , NonVirtual (cppclassref_ string) "erase" [] Nothing
+  ]
+
+
+
+classes = [ deletable
+          --
+          , string
+          ]
+
+toplevelfunctions = [ ]
+
+templates = [  ]
+
+headerMap = [ ("string"         , ([NS "std"          ], [HdrName "string"   ]))
+            ]
+
+main :: IO ()
+main = do
+  simpleBuilder
+    "STD"
+    headerMap
+    (cabal,cabalattr,classes,toplevelfunctions,templates)
+    [ ]
+    extraDep


### PR DESCRIPTION
In this PR, I added a new field `cabal_additional_pkgdeps` in the type `Cabal`. 
I also made a generator for stdcxx which will serve as a common dependency for fficxx binding to usual C++ libraries. Currently, only `string` is there, but it will grow.