### PR TITLE
support pkgconfig-depends

### DIFF
--- a/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
@@ -21,7 +21,6 @@ import           Data.Either                             (lefts,rights)
 import           Data.List
 import           Data.Maybe                              (maybeToList)
 import           Data.Monoid                             ((<>))
-import           Data.Traversable                        (for)
 import           Language.Haskell.Exts.Build             (app,binds,doE,letE,letStmt
                                                          ,name,pApp
                                                          ,qualStmt,strE,tuple)

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -16,13 +16,8 @@
 
 module FFICXX.Generate.Type.Class where
 
-import           Data.Default                      ( Default(def) )
 import qualified Data.Map                     as M
 import           Data.Monoid                       ( (<>) )
---
-
--- some type aliases
-
 
 -- | C types
 data CTypes = CTString
@@ -163,6 +158,7 @@ data Cabal = Cabal  { cabal_pkgname       :: String
                     , cabal_extraincludedirs :: [FilePath]
                     , cabal_extralibdirs     :: [FilePath]
                     , cabal_extrafiles       :: [FilePath]
+                    , cabal_pkg_config_depends :: [String]
                     }
 
 data Class = Class { class_cabal :: Cabal

--- a/fficxx/lib/FFICXX/Generate/Util/HaskellSrcExts.hs
+++ b/fficxx/lib/FFICXX/Generate/Util/HaskellSrcExts.hs
@@ -15,7 +15,6 @@
 module FFICXX.Generate.Util.HaskellSrcExts where
 
 import           Data.List                           (foldl')
-import           Data.Maybe                          (maybeToList)
 import           Language.Haskell.Exts        hiding (unit_tycon)
 import qualified Language.Haskell.Exts               (unit_tycon)
 

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -20,6 +20,7 @@ cabal = Cabal { cabal_pkgname = "stdcxx"
               , cabal_extraincludedirs = [ ]
               , cabal_extralibdirs = []
               , cabal_extrafiles = []
+              , cabal_pkg_config_depends = []
               }
 
 extraDep = [ ]


### PR DESCRIPTION
add a new record field cabal_pkg_config_depends to Cabal which will be translated into pkgconfig-depends in cabal file.