### PR TITLE
Wrap header map information as ModuleUnitMap

### DIFF
--- a/fficxx/fficxx.cabal
+++ b/fficxx/fficxx.cabal
@@ -54,6 +54,7 @@ Library
                    FFICXX.Generate.Util.HaskellSrcExts
                    FFICXX.Generate.Type.Annotate
                    FFICXX.Generate.Type.Cabal
+                   FFICXX.Generate.Type.Config
                    FFICXX.Generate.Type.Class
                    FFICXX.Generate.Type.Module
                    FFICXX.Generate.Type.PackageInterface

--- a/fficxx/lib/FFICXX/Generate/Builder.hs
+++ b/fficxx/lib/FFICXX/Generate/Builder.hs
@@ -19,7 +19,6 @@ import           Control.Monad                           ( forM_, void, when )
 import qualified Data.ByteString.Lazy.Char8        as L
 import           Data.Char                               ( toUpper )
 import           Data.Digest.Pure.MD5                    ( md5 )
--- import qualified Data.HashMap.Strict               as HM
 import           Data.Monoid                             ( (<>), mempty )
 import           Language.Haskell.Exts.Pretty            ( prettyPrint )
 import           System.FilePath                         ( (</>), (<.>), splitExtension )
@@ -44,7 +43,7 @@ macrofy :: String -> String
 macrofy = map ((\x->if x=='-' then '_' else x) . toUpper)
 
 simpleBuilder :: String
-              -> ModuleUnitMap -- [(String,([Namespace],[HeaderName]))]
+              -> ModuleUnitMap
               -> (Cabal, [Class], [TopLevelFunction], [(TemplateClass,HeaderName)])
               -> [String] -- ^ extra libs
               -> [(String,[String])] -- ^ extra module
@@ -62,7 +61,7 @@ simpleBuilder topLevelMod mumap (cabal,classes,toplevelfunctions,templates) extr
 
       pkgconfig@(PkgConfig mods cihs tih tcms _tcihs _ _) =
         mkPackageConfig
-          (unCabalName pkgname, mkClassNSHeaderFromMap mumap)
+          (unCabalName pkgname, findModuleUnitImports mumap)
           (classes, toplevelfunctions,templates,extramods)
           (cabal_additional_c_incs cabal)
           (cabal_additional_c_srcs cabal)

--- a/fficxx/lib/FFICXX/Generate/Builder.hs
+++ b/fficxx/lib/FFICXX/Generate/Builder.hs
@@ -19,7 +19,7 @@ import           Control.Monad                           ( forM_, void, when )
 import qualified Data.ByteString.Lazy.Char8        as L
 import           Data.Char                               ( toUpper )
 import           Data.Digest.Pure.MD5                    ( md5 )
-import qualified Data.HashMap.Strict               as HM
+-- import qualified Data.HashMap.Strict               as HM
 import           Data.Monoid                             ( (<>), mempty )
 import           Language.Haskell.Exts.Pretty            ( prettyPrint )
 import           System.FilePath                         ( (</>), (<.>), splitExtension )
@@ -33,6 +33,7 @@ import           FFICXX.Generate.Code.Dependency
 import           FFICXX.Generate.Config
 import           FFICXX.Generate.ContentMaker
 import           FFICXX.Generate.Type.Cabal (Cabal(..),AddCInc(..),AddCSrc(..),CabalName(..))
+import           FFICXX.Generate.Type.Config (ModuleUnitMap(..))
 import           FFICXX.Generate.Type.Class
 import           FFICXX.Generate.Type.Module
 import           FFICXX.Generate.Type.PackageInterface
@@ -43,12 +44,12 @@ macrofy :: String -> String
 macrofy = map ((\x->if x=='-' then '_' else x) . toUpper)
 
 simpleBuilder :: String
-              -> [(String,([Namespace],[HeaderName]))]
+              -> ModuleUnitMap -- [(String,([Namespace],[HeaderName]))]
               -> (Cabal, [Class], [TopLevelFunction], [(TemplateClass,HeaderName)])
               -> [String] -- ^ extra libs
               -> [(String,[String])] -- ^ extra module
               ->  IO ()
-simpleBuilder topLevelMod lst (cabal,classes,toplevelfunctions,templates) extralibs extramods = do
+simpleBuilder topLevelMod mumap (cabal,classes,toplevelfunctions,templates) extralibs extramods = do
   let pkgname = cabal_pkgname cabal
   putStrLn ("generating " <> unCabalName pkgname)
   cwd <- getCurrentDirectory
@@ -61,7 +62,7 @@ simpleBuilder topLevelMod lst (cabal,classes,toplevelfunctions,templates) extral
 
       pkgconfig@(PkgConfig mods cihs tih tcms _tcihs _ _) =
         mkPackageConfig
-          (unCabalName pkgname, mkClassNSHeaderFromMap (HM.fromList lst))
+          (unCabalName pkgname, mkClassNSHeaderFromMap mumap)
           (classes, toplevelfunctions,templates,extramods)
           (cabal_additional_c_incs cabal)
           (cabal_additional_c_srcs cabal)

--- a/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
@@ -243,8 +243,8 @@ mkClassModule mkincheaders extra c =
         extraimports = fromMaybe [] (lookup (class_name c) extra)
 
 
-mkClassNSHeaderFromMap :: ModuleUnitMap -> Class -> ModuleUnitImports -- ([Namespace],[HeaderName])
-mkClassNSHeaderFromMap m c =
+findModuleUnitImports :: ModuleUnitMap -> Class -> ModuleUnitImports
+findModuleUnitImports m c =
   fromMaybe emptyModuleUnitImports (HM.lookup (MU_Class (class_name c)) (unModuleUnitMap m))
 
 

--- a/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
@@ -2,7 +2,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      : FFICXX.Generate.Code.Dependency
--- Copyright   : (c) 2011-2017 Ian-Woo Kim
+-- Copyright   : (c) 2011-2018 Ian-Woo Kim
 --
 -- License     : BSD3
 -- Maintainer  : Ian-Woo Kim <ianwookim@gmail.com>
@@ -45,6 +45,9 @@ import           FFICXX.Generate.Type.Cabal (AddCInc,AddCSrc
                                             ,cabal_moduleprefix,cabal_pkgname
                                             ,cabal_cheaderprefix,unCabalName)
 import           FFICXX.Generate.Type.Class
+import           FFICXX.Generate.Type.Config (ModuleUnit(..)
+                                             ,ModuleUnitImports(..),emptyModuleUnitImports
+                                             ,ModuleUnitMap(..))
 import           FFICXX.Generate.Type.Module
 import           FFICXX.Generate.Type.PackageInterface
 --
@@ -72,6 +75,7 @@ extractClassFromType (TemplateApp t _ _)      = Just (Left t)
 extractClassFromType (TemplateAppRef t _ _)   = Just (Left t)
 extractClassFromType (TemplateType t)         = Just (Left t)
 extractClassFromType (TemplateParam _)        = Nothing
+extractClassFromType (TemplateParamPointer _) = Nothing
 
 
 class_allparents :: Class -> [Class]
@@ -217,7 +221,7 @@ mkModuleDepFFI y@(Right c) =
 mkModuleDepFFI (Left _) = []
 
 
-mkClassModule :: (Class->([Namespace],[HeaderName]))
+mkClassModule :: (Class->ModuleUnitImports)
               -> [(String,[String])]
               -> Class
               -> ClassModule
@@ -239,8 +243,9 @@ mkClassModule mkincheaders extra c =
         extraimports = fromMaybe [] (lookup (class_name c) extra)
 
 
-mkClassNSHeaderFromMap :: HM.HashMap String ([Namespace],[HeaderName]) -> Class -> ([Namespace],[HeaderName])
-mkClassNSHeaderFromMap m c = fromMaybe ([],[]) (HM.lookup (class_name c) m)
+mkClassNSHeaderFromMap :: ModuleUnitMap -> Class -> ModuleUnitImports -- ([Namespace],[HeaderName])
+mkClassNSHeaderFromMap m c =
+  fromMaybe emptyModuleUnitImports (HM.lookup (MU_Class (class_name c)) (unModuleUnitMap m))
 
 
 mkTCM :: (TemplateClass,HeaderName) -> TemplateClassModule
@@ -248,7 +253,7 @@ mkTCM (t,hdr) = TCM  (getTClassModuleBase t) [t] [TCIH t hdr]
 
 
 mkPackageConfig
-  :: (String,Class->([Namespace],[HeaderName])) -- ^ (package name,mkIncludeHeaders)
+  :: (String,Class->ModuleUnitImports) -- ^ (package name,mkIncludeHeaders)
   -> ([Class],[TopLevelFunction],[(TemplateClass,HeaderName)],[(String,[String])])
   -> [AddCInc]
   -> [AddCSrc]
@@ -304,16 +309,16 @@ mkPkgIncludeHeadersInCPP = map mkPkgHeaderFileName . rights . mkModuleDepCpp . R
 
 
 -- |
-mkCIH :: (Class->([Namespace],[HeaderName]))  -- ^ (mk namespace and include headers)
+mkCIH :: (Class -> ModuleUnitImports)  -- ^ (mk namespace and include headers)
       -> Class
       -> ClassImportHeader
 mkCIH mkNSandIncHdrs c =
   ClassImportHeader {
     cihClass                    = c
   , cihSelfHeader               = mkPkgHeaderFileName c
-  , cihNamespace                = (fst . mkNSandIncHdrs) c
+  , cihNamespace                = (muimports_namespaces . mkNSandIncHdrs) c
   , cihSelfCpp                  = mkPkgCppFileName c
   , cihIncludedHPkgHeadersInH   = mkPkgIncludeHeadersInH c
   , cihIncludedHPkgHeadersInCPP = mkPkgIncludeHeadersInCPP c
-  , cihIncludedCPkgHeaders      = (snd . mkNSandIncHdrs) c
+  , cihIncludedCPkgHeaders      = (muimports_headers . mkNSandIncHdrs) c
   }

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -35,9 +35,11 @@ import           FFICXX.Generate.Code.Primitive
 import           FFICXX.Generate.Type.Annotate
 import           FFICXX.Generate.Type.Class
 import           FFICXX.Generate.Type.Module
-import           FFICXX.Generate.Type.PackageInterface  ( TypeMacro(..), HeaderName(..)
+import           FFICXX.Generate.Type.PackageInterface  ( ClassName(..)
+                                                        , HeaderName(..)
+                                                        , Namespace(..)
                                                         , PackageInterface, PackageName(..)
-                                                        , ClassName(..)
+                                                        , TypeMacro(..)
                                                         )
 import           FFICXX.Generate.Util
 import           FFICXX.Generate.Util.HaskellSrcExts

--- a/fficxx/lib/FFICXX/Generate/Type/Config.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Config.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE DeriveGeneric #-}
+module FFICXX.Generate.Type.Config where
+
+import Data.Hashable (Hashable(..))
+import Data.HashMap.Strict (HashMap)
+import GHC.Generics (Generic)
+--
+import FFICXX.Generate.Type.PackageInterface (HeaderName(..),Namespace(..))
+
+data ModuleUnit = MU_TopLevel 
+                | MU_Class String
+                deriving (Show,Eq,Generic)
+
+instance Hashable ModuleUnit
+
+data ModuleUnitImports =
+  ModuleUnitImports {
+    muimports_namespaces :: [Namespace]
+  , muimports_headers    :: [HeaderName]
+  }
+  deriving (Show)
+
+
+data HeaderMap = HashMap ModuleUnit ModuleUnitImports

--- a/fficxx/lib/FFICXX/Generate/Type/Config.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Config.hs
@@ -20,5 +20,6 @@ data ModuleUnitImports =
   }
   deriving (Show)
 
+emptyModuleUnitImports = ModuleUnitImports [] []
 
-data HeaderMap = HashMap ModuleUnit ModuleUnitImports
+newtype ModuleUnitMap = ModuleUnitMap { unModuleUnitMap :: HashMap ModuleUnit ModuleUnitImports }

--- a/fficxx/lib/FFICXX/Generate/Type/Module.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Module.hs
@@ -14,18 +14,15 @@ module FFICXX.Generate.Type.Module where
 
 import FFICXX.Generate.Type.Cabal (AddCInc,AddCSrc)
 import FFICXX.Generate.Type.Class
-import FFICXX.Generate.Type.PackageInterface
-
-
-newtype Namespace = NS { unNamespace :: String } deriving (Show)
+import FFICXX.Generate.Type.PackageInterface (HeaderName(..),Namespace(..))
 
 data ClassImportHeader = ClassImportHeader
                        { cihClass :: Class
                        , cihSelfHeader :: HeaderName
                        , cihNamespace :: [Namespace]
                        , cihSelfCpp :: String
-                       , cihIncludedHPkgHeadersInH :: [HeaderName]
-                       , cihIncludedHPkgHeadersInCPP :: [HeaderName]
+                       , cihIncludedHPkgHeadersInH :: [HeaderName]    -- TODO: Explain why we need to have these two
+                       , cihIncludedHPkgHeadersInCPP :: [HeaderName]  --       separately.
                        , cihIncludedCPkgHeaders :: [HeaderName]
                        } deriving (Show)
 

--- a/fficxx/lib/FFICXX/Generate/Type/PackageInterface.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/PackageInterface.hs
@@ -3,7 +3,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      : FFICXX.Generate.Type.PackageInterface
--- Copyright   : (c) 2011-2016 Ian-Woo Kim
+-- Copyright   : (c) 2011-2018 Ian-Woo Kim
 --
 -- License     : BSD3
 -- Maintainer  : Ian-Woo Kim <ianwookim@gmail.com>
@@ -27,6 +27,8 @@ newtype HeaderName = HdrName { unHdrName :: String }
 
 instance IsString HeaderName where
   fromString = HdrName
+
+newtype Namespace = NS { unNamespace :: String } deriving (Show)
 
 type PackageInterface = HM.HashMap (PackageName, ClassName) HeaderName 
 

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -1,10 +1,12 @@
 module Main where
 
+import qualified Data.HashMap.Strict as HM
 import Data.Monoid (mempty)
 --
 import FFICXX.Generate.Builder
 import FFICXX.Generate.Code.Primitive
 import FFICXX.Generate.Type.Cabal (Cabal(..),CabalName(..))
+import FFICXX.Generate.Type.Config (ModuleUnitImports(..),ModuleUnitMap(..),ModuleUnit(..))
 import FFICXX.Generate.Type.Class
 import FFICXX.Generate.Type.Module
 import FFICXX.Generate.Type.PackageInterface
@@ -82,8 +84,14 @@ templates = [ (t_vector, HdrName "Vector.h")
 
 
 
-headerMap = [ ("string"         , ([NS "std"          ], [HdrName "string"   ]))
-            ]
+headerMap =
+  ModuleUnitMap $
+    HM.fromList [
+      (MU_Class "string", ModuleUnitImports {
+                            muimports_namespaces = [NS "std"]
+                          , muimports_headers = [ HdrName "string" ]
+                          })
+    ]
 
 main :: IO ()
 main = do


### PR DESCRIPTION
header map information was previously `[(String,([Namespace],[HeaderName])]`, very unreadable.
Now I wrapped it as a `ModuleUnitMap`, which is a HashMap with a `ModuleUnit` key and `ModuleUnitImports` value.
