### PR TITLE
Alias C++ class name consistently for all arguments and return types.

### DIFF
--- a/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
@@ -330,6 +330,7 @@ mkCIH getImports c =
   , cihSelfHeader               = mkPkgHeaderFileName c
   , cihNamespace                = (muimports_namespaces . getImports . MU_Class . class_name) c
   , cihSelfCpp                  = mkPkgCppFileName c
+  , cihImportedClasses          = mkModuleDepCpp (Right c)
   , cihIncludedHPkgHeadersInH   = mkPkgIncludeHeadersInH c
   , cihIncludedHPkgHeadersInCPP = mkPkgIncludeHeadersInCPP c
   , cihIncludedCPkgHeaders      = (muimports_headers . getImports . MU_Class . class_name) c

--- a/fficxx/lib/FFICXX/Generate/Type/Module.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Module.hs
@@ -16,16 +16,20 @@ import FFICXX.Generate.Type.Cabal (AddCInc,AddCSrc)
 import FFICXX.Generate.Type.Class
 import FFICXX.Generate.Type.PackageInterface (HeaderName(..),Namespace(..))
 
+-- | C++ side
 data ClassImportHeader = ClassImportHeader
                        { cihClass :: Class
                        , cihSelfHeader :: HeaderName
                        , cihNamespace :: [Namespace]
                        , cihSelfCpp :: String
+                       , cihImportedClasses :: [Either TemplateClass Class]
                        , cihIncludedHPkgHeadersInH :: [HeaderName]    -- TODO: Explain why we need to have these two
                        , cihIncludedHPkgHeadersInCPP :: [HeaderName]  --       separately.
                        , cihIncludedCPkgHeaders :: [HeaderName]
                        } deriving (Show)
 
+
+-- | Haskell side
 data ClassModule = ClassModule
                    { cmModule :: String
                    , cmClass :: [Class]


### PR DESCRIPTION
No more direct use of class_name (to avoid scope operator in variable names like `const_ServerCore::Options_t`). `typedef` statements need to be placed for all the class dependencies which appear arguments and return types in functions, so I implemented it.