### PR TITLE
buildPkgHs does not use string interpolation, but Haskell AST.

### DIFF
--- a/fficxx/lib/FFICXX/Generate/Builder.hs
+++ b/fficxx/lib/FFICXX/Generate/Builder.hs
@@ -4,7 +4,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      : FFICXX.Generate.Builder
--- Copyright   : (c) 2011-2016 Ian-Woo Kim
+-- Copyright   : (c) 2011-2018 Ian-Woo Kim
 --
 -- License     : BSD3
 -- Maintainer  : Ian-Woo Kim <ianwookim@gmail.com>
@@ -133,7 +133,7 @@ simpleBuilder summarymodule lst (cabal, cabalattr, classes, toplevelfunctions, t
   mapM_ (\m -> gen (cmModule m <.> "hs") (prettyPrint (buildModuleHs m))) mods
   --
   putStrLn "summary module generation generation"
-  gen (summarymodule <.> "hs") (buildPkgHs summarymodule (mods,tcms) tih)
+  gen (summarymodule <.> "hs") (prettyPrint (buildPkgHs summarymodule (mods,tcms) tih))
   --
   putStrLn "copying"
   touch (workingDir </> "LICENSE")
@@ -212,7 +212,6 @@ moduleFileCopy wdir ddir fname = do
 copyModule :: FilePath -> FilePath -> ClassModule -> IO ()
 copyModule wdir ddir m = do 
   let modbase = cmModule m 
-
   moduleFileCopy wdir ddir $ modbase <> ".hs"
   moduleFileCopy wdir ddir $ modbase <> ".RawType.hs"
   moduleFileCopy wdir ddir $ modbase <> ".FFI.hsc"
@@ -220,12 +219,10 @@ copyModule wdir ddir m = do
   moduleFileCopy wdir ddir $ modbase <> ".Cast.hs"
   moduleFileCopy wdir ddir $ modbase <> ".Implementation.hs"
   moduleFileCopy wdir ddir $ modbase <> ".Interface.hs-boot"
-  return ()
+
 
 copyTemplateModule :: FilePath -> FilePath -> TemplateClassModule -> IO ()
 copyTemplateModule wdir ddir m = do 
   let modbase = tcmModule m 
   moduleFileCopy wdir ddir $ modbase <> ".Template.hs"
   moduleFileCopy wdir ddir $ modbase <> ".TH.hs"
-  return ()
-

--- a/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
@@ -5,7 +5,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      : FFICXX.Generate.Code.HsFrontEnd
--- Copyright   : (c) 2011-2017 Ian-Woo Kim
+-- Copyright   : (c) 2011-2018 Ian-Woo Kim
 --
 -- License     : BSD3
 -- Maintainer  : Ian-Woo Kim <ianwookim@gmail.com>
@@ -32,7 +32,6 @@ import           Language.Haskell.Exts.Syntax            ( Asst(..), Binds(..), 
                                                          , QualConDecl(..), Stmt(..)
                                                          , Type(..), TyVarBind (..)
                                                          )
--- import           Language.Haskell.Exts.SrcLoc            ( noLoc )
 import           System.FilePath                         ((<.>))
 -- 
 import           FFICXX.Generate.Type.Class

--- a/fficxx/lib/FFICXX/Generate/Util/HaskellSrcExts.hs
+++ b/fficxx/lib/FFICXX/Generate/Util/HaskellSrcExts.hs
@@ -2,7 +2,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      : FFICXX.Generate.Util.HaskellSrcExts
--- Copyright   : (c) 2011-2017 Ian-Woo Kim
+-- Copyright   : (c) 2011-2018 Ian-Woo Kim
 --
 -- License     : BSD3
 -- Maintainer  : Ian-Woo Kim <ianwookim@gmail.com>
@@ -57,13 +57,13 @@ lit :: Literal () -> Exp ()
 lit = Lit ()
 
 
-mkVar :: String -> Exp () 
+mkVar :: String -> Exp ()
 mkVar = Var () . unqual
 
 con :: String -> Exp ()
 con = Con () . unqual
 
-mkTVar :: String -> Type () 
+mkTVar :: String -> Type ()
 mkTVar = TyVar () . Ident ()
 
 mkPVar :: String -> Pat ()
@@ -113,7 +113,7 @@ mkData n tbinds qdecls mderiv  = DataDecl () (DataType ()) Nothing declhead qdec
 #else
 mkData n tbinds qdecls mderiv  = DataDecl () (DataType ()) Nothing declhead qdecls mderiv
 #endif
-  where declhead = mkDeclHead n tbinds 
+  where declhead = mkDeclHead n tbinds
 
 mkNewtype :: String -> [TyVarBind ()] -> [QualConDecl ()] -> Maybe (Deriving ()) -> Decl ()
 #if MIN_VERSION_haskell_src_exts(1,20,0)
@@ -143,8 +143,8 @@ mkImportExp m lst =
   ImportDecl () (ModuleName () m) False False False Nothing Nothing (Just islist)
   where islist = ImportSpecList () False (map mkIVar lst)
 
-    
-mkImportSrc :: String -> ImportDecl ()          
+
+mkImportSrc :: String -> ImportDecl ()
 mkImportSrc m = ImportDecl () (ModuleName () m) False True False Nothing Nothing Nothing
 
 lang :: [String] -> ModulePragma ()
@@ -197,6 +197,8 @@ eabs = EAbs ()
 ethingwith = EThingWith ()
 
 ethingall q = ethingwith (EWildcard () 0) q []
+
+emodule nm = EModuleContents () (ModuleName () nm)
 
 nonamespace = NoNamespace ()
 


### PR DESCRIPTION
no more string interpolation in Haskell code generation.