### PR TITLE
Introduce CPTClassMove for std::move!

### DIFF
--- a/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
@@ -71,6 +71,7 @@ extractClassFromType (CT _ _)                 = Nothing
 extractClassFromType (CPT (CPTClass c) _)     = Just (Right c)
 extractClassFromType (CPT (CPTClassRef c) _)  = Just (Right c)
 extractClassFromType (CPT (CPTClassCopy c) _) = Just (Right c)
+extractClassFromType (CPT (CPTClassMove c) _) = Just (Right c)
 extractClassFromType (TemplateApp t _ _)      = Just (Left t)
 extractClassFromType (TemplateAppRef t _ _)   = Just (Left t)
 extractClassFromType (TemplateType t)         = Just (Left t)

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -42,6 +42,7 @@ data CTypes = CTString
 data CPPTypes = CPTClass Class
               | CPTClassRef Class
               | CPTClassCopy Class
+              | CPTClassMove Class
               deriving Show
 
 -- | const flag


### PR DESCRIPTION
some argument like r-value reference or deleted copy constructor (usual struct case) need `std::move`. To support this, I made a special class of type `CPTClassMove`.
 