### PR TITLE
nix expression for stdcxx code generation

### DIFF
--- a/stdcxx-gen/default.nix
+++ b/stdcxx-gen/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, haskellPackages }:
+
+let
+  stdcxx-src = import ./gen.nix { inherit stdenv haskellPackages; };
+in
+
+{ mkDerivation, base, fficxx, fficxx-runtime, stdenv, template-haskell }:
+mkDerivation {
+  pname = "stdcxx";
+  version = "0.0";
+  src = stdcxx-src;
+  libraryHaskellDepends = [
+    base fficxx fficxx-runtime template-haskell
+  ];
+  librarySystemDepends = [ ];
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/stdcxx-gen/gen.nix
+++ b/stdcxx-gen/gen.nix
@@ -1,0 +1,19 @@
+{ stdenv, haskellPackages }:
+
+let
+  hsenv = haskellPackages.ghcWithPackages (p: with p; [ fficxx-runtime fficxx ]);
+in
+
+stdenv.mkDerivation {
+  name = "stdcxx-src";
+  buildInputs = [ hsenv ];
+  src = ./.;
+  buildPhase = ''
+    ghc Gen.hs
+    ./Gen
+  '';
+  installPhase = ''
+    mkdir -p $out
+    cp -a stdcxx/* $out
+  '';
+}


### PR DESCRIPTION
`stdcxx-gen/gen.nix` prepares for fficxx-generated cabal pacakge with Haskell and C++ codes. 
`stdcxx-gen/default.nix` is nix-expression using the generated source file for building stdcxx.