### PR TITLE
Merge CabalAttr into Cabal

### DIFF
--- a/fficxx/lib/FFICXX/Generate/Builder.hs
+++ b/fficxx/lib/FFICXX/Generate/Builder.hs
@@ -43,11 +43,11 @@ macrofy = map ((\x->if x=='-' then '_' else x) . toUpper)
 
 simpleBuilder :: String
               -> [(String,([Namespace],[HeaderName]))]
-              -> (Cabal, CabalAttr, [Class], [TopLevelFunction], [(TemplateClass,HeaderName)])
+              -> (Cabal, [Class], [TopLevelFunction], [(TemplateClass,HeaderName)])
               -> [String] -- ^ extra libs
               -> [(String,[String])] -- ^ extra module
               ->  IO ()
-simpleBuilder topLevelMod lst (cabal, cabalattr, classes, toplevelfunctions, templates) extralibs extramods = do
+simpleBuilder topLevelMod lst (cabal,classes,toplevelfunctions,templates) extralibs extramods = do
   let pkgname = cabal_pkgname cabal
   putStrLn ("generating " <> pkgname)
   cwd <- getCurrentDirectory
@@ -73,7 +73,7 @@ simpleBuilder topLevelMod lst (cabal, cabalattr, classes, toplevelfunctions, tem
   notExistThenCreate (installDir </> "csrc")
   --
   putStrLn "cabal file generation"
-  buildCabalFile (cabal,cabalattr) topLevelMod pkgconfig extralibs (workingDir</>cabalFileName)
+  buildCabalFile cabal topLevelMod pkgconfig extralibs (workingDir</>cabalFileName)
   --
   putStrLn "header file generation"
   let typmacro = TypMcro ("__"  <> macrofy (cabal_pkgname cabal) <> "__")

--- a/fficxx/lib/FFICXX/Generate/Code/Cabal.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Cabal.hs
@@ -156,13 +156,14 @@ cabalTemplate =
   \$cppFiles\n"
 
 -- |
-buildCabalFile :: (Cabal, CabalAttr)
-            -> String
-            -> PackageConfig
-            -> [String] -- ^ extra libs
-            -> FilePath
-            -> IO ()
-buildCabalFile (cabal, cabalattr) summarymodule pkgconfig extralibs cabalfile = do
+buildCabalFile
+  :: Cabal
+  -> String
+  -> PackageConfig
+  -> [String] -- ^ extra libs
+  -> FilePath
+  -> IO ()
+buildCabalFile cabal summarymodule pkgconfig extralibs cabalfile = do
   let tih = pcfg_topLevelImportHeader pkgconfig
       classmodules = pcfg_classModules pkgconfig
       cih = pcfg_classImportHeaders pkgconfig
@@ -170,12 +171,12 @@ buildCabalFile (cabal, cabalattr) summarymodule pkgconfig extralibs cabalfile = 
       tcih = pcfg_templateClassImportHeaders pkgconfig
       acincs = pcfg_additional_c_incs pkgconfig
       acsrcs = pcfg_additional_c_srcs pkgconfig 
-      extrafiles = cabalattr_extrafiles cabalattr
+      extrafiles = cabal_extrafiles cabal
       txt = subst cabalTemplate
               (context ([ ("licenseField", "license: " <> license)
-                          | Just license <- [cabalattr_license cabalattr] ] <>
+                          | Just license <- [cabal_license cabal] ] <>
                         [ ("licenseFileField", "license-file: " <> licensefile)
-                          | Just licensefile <- [cabalattr_licensefile cabalattr] ] <>
+                          | Just licensefile <- [cabal_licensefile cabal] ] <>
                         [ ("pkgname", cabal_pkgname cabal)
                         , ("version",  "0.0")
                         , ("buildtype", "Simple")
@@ -194,8 +195,8 @@ buildCabalFile (cabal, cabalattr) summarymodule pkgconfig extralibs cabalfile = 
                         , ("cppFiles", genCppFiles (tih,classmodules) acsrcs)
                         , ("exposedModules", genExposedModules summarymodule (classmodules,tmods))
                         , ("otherModules", genOtherModules classmodules)
-                        , ("extralibdirs", intercalate ", " $ cabalattr_extralibdirs cabalattr)
-                        , ("extraincludedirs", intercalate ", " $ cabalattr_extraincludedirs cabalattr)
+                        , ("extralibdirs", intercalate ", " $ cabal_extralibdirs cabal)
+                        , ("extraincludedirs", intercalate ", " $ cabal_extraincludedirs cabal)
                         , ("extraLibraries", concatMap (", " <>) extralibs)
                         , ("cabalIndentation", cabalIndentation)
                         ]))

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -158,21 +158,11 @@ data Cabal = Cabal  { cabal_pkgname       :: String
                     , cabal_additional_c_incs :: [AddCInc]
                     , cabal_additional_c_srcs :: [AddCSrc]
                     , cabal_additional_pkgdeps :: [CabalName]
-                    }
-
-data CabalAttr = CabalAttr  { cabalattr_license          :: Maybe String
-                            , cabalattr_licensefile      :: Maybe String
-                            , cabalattr_extraincludedirs :: [FilePath]
-                            , cabalattr_extralibdirs     :: [FilePath]
-                            , cabalattr_extrafiles       :: [FilePath]
-                            }
-
-instance Default CabalAttr where
-    def = CabalAttr { cabalattr_license          = Nothing
-                    , cabalattr_licensefile      = Nothing
-                    , cabalattr_extraincludedirs = []
-                    , cabalattr_extralibdirs     = []
-                    , cabalattr_extrafiles       = []
+                    , cabal_license          :: Maybe String
+                    , cabal_licensefile      :: Maybe String
+                    , cabal_extraincludedirs :: [FilePath]
+                    , cabal_extralibdirs     :: [FilePath]
+                    , cabal_extrafiles       :: [FilePath]
                     }
 
 data Class = Class { class_cabal :: Cabal

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -15,19 +15,14 @@ cabal = Cabal { cabal_pkgname = "stdcxx"
               , cabal_additional_c_incs = []
               , cabal_additional_c_srcs = []
               , cabal_additional_pkgdeps = []
-              , cabal_pkg_config_deps = []
+              , cabal_license = Just "BSD3"
+              , cabal_licensefile = Just "LICENSE"
+              , cabal_extraincludedirs = [ ]
+              , cabal_extralibdirs = []
+              , cabal_extrafiles = []
               }
 
 extraDep = [ ]
-
-cabalattr =
-    CabalAttr
-    { cabalattr_license = Just "BSD3"
-    , cabalattr_licensefile = Just "LICENSE"
-    , cabalattr_extraincludedirs = [ ]
-    , cabalattr_extralibdirs = []
-    , cabalattr_extrafiles = []
-    }
 
 
 deletable :: Class
@@ -77,6 +72,6 @@ main = do
   simpleBuilder
     "STD"
     headerMap
-    (cabal,cabalattr,classes,toplevelfunctions,templates)
+    (cabal,classes,toplevelfunctions,templates)
     [ ]
     extraDep

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -15,6 +15,7 @@ cabal = Cabal { cabal_pkgname = "stdcxx"
               , cabal_additional_c_incs = []
               , cabal_additional_c_srcs = []
               , cabal_additional_pkgdeps = []
+              , cabal_pkg_config_deps = []
               }
 
 extraDep = [ ]


### PR DESCRIPTION
There is no semantic difference between CabalAttr and Cabal.

Later, we need to define External Cabal with only CabalName. 
