### PR TITLE
Aliasing class name on C++ side

### DIFF
--- a/fficxx/lib/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Cpp.hs
@@ -15,7 +15,7 @@
 
 module FFICXX.Generate.Code.Cpp where
 
-import           Data.Char 
+import           Data.Char
 import           Data.Monoid                           ( (<>) )
 --
 import           FFICXX.Generate.Code.MethodDef
@@ -37,56 +37,56 @@ import           FFICXX.Generate.Util
 
 ---- "Class Type Declaration" Instances
 
-genCppHeaderTmplType :: Class -> String 
+genCppHeaderTmplType :: Class -> String
 genCppHeaderTmplType c = let tmpl = "// Opaque type definition for $classname \n\
                                     \typedef struct ${classname}_tag ${classname}_t; \n\
                                     \typedef ${classname}_t * ${classname}_p; \n\
                                     \typedef ${classname}_t const* const_${classname}_p; \n"
-                      in subst tmpl (context [ ("classname", class_name c) ])
+                      in subst tmpl (context [ ("classname", ffiClassName c) ])
 
 genAllCppHeaderTmplType :: [Class] -> String
-genAllCppHeaderTmplType = intercalateWith connRet2 (genCppHeaderTmplType) 
+genAllCppHeaderTmplType = intercalateWith connRet2 (genCppHeaderTmplType)
 
----- "Class Declaration Virtual" Declaration 
+---- "Class Declaration Virtual" Declaration
 
-genCppHeaderTmplVirtual :: Class -> String 
-genCppHeaderTmplVirtual aclass =  
+genCppHeaderTmplVirtual :: Class -> String
+genCppHeaderTmplVirtual aclass =
   let tmpl = "#undef ${classname}_DECL_VIRT \n#define ${classname}_DECL_VIRT(Type) \\\n${funcdecl}"
       funcDeclStr = (funcsToDecls aclass) . virtualFuncs . class_funcs $ aclass
-  in subst tmpl (context [ ("classname", map toUpper (class_name aclass) ) 
-                         , ("funcdecl" , funcDeclStr                     ) ]) 
-      
-genAllCppHeaderTmplVirtual :: [Class] -> String 
+  in subst tmpl (context [ ("classname", map toUpper (ffiClassName aclass) )
+                         , ("funcdecl" , funcDeclStr                     ) ])
+
+genAllCppHeaderTmplVirtual :: [Class] -> String
 genAllCppHeaderTmplVirtual = intercalateWith connRet2 genCppHeaderTmplVirtual
 
 ---- "Class Declaration Non-Virtual" Declaration
 
 genCppHeaderTmplNonVirtual :: Class -> String
-genCppHeaderTmplNonVirtual c = 
-  let tmpl = "#undef ${classname}_DECL_NONVIRT \n#define ${classname}_DECL_NONVIRT(Type) \\\n$funcdecl" 
-      declBodyStr = subst tmpl (context [ ("classname", map toUpper (class_name c))
+genCppHeaderTmplNonVirtual c =
+  let tmpl = "#undef ${classname}_DECL_NONVIRT \n#define ${classname}_DECL_NONVIRT(Type) \\\n$funcdecl"
+      declBodyStr = subst tmpl (context [ ("classname", map toUpper (ffiClassName c))
                                         , ("funcdecl" , funcDeclStr               ) ])
-      funcDeclStr = (funcsToDecls c) . filter (not.isVirtualFunc) 
+      funcDeclStr = (funcsToDecls c) . filter (not.isVirtualFunc)
                                      . class_funcs $ c
-  in  declBodyStr 
+  in  declBodyStr
 
-genAllCppHeaderTmplNonVirtual :: [Class] -> String 
+genAllCppHeaderTmplNonVirtual :: [Class] -> String
 genAllCppHeaderTmplNonVirtual = intercalateWith connRet genCppHeaderTmplNonVirtual
 
 ---- "Class Declaration Virtual/NonVirtual" Instances
 
-genCppHeaderInstVirtual :: (Class,Class) -> String 
-genCppHeaderInstVirtual (p,c) = 
-  let strc = map toUpper (class_name p) 
-  in  strc<>"_DECL_VIRT(" <> class_name c <> ");\n"
+genCppHeaderInstVirtual :: (Class,Class) -> String
+genCppHeaderInstVirtual (p,c) =
+  let strc = map toUpper (ffiClassName p)
+  in  strc<>"_DECL_VIRT(" <> ffiClassName c <> ");\n"
 
-genCppHeaderInstNonVirtual :: Class -> String 
-genCppHeaderInstNonVirtual c = 
-  let strx = map toUpper (class_name c) 
-  in  strx<>"_DECL_NONVIRT(" <> class_name c <> ");\n" 
+genCppHeaderInstNonVirtual :: Class -> String
+genCppHeaderInstNonVirtual c =
+  let strx = map toUpper (ffiClassName c)
+  in  strx<>"_DECL_NONVIRT(" <> ffiClassName c <> ");\n"
 
-genAllCppHeaderInstNonVirtual :: [Class] -> String 
-genAllCppHeaderInstNonVirtual = 
+genAllCppHeaderInstNonVirtual :: [Class] -> String
+genAllCppHeaderInstNonVirtual =
   intercalateWith connRet genCppHeaderInstNonVirtual
 
 
@@ -96,51 +96,51 @@ genAllCppHeaderInstNonVirtual =
 
 ---- "Class Definition Virtual" Declaration
 
-genCppDefTmplVirtual :: Class -> String 
-genCppDefTmplVirtual aclass =  
-  let tmpl = "#undef ${classname}_DEF_VIRT\n#define ${classname}_DEF_VIRT(Type)\\\n$funcdef" 
-      defBodyStr = subst tmpl (context [ ("classname", map toUpper (class_name aclass) ) 
-                                       , ("funcdef"  , funcDefStr                      ) ]) 
+genCppDefTmplVirtual :: Class -> String
+genCppDefTmplVirtual aclass =
+  let tmpl = "#undef ${classname}_DEF_VIRT\n#define ${classname}_DEF_VIRT(Type)\\\n$funcdef"
+      defBodyStr = subst tmpl (context [ ("classname", map toUpper (ffiClassName aclass) )
+                                       , ("funcdef"  , funcDefStr                      ) ])
       funcDefStr = (funcsToDefs aclass) . virtualFuncs . class_funcs $ aclass
-  in  defBodyStr 
-      
+  in  defBodyStr
+
 genAllCppDefTmplVirtual :: [Class] -> String
 genAllCppDefTmplVirtual = intercalateWith connRet2 genCppDefTmplVirtual
 
 ---- "Class Definition NonVirtual" Declaration
 
-genCppDefTmplNonVirtual :: Class -> String 
-genCppDefTmplNonVirtual aclass =  
-  let tmpl = "#undef ${classname}_DEF_NONVIRT\n#define ${classname}_DEF_NONVIRT(Type)\\\n$funcdef" 
-      defBodyStr = subst tmpl (context [ ("classname", map toUpper (class_name aclass) ) 
-                                       , ("funcdef"  , funcDefStr                      ) ]) 
-      funcDefStr = (funcsToDefs aclass) . filter (not.isVirtualFunc) 
+genCppDefTmplNonVirtual :: Class -> String
+genCppDefTmplNonVirtual aclass =
+  let tmpl = "#undef ${classname}_DEF_NONVIRT\n#define ${classname}_DEF_NONVIRT(Type)\\\n$funcdef"
+      defBodyStr = subst tmpl (context [ ("classname", map toUpper (ffiClassName aclass) )
+                                       , ("funcdef"  , funcDefStr                      ) ])
+      funcDefStr = (funcsToDefs aclass) . filter (not.isVirtualFunc)
                                         . class_funcs $ aclass
-  in  defBodyStr 
-      
+  in  defBodyStr
+
 genAllCppDefTmplNonVirtual :: [Class] -> String
 genAllCppDefTmplNonVirtual = intercalateWith connRet2 genCppDefTmplNonVirtual
 
 ---- "Class Definition Virtual/NonVirtual" Instances
 
-genCppDefInstVirtual :: (Class,Class) -> String 
-genCppDefInstVirtual (p,c) = 
-  let strc = map toUpper (class_name p) 
-  in  strc<>"_DEF_VIRT(" <> class_name c <> ")\n"
+genCppDefInstVirtual :: (Class,Class) -> String
+genCppDefInstVirtual (p,c) =
+  let strc = map toUpper (ffiClassName p)
+  in  strc<>"_DEF_VIRT(" <> ffiClassName c <> ")\n"
 
 genCppDefInstNonVirtual :: Class -> String
-genCppDefInstNonVirtual c = 
+genCppDefInstNonVirtual c =
   subst "${capitalclassname}_DEF_NONVIRT(${classname})"
-    (context [ ("capitalclassname", toUppers (class_name c))
-             , ("classname"       , class_name c           ) ]) 
+    (context [ ("capitalclassname", toUppers (ffiClassName c))
+             , ("classname"       , ffiClassName c           ) ])
 
-genAllCppDefInstNonVirtual :: [Class] -> String 
+genAllCppDefInstNonVirtual :: [Class] -> String
 genAllCppDefInstNonVirtual = intercalateWith connRet genCppDefInstNonVirtual
 
 -----------------
 
-genAllCppHeaderInclude :: ClassImportHeader -> String 
-genAllCppHeaderInclude header = 
+genAllCppHeaderInclude :: ClassImportHeader -> String
+genAllCppHeaderInclude header =
     intercalateWith connRet (\x->"#include \""<>x<>"\"") $
       map unHdrName (cihIncludedHPkgHeadersInCPP header
                      <> cihIncludedCPkgHeaders header)
@@ -153,37 +153,37 @@ genAllCppHeaderInclude header =
 -- TOP LEVEL FUNCTIONS --
 -------------------------
 
-genTopLevelFuncCppHeader :: TopLevelFunction -> String 
-genTopLevelFuncCppHeader TopLevelFunction {..} = 
-  subst "$returntype $funcname ( $args );" 
-    (context [ ("returntype", rettypeToString toplevelfunc_ret                )  
-             , ("funcname"  , "TopLevel_" 
+genTopLevelFuncCppHeader :: TopLevelFunction -> String
+genTopLevelFuncCppHeader TopLevelFunction {..} =
+  subst "$returntype $funcname ( $args );"
+    (context [ ("returntype", rettypeToString toplevelfunc_ret                )
+             , ("funcname"  , "TopLevel_"
                               <> maybe toplevelfunc_name id toplevelfunc_alias)
              , ("args"      , argsToStringNoSelf toplevelfunc_args            ) ])
-genTopLevelFuncCppHeader TopLevelVariable {..} = 
+genTopLevelFuncCppHeader TopLevelVariable {..} =
   subst "$returntype $funcname ( );"
-    (context [ ("returntype", rettypeToString toplevelvar_ret                )  
-             , ("funcname"  , "TopLevel_" 
-                               <> maybe toplevelvar_name id toplevelvar_alias) ]) 
+    (context [ ("returntype", rettypeToString toplevelvar_ret                )
+             , ("funcname"  , "TopLevel_"
+                               <> maybe toplevelvar_name id toplevelvar_alias) ])
 
-genTopLevelFuncCppDefinition :: TopLevelFunction -> String 
-genTopLevelFuncCppDefinition TopLevelFunction {..} =  
-  let tmpl = "$returntype $funcname ( $args ) { \n  $funcbody\n}" 
+genTopLevelFuncCppDefinition :: TopLevelFunction -> String
+genTopLevelFuncCppDefinition TopLevelFunction {..} =
+  let tmpl = "$returntype $funcname ( $args ) { \n  $funcbody\n}"
       callstr = toplevelfunc_name <> "("
-                <> argsToCallString toplevelfunc_args   
+                <> argsToCallString toplevelfunc_args
                 <> ")"
       funcDefStr = returnCpp False (toplevelfunc_ret) callstr
-  in subst tmpl (context [ ("returntype", rettypeToString toplevelfunc_ret                )  
-                         , ("funcname"  , "TopLevel_" 
+  in subst tmpl (context [ ("returntype", rettypeToString toplevelfunc_ret                )
+                         , ("funcname"  , "TopLevel_"
                                           <> maybe toplevelfunc_name id toplevelfunc_alias)
-                         , ("args"      , argsToStringNoSelf toplevelfunc_args            ) 
+                         , ("args"      , argsToStringNoSelf toplevelfunc_args            )
                          , ("funcbody"  , funcDefStr                                      ) ])
-genTopLevelFuncCppDefinition TopLevelVariable {..} =  
-  let tmpl = "$returntype $funcname ( ) { \n  $funcbody\n}" 
+genTopLevelFuncCppDefinition TopLevelVariable {..} =
+  let tmpl = "$returntype $funcname ( ) { \n  $funcbody\n}"
       callstr = toplevelvar_name
       funcDefStr = returnCpp False (toplevelvar_ret) callstr
-  in subst tmpl (context [ ("returntype", rettypeToString toplevelvar_ret               )  
-                         , ("funcname"  , "TopLevel_" 
+  in subst tmpl (context [ ("returntype", rettypeToString toplevelvar_ret               )
+                         , ("funcname"  , "TopLevel_"
                                           <> maybe toplevelvar_name id toplevelvar_alias)
                          , ("funcbody"  , funcDefStr                                    ) ])
 
@@ -191,7 +191,7 @@ genTopLevelFuncCppDefinition TopLevelVariable {..} =
 genTmplFunCpp :: Bool -- ^ is for simple type?
               -> TemplateClass
               -> TemplateFunction
-              -> String 
+              -> String
 genTmplFunCpp b t@TmplCls {..} f = subst tmpl ctxt
  where
   tmpl = "#define ${tname}_${fname}${suffix}(Type) \\\n\
@@ -218,20 +218,19 @@ genTmplFunCpp b t@TmplCls {..} f = subst tmpl ctxt
 genTmplClassCpp :: Bool -- ^ is for simple type
                 -> TemplateClass
                 -> [TemplateFunction]
-                -> String 
+                -> String
 genTmplClassCpp b TmplCls {..} fs = subst tmpl ctxt
  where
   tmpl = "#define ${tname}_instance${suffix}(Type) \\\n\
          \$macro\n"
   suffix = if b then "_s" else ""
   ctxt = context [ ("tname"  , tclass_name )
-                 , ("suffix" , suffix      ) 
+                 , ("suffix" , suffix      )
                  , ("macro"  , macro       ) ]
   tname = tclass_name
-  
+
   macro1 TFun {..}    = "  " <> tname<> "_" <> tfun_name <> suffix <> "(Type) \\"
-                 
+
   macro1 TFunNew {..} = "  " <> tname<> "_new(Type) \\"
-  macro1 TFunDelete   = "  " <> tname<> "_delete(Type) \\"                 
+  macro1 TFunDelete   = "  " <> tname<> "_delete(Type) \\"
   macro = intercalateWith connRet macro1 fs
-                 

--- a/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
@@ -222,9 +222,16 @@ mkClassModule :: (Class->([Namespace],[HeaderName]))
               -> Class
               -> ClassModule
 mkClassModule mkincheaders extra c =
-  ClassModule (getClassModuleBase c) [c] (map (mkCIH mkincheaders) [c]) highs_nonsource
-              raws highs_source ffis extraimports
-
+    ClassModule {
+      cmModule = getClassModuleBase c
+    , cmClass = [c]
+    , cmCIH = map (mkCIH mkincheaders) [c]
+    , cmImportedModulesHighNonSource = highs_nonsource
+    , cmImportedModulesRaw =raws
+    , cmImportedModulesHighSource = highs_source
+    , cmImportedModulesForFFI = ffis
+    , cmExtraImport = extraimports
+    }
   where highs_nonsource = (map getmodulebase . mkModuleDepHighNonSource) (Right c)
         raws = (map getmodulebase . mkModuleDepRaw) (Right c)
         highs_source = (map getmodulebase . mkModuleDepHighSource) (Right c)
@@ -269,12 +276,17 @@ mkHSBOOTCandidateList ms = nub (concatMap cmImportedModulesHighSource ms)
 -- |
 mkPkgHeaderFileName ::Class -> HeaderName
 mkPkgHeaderFileName c =
-    HdrName ((cabal_cheaderprefix.class_cabal) c <> class_name c <.> "h")
+    HdrName (   (cabal_cheaderprefix.class_cabal) c
+            <>  maybe (class_name c) caCHeaderName (class_alias c)
+            <.> "h"
+            )
 
 -- |
 mkPkgCppFileName ::Class -> String
 mkPkgCppFileName c =
-    (cabal_cheaderprefix.class_cabal) c <> class_name c <.> "cpp"
+        (cabal_cheaderprefix.class_cabal) c
+    <>  maybe (class_name c) caCHeaderName (class_alias c)
+    <.> "cpp"
 
 -- |
 mkPkgIncludeHeadersInH :: Class -> [HeaderName]
@@ -295,10 +307,13 @@ mkPkgIncludeHeadersInCPP = map mkPkgHeaderFileName . rights . mkModuleDepCpp . R
 mkCIH :: (Class->([Namespace],[HeaderName]))  -- ^ (mk namespace and include headers)
       -> Class
       -> ClassImportHeader
-mkCIH mkNSandIncHdrs c = ClassImportHeader c
-                           (mkPkgHeaderFileName c)
-                           ((fst . mkNSandIncHdrs) c)
-                           (mkPkgCppFileName c)
-                           (mkPkgIncludeHeadersInH c)
-                           (mkPkgIncludeHeadersInCPP c)
-                           ((snd . mkNSandIncHdrs) c)
+mkCIH mkNSandIncHdrs c =
+  ClassImportHeader {
+    cihClass                    = c
+  , cihSelfHeader               = mkPkgHeaderFileName c
+  , cihNamespace                = (fst . mkNSandIncHdrs) c
+  , cihSelfCpp                  = mkPkgCppFileName c
+  , cihIncludedHPkgHeadersInH   = mkPkgIncludeHeadersInH c
+  , cihIncludedHPkgHeadersInCPP = mkPkgIncludeHeadersInCPP c
+  , cihIncludedCPkgHeaders      = (snd . mkNSandIncHdrs) c
+  }

--- a/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
@@ -40,7 +40,7 @@ import           Data.Maybe
 import           Data.Monoid               ( (<>) )
 import           System.FilePath
 --
-import           FFICXX.Generate.Code.Primitive (hsClassName,hsTemplateClassName)
+import           FFICXX.Generate.Code.Primitive (ffiClassName,hsClassName,hsTemplateClassName)
 import           FFICXX.Generate.Type.Cabal (AddCInc,AddCSrc
                                             ,cabal_moduleprefix,cabal_pkgname
                                             ,cabal_cheaderprefix,unCabalName)
@@ -277,7 +277,7 @@ mkHSBOOTCandidateList ms = nub (concatMap cmImportedModulesHighSource ms)
 mkPkgHeaderFileName ::Class -> HeaderName
 mkPkgHeaderFileName c =
     HdrName (   (cabal_cheaderprefix.class_cabal) c
-            <>  maybe (class_name c) caCHeaderName (class_alias c)
+            <>  ffiClassName c
             <.> "h"
             )
 
@@ -285,7 +285,7 @@ mkPkgHeaderFileName c =
 mkPkgCppFileName ::Class -> String
 mkPkgCppFileName c =
         (cabal_cheaderprefix.class_cabal) c
-    <>  maybe (class_name c) caCHeaderName (class_alias c)
+    <>  ffiClassName c
     <.> "cpp"
 
 -- |

--- a/fficxx/lib/FFICXX/Generate/Code/HsFFI.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/HsFFI.hs
@@ -21,10 +21,9 @@ import           Language.Haskell.Exts.Syntax            (Decl(..))
 import           System.FilePath                         ((<.>))
 --
 import           FFICXX.Generate.Code.Dependency         (class_allparents)
-import           FFICXX.Generate.Code.Primitive          (aliasedFuncName,hscFuncName
-                                                         ,genericFuncArgs,genericFuncRet
-                                                         ,hsFFIFuncTyp
-                                                         )
+import           FFICXX.Generate.Code.Primitive          (hscFuncName,genericFuncArgs
+                                                         ,genericFuncRet
+                                                         ,hsFFIFuncTyp)
 import           FFICXX.Generate.Type.Class
 import           FFICXX.Generate.Type.Module
 import           FFICXX.Generate.Type.PackageInterface
@@ -48,7 +47,7 @@ hsFFIClassFunc headerfilename c f =
   if isAbstractClass c 
   then Nothing
   else let hfile = unHdrName headerfilename
-           cname = class_name c <> "_" <> aliasedFuncName c f
+           cname = hscFuncName c f -- class_name c <> "_" <> aliasedFuncName c f
            typ = if (isNewFunc f || isStaticFunc f)
                  then hsFFIFuncTyp (Just (NoSelf,c)) (genericFuncArgs f, genericFuncRet f)
                  else hsFFIFuncTyp (Just (Self,c)  ) (genericFuncArgs f, genericFuncRet f)

--- a/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
@@ -432,7 +432,7 @@ typeclassNameFromStr = ('I':)
 
 hsClassName :: Class -> (String, String)  -- ^ High-level, 'Raw'-level
 hsClassName c =
-  let cname = maybe (class_name c) id (class_alias c)
+  let cname = maybe (class_name c) caHaskellName (class_alias c)
   in (cname, "Raw" <> cname)
 
 hsTemplateClassName :: TemplateClass -> (String, String)  -- ^ High-level, 'Raw'-level

--- a/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
@@ -444,8 +444,14 @@ existConstructorName :: Class -> String
 existConstructorName c = 'E' : (fst.hsClassName) c
 
 
+ffiClassName :: Class -> String
+ffiClassName c = maybe (class_name c) caFFIName (class_alias c)
+
 hscFuncName :: Class -> Function -> String
-hscFuncName c f = "c_" <> toLowers (class_name c) <> "_" <> toLowers (aliasedFuncName c f)
+hscFuncName c f =    "c_"
+                  <> toLowers (ffiClassName c)
+                  <> "_"
+                  <> toLowers (aliasedFuncName c f)
 
 hsFuncName :: Class -> Function -> String
 hsFuncName c f = let (x:xs) = aliasedFuncName c f

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -113,10 +113,10 @@ declarationTemplate =
   \#ifndef $typemacro\n\
   \#define $typemacro\n\
   \\n\
-  \#include \"${cprefix}Type.h\"\
-  \\n\
+  \#include \"${cprefix}Type.h\"\n\
+  \ // \n\
   \$declarationheader\n\
-  \\n\
+  \ // \n\
   \$declarationbody\n\
   \\n\
   \#endif // $typemacro\n\
@@ -134,8 +134,10 @@ buildDeclHeader (TypMcro typemacroprefix) cprefix header =
   let classes = [cihClass header]
       aclass = cihClass header
       typemacrostr = typemacroprefix <> ffiClassName aclass <> "__"
-      declHeaderStr = intercalateWith connRet (\x->"#include \""<>x<>"\"") $
-                        map unHdrName (cihIncludedHPkgHeadersInH header)
+      declHeaderStr = intercalateWith
+                        connRet
+                        (\x->"#include \""<>x<>"\"")
+                        (map unHdrName (cihIncludedHPkgHeadersInH header))
       declDefStr    = genAllCppHeaderTmplVirtual classes
                       `connRet2`
                       genAllCppHeaderTmplNonVirtual classes
@@ -167,6 +169,8 @@ definitionTemplate =
   \\n\
   \$namespace\n\
   \\n\
+  \$alias\n\
+  \\n\
   \$cppbody\n"
 
 
@@ -178,6 +182,10 @@ buildDefMain header =
       headerStr = genAllCppHeaderInclude header <> "\n#include \"" <> (unHdrName (cihSelfHeader header)) <> "\""
       namespaceStr = (concatMap (\x->"using namespace " <> unNamespace x <> ";\n") . cihNamespace) header
       aclass = cihClass header
+      aliasStr = let n1 = class_name aclass
+                     n2 = ffiClassName aclass
+                 in if n1 == n2 then "" else "typedef " <> n1 <> " " <> n2 <> ";"
+
       cppBody = mkProtectedFunctionList (cihClass header)
                 `connRet`
                 buildParentDef genCppDefInstVirtual (cihClass header)
@@ -188,6 +196,7 @@ buildDefMain header =
                 `connRet`
                 genAllCppDefInstNonVirtual classes
   in subst definitionTemplate (context ([ ("header"   , headerStr    )
+                                        , ("alias"    , aliasStr     )
                                         , ("namespace", namespaceStr )
                                         , ("cppbody"  , cppBody      ) ]))
 
@@ -218,10 +227,12 @@ buildTopLevelFunctionCppDef tih =
       allns = nubBy ((==) `on` unNamespace) (tihClassDep tih >>= cihNamespace)
       namespaceStr = do ns <- allns
                         ("using namespace " <> unNamespace ns <> ";\n")
+      aliasStr = ""
       declBodyStr    = intercalateWith connRet genTopLevelFuncCppDefinition (tihFuncs tih)
 
   in subst definitionTemplate (context [ ("header"   , declHeaderStr)
                                        , ("namespace", namespaceStr )
+                                       , ("alias"    , aliasStr     )
                                        , ("cppbody"  , declBodyStr  ) ])
 
 -- |

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -15,7 +15,7 @@
 
 module FFICXX.Generate.ContentMaker where
 
-import           Control.Lens                           (set,at)
+import           Control.Lens                           ((&),(.~),at)
 import           Control.Monad.Trans.Reader
 import           Data.Function                          (on)
 import qualified Data.Map                          as M
@@ -133,7 +133,7 @@ buildDeclHeader :: TypeMacro  -- ^ typemacro prefix
 buildDeclHeader (TypMcro typemacroprefix) cprefix header =
   let classes = [cihClass header]
       aclass = cihClass header
-      typemacrostr = typemacroprefix <> class_name aclass <> "__"
+      typemacrostr = typemacroprefix <> ffiClassName aclass <> "__"
       declHeaderStr = intercalateWith connRet (\x->"#include \""<>x<>"\"") $
                         map unHdrName (cihIncludedHPkgHeadersInH header)
       declDefStr    = genAllCppHeaderTmplVirtual classes
@@ -398,4 +398,4 @@ buildPackageInterface pinfc pkgname = foldr f pinfc
   where f cih repo =
           let name = (class_name . cihClass) cih
               header = cihSelfHeader cih
-          in set (at (pkgname,ClsName name)) (Just header) repo
+          in repo & at (pkgname,ClsName name) .~ (Just header)

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -144,7 +144,7 @@ newtype ProtectedMethod = Protected { unProtected :: [String] }
 
 
 data ClassAlias = ClassAlias { caHaskellName :: String
-                             -- , caNewHeaderName :: String
+                             , caCHeaderName :: String
                              }
 
 data Class = Class { class_cabal :: Cabal

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -144,7 +144,7 @@ newtype ProtectedMethod = Protected { unProtected :: [String] }
 
 
 data ClassAlias = ClassAlias { caHaskellName :: String
-                             , caCHeaderName :: String
+                             , caFFIName :: String
                              }
 
 data Class = Class { class_cabal :: Cabal

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -143,7 +143,9 @@ newtype ProtectedMethod = Protected { unProtected :: [String] }
                         deriving (Monoid)
 
 
-type ClassAlias = String
+data ClassAlias = ClassAlias { caHaskellName :: String
+                             -- , caNewHeaderName :: String
+                             }
 
 data Class = Class { class_cabal :: Cabal
                    , class_name :: String
@@ -156,7 +158,7 @@ data Class = Class { class_cabal :: Cabal
                            , class_name :: String
                            , class_parents :: [Class]
                            , class_protected :: ProtectedMethod
-                           , class_alias :: Maybe String
+                           , class_alias :: Maybe ClassAlias
                            , class_funcs :: [Function]
                            }
 
@@ -215,6 +217,3 @@ isAbstractClass AbstractClass{} = True
 
 
 type DaughterMap = M.Map String [Class]
-
-
-

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -35,7 +35,7 @@ deletable =
 
 string :: Class
 string =
-  Class cabal "string" [ deletable ] mempty  (Just "CppString")
+  Class cabal "string" [ deletable ] mempty  (Just (ClassAlias { caHaskellName = "CppString"}))
   [ Constructor [ cstring "p" ] Nothing
   , NonVirtual cstring_ "c_str" [] Nothing
   , NonVirtual (cppclassref_ string) "append" [cppclassref string "str"] Nothing
@@ -43,7 +43,7 @@ string =
   ]
 
 ostream :: Class
-ostream = Class cabal "ostream" [] mempty (Just "Ostream") []
+ostream = Class cabal "ostream" [] mempty (Just (ClassAlias { caHaskellName = "Ostream" })) []
 
 
 classes = [ deletable

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -35,15 +35,18 @@ deletable =
 
 string :: Class
 string =
-  Class cabal "string" [ deletable ] mempty  (Just (ClassAlias { caHaskellName = "CppString"}))
-  [ Constructor [ cstring "p" ] Nothing
-  , NonVirtual cstring_ "c_str" [] Nothing
-  , NonVirtual (cppclassref_ string) "append" [cppclassref string "str"] Nothing
-  , NonVirtual (cppclassref_ string) "erase" [] Nothing
-  ]
+  Class cabal "string" [ deletable ] mempty
+    (Just (ClassAlias { caHaskellName = "CppString", caCHeaderName = "string"}))
+    [ Constructor [ cstring "p" ] Nothing
+    , NonVirtual cstring_ "c_str" [] Nothing
+    , NonVirtual (cppclassref_ string) "append" [cppclassref string "str"] Nothing
+    , NonVirtual (cppclassref_ string) "erase" [] Nothing
+    ]
 
 ostream :: Class
-ostream = Class cabal "ostream" [] mempty (Just (ClassAlias { caHaskellName = "Ostream" })) []
+ostream = Class cabal "ostream" [] mempty
+                (Just (ClassAlias { caHaskellName = "Ostream", caCHeaderName = "ostream" }))
+                []
 
 
 classes = [ deletable

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -36,7 +36,7 @@ deletable =
 string :: Class
 string =
   Class cabal "string" [ deletable ] mempty
-    (Just (ClassAlias { caHaskellName = "CppString", caCHeaderName = "string"}))
+    (Just (ClassAlias { caHaskellName = "CppString", caFFIName = "string"}))
     [ Constructor [ cstring "p" ] Nothing
     , NonVirtual cstring_ "c_str" [] Nothing
     , NonVirtual (cppclassref_ string) "append" [cppclassref string "str"] Nothing
@@ -45,7 +45,7 @@ string =
 
 ostream :: Class
 ostream = Class cabal "ostream" [] mempty
-                (Just (ClassAlias { caHaskellName = "Ostream", caCHeaderName = "ostream" }))
+                (Just (ClassAlias { caHaskellName = "Ostream", caFFIName = "ostream" }))
                 []
 
 


### PR DESCRIPTION
I introduce ClassAlias for both haskell class renaming and C++ class renaming. Previously, we only have Haskell side one. This is necessary to support inner class definition such as `ServerCore::Options` since the name is not valid C type or header file name. 