### PR TITLE
No more TYPECASTMETHOD

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,8 @@ For the time being, to see how to use generated haskell library, check examples 
 
 
 
+
+C Macro tricks
+==============
+We use C Macro tricks described in the following:
+* https://github.com/pfultz2/Cloak/wiki/C-Preprocessor-tricks,-tips,-and-idioms

--- a/fficxx/lib/FFICXX/Generate/Code/MethodDef.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/MethodDef.hs
@@ -96,7 +96,7 @@ funcToDef c func
     in intercalateWith connBSlash id [declstr, "{", returnstr, "}"] 
   | otherwise = 
     let declstr = funcToDecl c func
-        callstr = "TYPECASTMETHOD(Type,"<> aliasedFuncName c func <> "," <> class_name c <> ")(p)->"
+        callstr = "to_nonconst<Type,Type ## _t>(p)->"
                   <> cppFuncName c func <> "("
                   <> argsToCallString (genericFuncArgs func)   
                   <> ")"

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -162,17 +162,10 @@ buildDeclHeader (TypMcro typemacroprefix) cprefix header =
 
 definitionTemplate :: Text
 definitionTemplate =
-  "#include <MacroPatternMatch.h>\n\
+  "#include<MacroPatternMatch.h>\n\
   \$header\n\
   \\n\
   \$namespace\n\
-  \\n\
-  \#define CHECKPROTECT(x,y) IS_PAREN(IS_ ## x ## _ ## y ## _PROTECTED)\n\
-  \\n\
-  \#define TYPECASTMETHOD(cname,mname,oname) \\\n\
-  \  IIF( CHECKPROTECT(cname,mname) ) ( \\\n\
-  \  (to_nonconst<oname,cname ## _t>), \\\n\
-  \  (to_nonconst<cname,cname ## _t>) )\n\
   \\n\
   \$cppbody\n"
 


### PR DESCRIPTION
I am abandoning macro pattern match approach. 
This was needed to eliminate protected method in subclass. The case is very rare, but the treatment for that rare case is ubiquitous and very hard to understand. I will find another way to resolve the protected-later-method problem. 
