### PR TITLE
Binding to class with methods using template class arguments

### DIFF
--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -17,6 +17,7 @@ module FFICXX.Generate.ContentMaker where
 
 import           Control.Lens                           ((&),(.~),at)
 import           Control.Monad.Trans.Reader
+import           Data.Char                              (toUpper)
 import           Data.Function                          (on)
 import qualified Data.Map                          as M
 import           Data.Monoid                            ((<>))
@@ -246,11 +247,10 @@ buildTopLevelCppDef tih =
 
 -- |
 buildTemplateHeader :: TypeMacro  -- ^ typemacro prefix
-                 -- -> String     -- ^ C prefix
-                 -> TemplateClass
-                 -> String
+                    -> TemplateClass
+                    -> String
 buildTemplateHeader (TypMcro typemacroprefix) t =
-  let typemacrostr = typemacroprefix <> "TEMPLATE" <> "__"
+  let typemacrostr = typemacroprefix <> "TEMPLATE__" <> map toUpper (tclass_name t) <> "__"
       fs = tclass_funcs t
       deffunc = intercalateWith connRet (genTmplFunCpp False t) fs
                 ++ "\n\n"

--- a/fficxx/lib/FFICXX/Generate/Type/Module.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Module.hs
@@ -30,10 +30,12 @@ data ClassModule = ClassModule
                    { cmModule :: String
                    , cmClass :: [Class]
                    , cmCIH :: [ClassImportHeader]
-                   , cmImportedModulesHighNonSource :: [String]  -- ^ imported modules that do not need source
-                   , cmImportedModulesRaw :: [String]            -- ^ imported modules for raw types.
-                   , cmImportedModulesHighSource :: [String]     -- ^ imported modules that need source
-                   , cmImportedModulesForFFI :: [String]
+                   , cmImportedModulesHighNonSource :: [Either TemplateClass Class]  -- ^ imported modules that do not need source
+                                                                         -- NOTE: source means the same cabal package.
+                                                                         -- TODO: rename Source to something more clear.
+                   , cmImportedModulesRaw           :: [Either TemplateClass Class]  -- ^ imported modules for raw types.
+                   , cmImportedModulesHighSource    :: [Either TemplateClass Class]  -- ^ imported modules that need source
+                   , cmImportedModulesForFFI        :: [Either TemplateClass Class]
                    , cmExtraImport :: [String]
                    } deriving (Show)
 

--- a/test/testpkg-gen/Gen.hs
+++ b/test/testpkg-gen/Gen.hs
@@ -46,22 +46,42 @@ t_vector = TmplCls stdcxx_cabal "Vector" "std::vector" "t" [ ]
 testH =
   "#include <iostream>\n\
   \#include <vector>\n\
-  \void test( std::vector<float>&  vect);\n\
+  \using namespace std;\n\
+  \void test( vector<float>&  vect);\n\
   \class A {\n\
   \public:\n\
-  \  A() {}\n\
-  \  ~A() {\n\
-  \     std::cout << \"A deleted\" << std::endl;\n\
+  \  A() {\n\
+  \    cout << \"A created\" << endl;\n\
   \  }\n\
+  \  virtual ~A() {\n\
+  \    cout << \"A deleted\" << endl;\n\
+  \  }\n\
+  \};\n\
+  \class B {\n\
+  \public:\n\
+  \  B() {\n\
+  \    cout << \"B created\" << endl;\n\
+  \  }\n\
+  \  virtual ~B() {\n\
+  \    cout << \"B deleted\" << endl;\n\
+  \  }\n\
+  \  virtual void call( vector<float>& vect );\n\
   \};\n"
 
 testCpp  =
   "#include <iostream>\n\
   \#include <vector>\n\
+  \#include \"test.h\"\n\
   \using namespace std;\n\
   \void test( vector<float>& vec ) {\n\
   \  cout << vec.size() << endl;\n\
+  \}\n\
+  \\n\
+  \void B::call( vector<float>& vec ) {\n\
+  \  cout << \"in B::call\" << endl;\n\
+  \  cout << vec.size() << endl;\n\
   \}\n"
+
 
 
 cabal = Cabal { cabal_pkgname = CabalName "testpkg"
@@ -91,8 +111,14 @@ classA =
     [ Constructor [ ] Nothing
     ]
 
+classB =
+  Class cabal "B" [ deletable ] mempty Nothing
+    [ Constructor [ ] Nothing
+    , Virtual void_ "call" [ (vectorfloatref_, "vec") ] Nothing
+    ]
 
-classes = [ classA ]
+
+classes = [ classA, classB ]
 
 toplevelfunctions =
   [ TopLevelFunction void_ "test" [ (vectorfloatref_, "vec") ] Nothing
@@ -110,6 +136,12 @@ headerMap =
           }
         )
       , ( MU_Class "A"
+        , ModuleUnitImports {
+            muimports_namespaces = []
+          , muimports_headers = [HdrName "test.h"]
+          }
+        )
+      , ( MU_Class "B"
         , ModuleUnitImports {
             muimports_namespaces = []
           , muimports_headers = [HdrName "test.h"]

--- a/test/testpkg-gen/build.sh
+++ b/test/testpkg-gen/build.sh
@@ -1,15 +1,10 @@
 GHCDIR=$(dirname $(which ghc))
 BASEDIR=${GHCDIR}/../lib/ghc-8.0.2
 
-ghc Gen.hs
-./Gen
-cd testpkg && cabal clean && cd ..
+ghc Gen.hs && ./Gen && cd testpkg && cabal clean && cd ..
 
-cabal sandbox delete
-cabal sandbox init
-cabal sandbox add-source testpkg
-cabal install testpkg
+cabal sandbox delete && cabal sandbox init && cabal sandbox add-source testpkg && cabal install testpkg \
 
-g++ -c stub.cc -I${BASEDIR}/stdcxx-0.0/include -I${BASEDIR}/fficxx-runtime-0.3/include
+g++ -c stub.cc -I${BASEDIR}/stdcxx-0.0/include -I${BASEDIR}/fficxx-runtime-0.3/include -Itestpkg/csrc
 cabal exec -- ghc -c test.hs
 cabal exec -- ghc test.hs stub.o

--- a/test/testpkg-gen/build.sh
+++ b/test/testpkg-gen/build.sh
@@ -1,0 +1,15 @@
+GHCDIR=$(dirname $(which ghc))
+BASEDIR=${GHCDIR}/../lib/ghc-8.0.2
+
+ghc Gen.hs
+./Gen
+cd testpkg && cabal clean && cd ..
+
+cabal sandbox delete
+cabal sandbox init
+cabal sandbox add-source testpkg
+cabal install testpkg
+
+g++ -c stub.cc -I${BASEDIR}/stdcxx-0.0/include -I${BASEDIR}/fficxx-runtime-0.3/include
+cabal exec -- ghc -c test.hs
+cabal exec -- ghc test.hs stub.o

--- a/test/testpkg-gen/stub.cc
+++ b/test/testpkg-gen/stub.cc
@@ -1,8 +1,13 @@
 #include <MacroPatternMatch.h>
+#include <memory>
 #include <vector>
+#include "test.h"
+#include "TestPkgA.h"
+#include "UniquePtr.h"
 #include "Vector.h"
 #include "stdcxxType.h"
 
 using namespace std;
 
 Vector_instance_s(float)
+UniquePtr_instance(A)

--- a/test/testpkg-gen/stub.cc
+++ b/test/testpkg-gen/stub.cc
@@ -1,0 +1,8 @@
+#include <MacroPatternMatch.h>
+#include <vector>
+#include "Vector.h"
+#include "stdcxxType.h"
+
+using namespace std;
+
+Vector_instance_s(float)

--- a/test/testpkg-gen/test.hs
+++ b/test/testpkg-gen/test.hs
@@ -26,7 +26,6 @@ main = do
   v :: Vector CFloat <- newVector
   mapM_ (push_back v) [1.0,1.1,1.2,1.3]
   test v
-  deleteVector v
 
   a <- newA
   ptr <- newUniquePtr a
@@ -34,4 +33,7 @@ main = do
   -- delete a
 
   b <- newB
+  call b v
   delete b
+
+  deleteVector v

--- a/test/testpkg-gen/test.hs
+++ b/test/testpkg-gen/test.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+import qualified Data.ByteString.Char8 as B
+
+import           Foreign.C.Types
+import           Foreign.Ptr
+import           Foreign.C.String
+
+import           STD.CppString
+import           STD.Vector.Template
+import qualified STD.Vector.TH as TH
+
+import           TestPkg (test)
+
+$(TH.genVectorInstanceFor ''CFloat "float")
+
+main = do
+  v :: Vector CFloat <- newVector
+  mapM_ (push_back v) [1.0,1.1,1.2,1.3]
+  test v
+  deleteVector v
+
+
+

--- a/test/testpkg-gen/test.hs
+++ b/test/testpkg-gen/test.hs
@@ -9,12 +9,17 @@ import           Foreign.Ptr
 import           Foreign.C.String
 
 import           STD.CppString
+import           STD.Deletable
+import           STD.UniquePtr.Template
+import           STD.UniquePtr.TH
 import           STD.Vector.Template
-import qualified STD.Vector.TH as TH
+import           STD.Vector.TH
 
 import           TestPkg (test)
+import           TestPkg.A
 
-$(TH.genVectorInstanceFor ''CFloat "float")
+$(genVectorInstanceFor ''CFloat "float")
+$(genUniquePtrInstanceFor ''A "A")
 
 main = do
   v :: Vector CFloat <- newVector
@@ -22,5 +27,7 @@ main = do
   test v
   deleteVector v
 
-
-
+  a <- newA
+  ptr <- newUniquePtr a
+  deleteUniquePtr ptr
+  -- delete a

--- a/test/testpkg-gen/test.hs
+++ b/test/testpkg-gen/test.hs
@@ -17,6 +17,7 @@ import           STD.Vector.TH
 
 import           TestPkg (test)
 import           TestPkg.A
+import           TestPkg.B
 
 $(genVectorInstanceFor ''CFloat "float")
 $(genUniquePtrInstanceFor ''A "A")
@@ -31,3 +32,6 @@ main = do
   ptr <- newUniquePtr a
   deleteUniquePtr ptr
   -- delete a
+
+  b <- newB
+  delete b


### PR DESCRIPTION
With this PR, we can now make a binding to an ordinary class that uses template class argument like the following: 
```
class B {
public:
  B() {}
  ~B() {}
  void call (vector<float>& v);
}
```