### PR TITLE
Import module generation for top-level functions

### DIFF
--- a/fficxx/lib/FFICXX/Generate/Builder.hs
+++ b/fficxx/lib/FFICXX/Generate/Builder.hs
@@ -47,7 +47,7 @@ simpleBuilder :: String
               -> [String] -- ^ extra libs
               -> [(String,[String])] -- ^ extra module
               ->  IO ()
-simpleBuilder summarymodule lst (cabal, cabalattr, classes, toplevelfunctions, templates) extralibs extramods = do
+simpleBuilder topLevelMod lst (cabal, cabalattr, classes, toplevelfunctions, templates) extralibs extramods = do
   let pkgname = cabal_pkgname cabal
   putStrLn ("generating " <> pkgname)
   cwd <- getCurrentDirectory
@@ -73,7 +73,7 @@ simpleBuilder summarymodule lst (cabal, cabalattr, classes, toplevelfunctions, t
   notExistThenCreate (installDir </> "csrc")
   --
   putStrLn "cabal file generation"
-  buildCabalFile (cabal,cabalattr) summarymodule pkgconfig extralibs (workingDir</>cabalFileName)
+  buildCabalFile (cabal,cabalattr) topLevelMod pkgconfig extralibs (workingDir</>cabalFileName)
   --
   putStrLn "header file generation"
   let typmacro = TypMcro ("__"  <> macrofy (cabal_pkgname cabal) <> "__")
@@ -132,8 +132,8 @@ simpleBuilder summarymodule lst (cabal, cabalattr, classes, toplevelfunctions, t
   putStrLn "module file generation"
   mapM_ (\m -> gen (cmModule m <.> "hs") (prettyPrint (buildModuleHs m))) mods
   --
-  putStrLn "summary module generation generation"
-  gen (summarymodule <.> "hs") (prettyPrint (buildPkgHs summarymodule (mods,tcms) tih))
+  putStrLn "top level module generation generation"
+  gen (topLevelMod <.> "hs") (prettyPrint (buildTopLevelHs topLevelMod (mods,tcms) tih))
   --
   putStrLn "copying"
   touch (workingDir </> "LICENSE")
@@ -143,7 +143,7 @@ simpleBuilder summarymodule lst (cabal, cabalattr, classes, toplevelfunctions, t
   copyCppFiles workingDir (csrcDir installDir) pkgname pkgconfig
   mapM_ (copyModule workingDir (srcDir installDir)) mods
   mapM_ (copyTemplateModule workingDir (srcDir installDir)) tcms  
-  moduleFileCopy workingDir (srcDir installDir) $ summarymodule <.> "hs"
+  moduleFileCopy workingDir (srcDir installDir) $ topLevelMod <.> "hs"
 
 
 -- | some dirty hack. later, we will do it with more proper approcah.

--- a/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
@@ -39,8 +39,6 @@ import           FFICXX.Generate.Util
 import           FFICXX.Generate.Util.HaskellSrcExts
 
 
-import Debug.Trace
-
 genHsFrontDecl :: Class -> Reader AnnotateMap (Decl ())
 genHsFrontDecl c = do
   -- TODO: revive annotation
@@ -307,8 +305,7 @@ genImportInTopLevel ::
   -> [ImportDecl ()]
 genImportInTopLevel modname (mods,tmods) tih =
   let tfns = tihFuncs tih
-  in trace (show tfns) $
-        map (mkImport . cmModule) mods
+  in    map (mkImport . cmModule) mods
      ++ if null tfns
         then []
         else    map mkImport [ "Foreign.C", "Foreign.Ptr", "FFICXX.Runtime.Cast" ]

--- a/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
@@ -17,8 +17,11 @@
 module FFICXX.Generate.Code.HsFrontEnd where
 
 import           Control.Monad.Reader
+import           Data.Either                             (lefts,rights)
 import           Data.List
+import           Data.Maybe                              (maybeToList)
 import           Data.Monoid                             ((<>))
+import           Data.Traversable                        (for)
 import           Language.Haskell.Exts.Build             (app,binds,doE,letE,letStmt
                                                          ,name,pApp
                                                          ,qualStmt,strE,tuple)
@@ -36,8 +39,11 @@ import           FFICXX.Generate.Util
 import           FFICXX.Generate.Util.HaskellSrcExts
 
 
+import Debug.Trace
+
 genHsFrontDecl :: Class -> Reader AnnotateMap (Decl ())
 genHsFrontDecl c = do
+  -- TODO: revive annotation
   -- for the time being, let's ignore annotation.
   -- amap <- ask
   -- let cann = maybe "" id $ M.lookup (PkgClass,class_name c) amap
@@ -282,9 +288,16 @@ genImportInImplementation m =
 
 
 -- | generate import list for a given top-level function
+--   currently this may generate duplicate import list.
+-- TODO: eliminate duplicated imports.
 genImportForTopLevelFunction :: TopLevelFunction -> [ImportDecl ()]
-genImportForTopLevelFunction TopLevelFunction {..} = []
-genImportForTopLevelFunction TopLevelVariable {..} = []
+genImportForTopLevelFunction f =
+  let dep4func = extractClassDepForTopLevelFunction f
+      ecs = maybeToList (returnDependency dep4func) ++ argumentDependency dep4func
+      cmods = nub $ map getClassModuleBase $ rights ecs
+      tmods = nub $ map getTClassModuleBase $ lefts ecs
+  in    concatMap (\x -> map (\y -> mkImport (x<.>y)) ["RawType","Cast","Interface"]) cmods
+     <> concatMap (\x -> map (\y -> mkImport (x<.>y)) ["Template"]) tmods
 
 -- | generate import list for top level module
 genImportInTopLevel ::
@@ -294,7 +307,8 @@ genImportInTopLevel ::
   -> [ImportDecl ()]
 genImportInTopLevel modname (mods,tmods) tih =
   let tfns = tihFuncs tih
-  in    map (mkImport . cmModule) mods
+  in trace (show tfns) $
+        map (mkImport . cmModule) mods
      ++ if null tfns
         then []
         else    map mkImport [ "Foreign.C", "Foreign.Ptr", "FFICXX.Runtime.Cast" ]
@@ -348,7 +362,7 @@ genTmplImplementation t = concatMap gen (tclass_funcs t)
             tp = tclass_param t
             prefix = tclass_name t
             lit' = strE (prefix<>"_"<>nc<>"_")
-            lam = lambda [p "n"] ( lit' `app` v "<>" `app` v "n") 
+            lam = lambda [p "n"] ( lit' `app` v "<>" `app` v "n")
             rhs = app (v "mkTFunc") (tuple [v "nty", v "ncty", lam, v "tyf"])
             sig' = functionSignatureTT t f
             bstmts = binds [ mkBind1 "tyf" [mkPVar "n"]

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -384,8 +384,8 @@ buildModuleHs :: ClassModule -> Module ()
 buildModuleHs m = mkModuleE (cmModule m) [] (concatMap genExport (cmClass m)) (genImportInModule (cmClass m)) []
 
 -- |
-buildPkgHs :: String -> ([ClassModule],[TemplateClassModule]) -> TopLevelImportHeader -> Module ()
-buildPkgHs modname (mods,tmods) tih =
+buildTopLevelHs :: String -> ([ClassModule],[TemplateClassModule]) -> TopLevelImportHeader -> Module ()
+buildTopLevelHs modname (mods,tmods) tih =
     mkModuleE modname pkgExtensions pkgExports pkgImports pkgBody
   where
     tfns = tihFuncs tih

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -43,8 +43,6 @@ import           FFICXX.Generate.Util
 import           FFICXX.Generate.Util.HaskellSrcExts
 --
 
-import Debug.Trace
-
 
 srcDir :: FilePath -> FilePath
 srcDir installbasedir = installbasedir </> "src"
@@ -393,16 +391,8 @@ buildTopLevelHs modname (mods,tmods) tih =
     pkgExports =     map (emodule . cmModule) mods
                  ++  map (evar . unqual . hsFrontNameForTopLevelFunction) tfns
 
-    pkgImports = trace (show tfns) $
+    pkgImports = genImportInTopLevel modname (mods,tmods) tih
 
-
-                    map (mkImport . cmModule) mods
-                 ++ if null tfns
-                    then []
-                    else    map mkImport [ "Foreign.C", "Foreign.Ptr", "FFICXX.Runtime.Cast" ]
-                         ++ map (\c -> mkImport (modname <.> (fst.hsClassName.cihClass) c <.> "RawType")) (tihClassDep tih)
-                         ++ map (\m -> mkImport (tcmModule m <.> "Template")) tmods
-                         ++ concatMap genImportInTopLevel tfns
     pkgBody    =    map (genTopLevelFuncFFI tih) tfns
                  ++ concatMap genTopLevelFuncDef tfns
 


### PR DESCRIPTION
In this PR, I implement import statement generation for top-level functions by examining class and template class argument types and return type. This has been tested with cross-package template class imports via vector<T> (stdcxx) example. 
