### PR TITLE
Top-level c++ module can have extra namespace and header imports

### DIFF
--- a/fficxx/lib/FFICXX/Generate/Builder.hs
+++ b/fficxx/lib/FFICXX/Generate/Builder.hs
@@ -85,7 +85,7 @@ simpleBuilder topLevelMod mumap (cabal,classes,toplevelfunctions,templates) extr
 
   gen (unCabalName pkgname <> "Type.h") (buildTypeDeclHeader typmacro (map cihClass cihs))
   mapM_ (\hdr -> gen (unHdrName (cihSelfHeader hdr)) (buildDeclHeader typmacro (unCabalName pkgname) hdr)) cihs
-  gen (tihHeaderFileName tih <.> "h") (buildTopLevelFunctionHeader typmacro (unCabalName pkgname) tih)
+  gen (tihHeaderFileName tih <.> "h") (buildTopLevelHeader typmacro (unCabalName pkgname) tih)
   forM_ tcms $ \m ->
     let tcihs = tcmTCIH m
     in forM_ tcihs $ \tcih ->
@@ -95,7 +95,7 @@ simpleBuilder topLevelMod mumap (cabal,classes,toplevelfunctions,templates) extr
   --
   putStrLn "cpp file generation"
   mapM_ (\hdr -> gen (cihSelfCpp hdr) (buildDefMain hdr)) cihs
-  gen (tihHeaderFileName tih <.> "cpp") (buildTopLevelFunctionCppDef tih)
+  gen (tihHeaderFileName tih <.> "cpp") (buildTopLevelCppDef tih)
   --
   putStrLn "additional header/source generation"
   mapM_ (\(AddCInc hdr txt) -> gen hdr txt) (cabal_additional_c_incs cabal)

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -203,11 +203,11 @@ buildDefMain header =
                                         , ("cppbody"  , cppBody      ) ]))
 
 -- |
-buildTopLevelFunctionHeader :: TypeMacro  -- ^ typemacro prefix
-                         -> String     -- ^ C prefix
-                         -> TopLevelImportHeader
-                         -> String
-buildTopLevelFunctionHeader (TypMcro typemacroprefix) cprefix tih =
+buildTopLevelHeader :: TypeMacro  -- ^ typemacro prefix
+                    -> String     -- ^ C prefix
+                    -> TopLevelImportHeader
+                    -> String
+buildTopLevelHeader (TypMcro typemacroprefix) cprefix tih =
   let typemacrostr = typemacroprefix <> "TOPLEVEL" <> "__"
       declHeaderStr = intercalateWith connRet (\x->"#include \""<>x<>"\"") $
                         map unHdrName $
@@ -219,8 +219,8 @@ buildTopLevelFunctionHeader (TypMcro typemacroprefix) cprefix tih =
                                         , ("declarationbody"  , declBodyStr   ) ])
 
 -- |
-buildTopLevelFunctionCppDef :: TopLevelImportHeader -> String
-buildTopLevelFunctionCppDef tih =
+buildTopLevelCppDef :: TopLevelImportHeader -> String
+buildTopLevelCppDef tih =
   let cihs = tihClassDep tih
       declHeaderStr = "#include \"" <> tihHeaderFileName tih <.> "h" <> "\""
                       `connRet2`

--- a/fficxx/lib/FFICXX/Generate/Type/Module.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Module.hs
@@ -50,6 +50,8 @@ data TemplateClassImportHeader = TCIH { tcihTClass :: TemplateClass
 data TopLevelImportHeader = TopLevelImportHeader { tihHeaderFileName :: String
                                                  , tihClassDep :: [ClassImportHeader]
                                                  , tihFuncs :: [TopLevelFunction]
+                                                 , tihNamespaces :: [Namespace]
+                                                 , tihExtraHeaders :: [HeaderName]
                                                  } deriving (Show)
 
 data PackageConfig = PkgConfig { pcfg_classModules :: [ClassModule]

--- a/test/testpkg-gen/Gen.hs
+++ b/test/testpkg-gen/Gen.hs
@@ -1,10 +1,13 @@
 module Main where
 
+import qualified Data.HashMap.Strict as HM (fromList)
 import Data.Monoid (mempty)
 --
 import FFICXX.Generate.Builder
 import FFICXX.Generate.Code.Primitive
-import FFICXX.Generate.Type.Cabal (Cabal(..),CabalName(..))
+import FFICXX.Generate.Type.Cabal (AddCInc(..),AddCSrc(..),Cabal(..),CabalName(..))
+import FFICXX.Generate.Type.Config (ModuleUnit(..),ModuleUnitMap(..)
+                                   ,ModuleUnitImports(..))
 import FFICXX.Generate.Type.Class
 import FFICXX.Generate.Type.Module
 import FFICXX.Generate.Type.PackageInterface
@@ -47,8 +50,12 @@ t_vector = TmplCls stdcxx_cabal "Vector" "std::vector" "t" [ ]
 cabal = Cabal { cabal_pkgname = CabalName "testpkg"
               , cabal_cheaderprefix = "TestPkg"
               , cabal_moduleprefix = "TestPkg"
-              , cabal_additional_c_incs = []
-              , cabal_additional_c_srcs = []
+              , cabal_additional_c_incs = [
+                  AddCInc "test.h" "#include <vector>\nvoid test( std::vector<float>&  vect);\n" 
+                ]
+              , cabal_additional_c_srcs = [
+                  AddCSrc "test.cpp" "#include <iostream>\n#include <vector>\nusing namespace std;\nvoid test( vector<float>& vec ) {\ncout << vec.size() << endl;\n}\n"
+                ]
               , cabal_additional_pkgdeps = [ CabalName "stdcxx" ]
               , cabal_license = Just "BSD3"
               , cabal_licensefile = Just "LICENSE"
@@ -71,9 +78,18 @@ toplevelfunctions =
 templates = [  ]
 
 headerMap =
-  [
-  ]
+  ModuleUnitMap $ 
+    HM.fromList $
+      [ ( MU_TopLevel
+        , ModuleUnitImports {
+            muimports_namespaces = [NS "std"]
+          , muimports_headers = [HdrName "vector", HdrName "test.h"] 
+          }
+        )
+      ]
 
+
+  
 main :: IO ()
 main = do
   simpleBuilder


### PR DESCRIPTION
This PR allows for designating extra namespaces and header imports for top-level C++ module. 
I also added a new simple example to test this. 