### PR TITLE
Automatic member variable accessor generation!

### DIFF
--- a/fficxx/lib/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Cpp.hs
@@ -35,32 +35,32 @@ import           FFICXX.Generate.Util
 
 ---- "Class Type Declaration" Instances
 
-genCppHeaderTmplType :: Class -> String
-genCppHeaderTmplType c = let tmpl = "// Opaque type definition for $classname \n\
+genCppHeaderMacroType :: Class -> String
+genCppHeaderMacroType c = let tmpl = "// Opaque type definition for $classname \n\
                                     \typedef struct ${classname}_tag ${classname}_t; \n\
                                     \typedef ${classname}_t * ${classname}_p; \n\
                                     \typedef ${classname}_t const* const_${classname}_p; \n"
                       in subst tmpl (context [ ("classname", ffiClassName c) ])
 
-genAllCppHeaderTmplType :: [Class] -> String
-genAllCppHeaderTmplType = intercalateWith connRet2 (genCppHeaderTmplType)
+genAllCppHeaderMacroType :: [Class] -> String
+genAllCppHeaderMacroType = intercalateWith connRet2 (genCppHeaderMacroType)
 
 ---- "Class Declaration Virtual" Declaration
 
-genCppHeaderTmplVirtual :: Class -> String
-genCppHeaderTmplVirtual aclass =
+genCppHeaderMacroVirtual :: Class -> String
+genCppHeaderMacroVirtual aclass =
   let tmpl = "#undef ${classname}_DECL_VIRT \n#define ${classname}_DECL_VIRT(Type) \\\n${funcdecl}"
       funcDeclStr = (funcsToDecls aclass) . virtualFuncs . class_funcs $ aclass
   in subst tmpl (context [ ("classname", map toUpper (ffiClassName aclass) )
                          , ("funcdecl" , funcDeclStr                     ) ])
 
-genAllCppHeaderTmplVirtual :: [Class] -> String
-genAllCppHeaderTmplVirtual = intercalateWith connRet2 genCppHeaderTmplVirtual
+genAllCppHeaderMacroVirtual :: [Class] -> String
+genAllCppHeaderMacroVirtual = intercalateWith connRet2 genCppHeaderMacroVirtual
 
 ---- "Class Declaration Non-Virtual" Declaration
 
-genCppHeaderTmplNonVirtual :: Class -> String
-genCppHeaderTmplNonVirtual c =
+genCppHeaderMacroNonVirtual :: Class -> String
+genCppHeaderMacroNonVirtual c =
   let tmpl = "#undef ${classname}_DECL_NONVIRT \n#define ${classname}_DECL_NONVIRT(Type) \\\n$funcdecl"
       declBodyStr = subst tmpl (context [ ("classname", map toUpper (ffiClassName c))
                                         , ("funcdecl" , funcDeclStr               ) ])
@@ -68,8 +68,8 @@ genCppHeaderTmplNonVirtual c =
                                      . class_funcs $ c
   in  declBodyStr
 
-genAllCppHeaderTmplNonVirtual :: [Class] -> String
-genAllCppHeaderTmplNonVirtual = intercalateWith connRet genCppHeaderTmplNonVirtual
+genAllCppHeaderMacroNonVirtual :: [Class] -> String
+genAllCppHeaderMacroNonVirtual = intercalateWith connRet genCppHeaderMacroNonVirtual
 
 ---- "Class Declaration Virtual/NonVirtual" Instances
 
@@ -94,21 +94,21 @@ genAllCppHeaderInstNonVirtual =
 
 ---- "Class Definition Virtual" Declaration
 
-genCppDefTmplVirtual :: Class -> String
-genCppDefTmplVirtual aclass =
+genCppDefMacroVirtual :: Class -> String
+genCppDefMacroVirtual aclass =
   let tmpl = "#undef ${classname}_DEF_VIRT\n#define ${classname}_DEF_VIRT(Type)\\\n$funcdef"
       defBodyStr = subst tmpl (context [ ("classname", map toUpper (ffiClassName aclass) )
                                        , ("funcdef"  , funcDefStr                      ) ])
       funcDefStr = (funcsToDefs aclass) . virtualFuncs . class_funcs $ aclass
   in  defBodyStr
 
-genAllCppDefTmplVirtual :: [Class] -> String
-genAllCppDefTmplVirtual = intercalateWith connRet2 genCppDefTmplVirtual
+genAllCppDefMacroVirtual :: [Class] -> String
+genAllCppDefMacroVirtual = intercalateWith connRet2 genCppDefMacroVirtual
 
 ---- "Class Definition NonVirtual" Declaration
 
-genCppDefTmplNonVirtual :: Class -> String
-genCppDefTmplNonVirtual aclass =
+genCppDefMacroNonVirtual :: Class -> String
+genCppDefMacroNonVirtual aclass =
   let tmpl = "#undef ${classname}_DEF_NONVIRT\n#define ${classname}_DEF_NONVIRT(Type)\\\n$funcdef"
       defBodyStr = subst tmpl (context [ ("classname", map toUpper (ffiClassName aclass) )
                                        , ("funcdef"  , funcDefStr                      ) ])
@@ -116,8 +116,8 @@ genCppDefTmplNonVirtual aclass =
                                         . class_funcs $ aclass
   in  defBodyStr
 
-genAllCppDefTmplNonVirtual :: [Class] -> String
-genAllCppDefTmplNonVirtual = intercalateWith connRet2 genCppDefTmplNonVirtual
+genAllCppDefMacroNonVirtual :: [Class] -> String
+genAllCppDefMacroNonVirtual = intercalateWith connRet2 genCppDefMacroNonVirtual
 
 ---- "Class Definition Virtual/NonVirtual" Instances
 

--- a/fficxx/lib/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Cpp.hs
@@ -433,7 +433,10 @@ accessorToDef c v a =
       declstr = accessorToDecl c v a
       varstr = "to_nonconst<Type,Type ## _t>(p)->" <> var_name v
       body Getter = returnCpp False (cRetType csig) varstr
-      body Setter = varstr <> " = *x;"
+      body Setter =    varstr
+                    <> " = "
+                    <> argToCallString (var_type v,"x")
+                    <> ";"
   in  intercalate "\\\n" [declstr, "{", body a, "}"]
 
 

--- a/fficxx/lib/FFICXX/Generate/Code/HsFFI.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/HsFFI.hs
@@ -74,7 +74,7 @@ hsFFIClassFunc headerfilename c f =
 hsFFIAccessor ::Class -> Variable -> Accessor -> Decl ()
 hsFFIAccessor c v a =
   let -- TODO: make this a separate function
-      cname = ffiClassName c <> "_" <> accessorName c v a
+      cname = ffiClassName c <> "_" <> var_name v <> "_" <> (case a of Getter -> "get"; Setter -> "set")
       typ = hsFFIFuncTyp (Just (Self,c)) (accessorCFunSig (var_type v) a)
   in mkForImpCcall cname (hscAccessorName c v a) typ
 

--- a/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
@@ -95,6 +95,15 @@ genHsFrontInstStatic c =
     in mkFun (aliasedFuncName c f) (functionSignature c f) [] rhs Nothing
 
 -----
+{-
+genHsFrontInstVariables :: Class -> [Decl ()]
+genHsFrontInstVariables c =
+  flip concatMap (class_vars c) $ \v ->
+    let rhs = mkVar "undefined" -- app (mkVar (hsFuncXformer f)) (mkVar (hscFuncName c f))
+    in mkFun (accessorName c v Getter) (accessorSignature c v Getter) [] rhs Nothing
+-}
+
+-----
 
 castBody :: [InstDecl ()]
 castBody =
@@ -192,7 +201,11 @@ genHsFrontDowncastClass c = mkFun ("downcast"<>highname) typ [mkPVar "h"] rhs No
 genTopLevelFuncDef :: TopLevelFunction -> [Decl ()]
 genTopLevelFuncDef f@TopLevelFunction {..} =
     let fname = hsFrontNameForTopLevelFunction f
-        (typs,assts) = extractArgRetTypes Nothing False (toplevelfunc_args,toplevelfunc_ret)
+        HaskellTypeSig typs assts =
+          extractArgRetTypes
+            Nothing
+            False
+            (toplevelfunc_args,toplevelfunc_ret)
         sig = tyForall Nothing (Just (cxTuple assts)) (foldr1 tyfun typs)
         xformerstr = let len = length toplevelfunc_args in if len > 0 then "xform" <> show (len-1) else "xformnull"
         cfname = "c_" <> toLowers fname

--- a/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
@@ -201,11 +201,11 @@ genHsFrontDowncastClass c = mkFun ("downcast"<>highname) typ [mkPVar "h"] rhs No
 genTopLevelFuncDef :: TopLevelFunction -> [Decl ()]
 genTopLevelFuncDef f@TopLevelFunction {..} =
     let fname = hsFrontNameForTopLevelFunction f
-        HaskellTypeSig typs assts =
+        HsFunSig typs assts =
           extractArgRetTypes
             Nothing
             False
-            (toplevelfunc_args,toplevelfunc_ret)
+            (CFunSig toplevelfunc_args toplevelfunc_ret)
         sig = tyForall Nothing (Just (cxTuple assts)) (foldr1 tyfun typs)
         xformerstr = let len = length toplevelfunc_args in if len > 0 then "xform" <> show (len-1) else "xformnull"
         cfname = "c_" <> toLowers fname

--- a/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
@@ -95,13 +95,16 @@ genHsFrontInstStatic c =
     in mkFun (aliasedFuncName c f) (functionSignature c f) [] rhs Nothing
 
 -----
-{-
+
 genHsFrontInstVariables :: Class -> [Decl ()]
 genHsFrontInstVariables c =
   flip concatMap (class_vars c) $ \v ->
-    let rhs = mkVar "undefined" -- app (mkVar (hsFuncXformer f)) (mkVar (hscFuncName c f))
-    in mkFun (accessorName c v Getter) (accessorSignature c v Getter) [] rhs Nothing
--}
+    let rhs accessor =
+          app (mkVar (case accessor of Getter -> "xform0"; _ -> "xform1"))
+              (mkVar (hscAccessorName c v accessor))
+    in    mkFun (accessorName c v Getter) (accessorSignature c v Getter) [] (rhs Getter) Nothing
+       <> mkFun (accessorName c v Setter) (accessorSignature c v Setter) [] (rhs Setter) Nothing
+
 
 -----
 

--- a/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
@@ -13,7 +13,7 @@ import           FFICXX.Generate.Util
 import           FFICXX.Generate.Util.HaskellSrcExts
 
 data CFunSig = CFunSig { cArgTypes :: Args
-                       , cRetTypes :: Types
+                       , cRetType :: Types
                        }
 
 data HsFunSig = HsFunSig { hsSigTypes :: [Type ()]

--- a/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
@@ -678,12 +678,14 @@ functionSignatureTT t f = foldr1 tyfun (lst <> [tyapp (tycon "IO") ctyp])
       TFunDelete -> [e]
 
 
+accessorCFunSig :: Types -> Accessor -> CFunSig
+accessorCFunSig typ Getter = CFunSig [] typ
+accessorCFunSig typ Setter = CFunSig [(typ,"x")] Void
+
 
 accessorSignature :: Class -> Variable -> Accessor -> Type ()
 accessorSignature c v accessor =
-  let csig = case accessor of
-               Getter -> CFunSig [] (var_type v)
-               Setter -> CFunSig [(var_type v,"x")] Void
+  let csig = accessorCFunSig (var_type v) accessor
       HsFunSig typs assts = extractArgRetTypes (Just c) False csig
       ctxt = cxTuple assts
       arg0 = (mkTVar (fst (hsClassName c)) :)
@@ -691,8 +693,8 @@ accessorSignature c v accessor =
 
 
 -- | this is for FFI type.
-hsFFIFuncTyp :: Maybe (Selfness, Class) -> (Args,Types) -> Type ()
-hsFFIFuncTyp msc (args,ret) =
+hsFFIFuncTyp :: Maybe (Selfness, Class) -> CFunSig -> Type ()
+hsFFIFuncTyp msc (CFunSig args ret) =
   foldr1 tyfun $ case msc of
                    Nothing         -> argtyps <> [tyapp (tycon "IO") rettyp]
                    Just (Self,_)   -> selftyp: argtyps <> [tyapp (tycon "IO") rettyp]

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -360,7 +360,7 @@ buildImplementationHs amap m = mkModule (cmModule m <.> "Implementation")
                    <> runReader (concat <$> mapM genHsFrontInstNew classes) amap
                    <> concatMap genHsFrontInstNonVirtual classes
                    <> concatMap genHsFrontInstStatic classes
-                   --  <> concatMap genHsFrontInstVariables classes
+                   <> concatMap genHsFrontInstVariables classes
 
 buildTemplateHs :: TemplateClassModule -> Module ()
 buildTemplateHs m = mkModule (tcmModule m <.> "Template")

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -151,6 +151,8 @@ buildDeclHeader (TypMcro typemacroprefix) cprefix header =
                       genAllCppDefMacroVirtual classes
                       `connRet2`
                       genAllCppDefMacroNonVirtual classes
+                      `connRet2`
+                      genAllCppDefMacroAccessor classes
       classDeclsStr = -- NOTE: Deletable is treated specially.
                       -- TODO: We had better make it as a separate constructor in Class.
                       if (fst.hsClassName) aclass /= "Deletable"
@@ -158,7 +160,9 @@ buildDeclHeader (TypMcro typemacroprefix) cprefix header =
                              `connRet2`
                              genCppHeaderInstVirtual (aclass, aclass)
                              `connRet2`
-                             genAllCppHeaderInstNonVirtual classes
+                             intercalateWith connRet genCppHeaderInstNonVirtual classes
+                             `connRet2`
+                             intercalateWith connRet genCppHeaderInstAccessor classes
                         else ""
       declBodyStr   = declDefStr
                       `connRet2`
@@ -207,7 +211,9 @@ buildDefMain cih =
                   then ""
                   else genCppDefInstVirtual (aclass, aclass)
                 `connRet`
-                genAllCppDefInstNonVirtual classes
+                intercalateWith connRet genCppDefInstNonVirtual classes
+                `connRet`
+                intercalateWith connRet genCppDefInstAccessor classes
   in subst definitionTemplate (context ([ ("header"   , headerStr    )
                                         , ("alias"    , aliasStr     )
                                         , ("namespace", namespaceStr )

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -87,7 +87,7 @@ buildTypeDeclHeader :: TypeMacro -- ^ typemacro
                  -> [Class]
                  -> String
 buildTypeDeclHeader (TypMcro typemacro) classes =
-  let typeDeclBodyStr   = genAllCppHeaderTmplType classes
+  let typeDeclBodyStr   = genAllCppHeaderMacroType classes
   in subst
        "#ifdef __cplusplus\n\
        \extern \"C\" { \n\
@@ -142,13 +142,15 @@ buildDeclHeader (TypMcro typemacroprefix) cprefix header =
                         connRet
                         (\x->"#include \""<>x<>"\"")
                         (map unHdrName (cihIncludedHPkgHeadersInH header))
-      declDefStr    = genAllCppHeaderTmplVirtual classes
+      declDefStr    = genAllCppHeaderMacroVirtual classes
                       `connRet2`
-                      genAllCppHeaderTmplNonVirtual classes
+                      genAllCppHeaderMacroNonVirtual classes
                       `connRet2`
-                      genAllCppDefTmplVirtual classes
+                      -- genAllCppHeaderMacroAccessor classes
+                      -- `connRet2`
+                      genAllCppDefMacroVirtual classes
                       `connRet2`
-                      genAllCppDefTmplNonVirtual classes
+                      genAllCppDefMacroNonVirtual classes
       classDeclsStr = -- NOTE: Deletable is treated specially.
                       -- TODO: We had better make it as a separate constructor in Class.
                       if (fst.hsClassName) aclass /= "Deletable"
@@ -240,9 +242,9 @@ buildTopLevelCppDef tih =
         intercalateWith connRet (\x->"#include \""<>x<>"\"") $
           map unHdrName $
             map cihSelfHeader cihs ++ tihExtraHeaders tih
-                      
+
       allns = nubBy ((==) `on` unNamespace) ((tihClassDep tih >>= cihNamespace) ++ tihNamespaces tih)
-             
+
       namespaceStr = do ns <- allns
                         ("using namespace " <> unNamespace ns <> ";\n")
       aliasStr = ""

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -327,11 +327,11 @@ buildCastHs m = mkModule (cmModule m <.> "Cast")
                       , "MultiParamTypeClasses", "OverlappingInstances", "IncoherentInstances" ] ]
                castImports body
   where classes = cmClass m
-        castImports = [ mkImport "Foreign.Ptr"
-                      , mkImport "FFICXX.Runtime.Cast"
-                      , mkImport "System.IO.Unsafe" ]
+        castImports =    [ mkImport "Foreign.Ptr"
+                         , mkImport "FFICXX.Runtime.Cast"
+                         , mkImport "System.IO.Unsafe" ]
                       <> genImportInCast m
-        body = mapMaybe genHsFrontInstCastable classes
+        body =    mapMaybe genHsFrontInstCastable classes
                <> mapMaybe genHsFrontInstCastableSelf classes
 
 -- |
@@ -356,10 +356,11 @@ buildImplementationHs amap m = mkModule (cmModule m <.> "Implementation")
         f :: Class -> [Decl ()]
         f y = concatMap (flip genHsFrontInst y) (y:class_allparents y)
 
-        implBody = concatMap f classes
+        implBody =    concatMap f classes
                    <> runReader (concat <$> mapM genHsFrontInstNew classes) amap
                    <> concatMap genHsFrontInstNonVirtual classes
                    <> concatMap genHsFrontInstStatic classes
+                   --  <> concatMap genHsFrontInstVariables classes
 
 buildTemplateHs :: TemplateClassModule -> Module ()
 buildTemplateHs m = mkModule (tcmModule m <.> "Template")

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -146,8 +146,8 @@ buildDeclHeader (TypMcro typemacroprefix) cprefix header =
                       `connRet2`
                       genAllCppHeaderMacroNonVirtual classes
                       `connRet2`
-                      -- genAllCppHeaderMacroAccessor classes
-                      -- `connRet2`
+                      genAllCppHeaderMacroAccessor classes
+                      `connRet2`
                       genAllCppDefMacroVirtual classes
                       `connRet2`
                       genAllCppDefMacroNonVirtual classes

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -149,7 +149,9 @@ buildDeclHeader (TypMcro typemacroprefix) cprefix header =
                       genAllCppDefTmplVirtual classes
                       `connRet2`
                       genAllCppDefTmplNonVirtual classes
-      classDeclsStr = if (fst.hsClassName) aclass /= "Deletable"
+      classDeclsStr = -- NOTE: Deletable is treated specially.
+                      -- TODO: We had better make it as a separate constructor in Class.
+                      if (fst.hsClassName) aclass /= "Deletable"
                         then buildParentDef genCppHeaderInstVirtual aclass
                              `connRet2`
                              genCppHeaderInstVirtual (aclass, aclass)

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -241,3 +241,6 @@ isAbstractClass AbstractClass{} = True
 
 
 type DaughterMap = M.Map String [Class]
+
+data Accessor = Getter | Setter
+              deriving (Show, Eq)

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -99,6 +99,11 @@ data Function = Constructor { func_args :: Args
               deriving Show
 
 
+data Variable = Variable { var_type :: Types
+                         , var_name :: String
+                         }
+              deriving Show
+
 data TopLevelFunction = TopLevelFunction { toplevelfunc_ret :: Types
                                          , toplevelfunc_name :: String
                                          , toplevelfunc_args :: Args
@@ -158,12 +163,14 @@ data ClassAlias = ClassAlias { caHaskellName :: String
                              , caFFIName :: String
                              }
 
+-- TODO: partial record must be avoided.
 data Class = Class { class_cabal :: Cabal
                    , class_name :: String
                    , class_parents :: [Class]
                    , class_protected :: ProtectedMethod
                    , class_alias :: Maybe ClassAlias
                    , class_funcs :: [Function]
+                   , class_vars :: [Variable]
                    }
            | AbstractClass { class_cabal :: Cabal
                            , class_name :: String
@@ -171,14 +178,18 @@ data Class = Class { class_cabal :: Cabal
                            , class_protected :: ProtectedMethod
                            , class_alias :: Maybe ClassAlias
                            , class_funcs :: [Function]
+                           , class_vars :: [Variable]
                            }
 
+-- TODO: we had better not override standard definitions
 instance Show Class where
   show x = show (class_name x)
 
+-- TODO: we had better not override standard definitions
 instance Eq Class where
   (==) x y = class_name x == class_name y
 
+-- TODO: we had better not override standard definitions
 instance Ord Class where
   compare x y = compare (class_name x) (class_name y)
 
@@ -190,7 +201,7 @@ data TemplateFunction = TFun { tfun_ret :: Types
                              , tfun_alias :: Maybe String }
                       | TFunNew { tfun_new_args :: Args }
                       | TFunDelete
---                       deriving (Show,Eq,Ord)
+
 
 data TemplateClass = TmplCls { tclass_cabal :: Cabal
                              , tclass_name :: String
@@ -198,14 +209,16 @@ data TemplateClass = TmplCls { tclass_cabal :: Cabal
                              , tclass_param :: String
                              , tclass_funcs :: [TemplateFunction]
                              }
---                     deriving (Show,Eq,Ord)
 
+-- TODO: we had better not override standard definitions
 instance Show TemplateClass where
   show x = show (tclass_name x <> " " <> tclass_param x)
 
+-- TODO: we had better not override standard definitions
 instance Eq TemplateClass where
   (==) x y = tclass_name x == tclass_name y
 
+-- TODO: we had better not override standard definitions
 instance Ord TemplateClass where
   compare x y = compare (tclass_name x) (tclass_name y)
 

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -32,8 +32,8 @@ extraDep = [ ]
 deletable :: Class
 deletable =
   AbstractClass cabal "Deletable" [] mempty Nothing
-  [ Destructor Nothing
-  ]
+  [ Destructor Nothing ]
+  []
 
 string :: Class
 string =
@@ -44,12 +44,14 @@ string =
     , NonVirtual (cppclassref_ string) "append" [cppclassref string "str"] Nothing
     , NonVirtual (cppclassref_ string) "erase" [] Nothing
     ]
+    []
+
 
 ostream :: Class
 ostream = Class cabal "ostream" [] mempty
                 (Just (ClassAlias { caHaskellName = "Ostream", caFFIName = "ostream" }))
                 []
-
+                []
 
 classes = [ deletable
           --

--- a/test/testpkg-gen/Gen.hs
+++ b/test/testpkg-gen/Gen.hs
@@ -30,8 +30,8 @@ stdcxx_cabal = Cabal { cabal_pkgname = CabalName "stdcxx"
 deletable :: Class
 deletable =
   AbstractClass stdcxx_cabal "Deletable" [] mempty Nothing
-  [ Destructor Nothing
-  ]
+  [ Destructor Nothing ]
+  []
 
 
 -- import from stdcxx
@@ -39,7 +39,8 @@ string :: Class
 string =
   Class stdcxx_cabal "string" [ ] mempty
   (Just (ClassAlias { caHaskellName = "CppString", caFFIName = "CppString"}))
-  [ ]
+  []
+  []
 
 t_vector = TmplCls stdcxx_cabal "Vector" "std::vector" "t" [ ]
 
@@ -56,6 +57,7 @@ testH =
   \  virtual ~A() {\n\
   \    cout << \"A deleted\" << endl;\n\
   \  }\n\
+  \  int member;\n\
   \};\n\
   \class B {\n\
   \public:\n\
@@ -119,8 +121,8 @@ vectorfloatref_ = TemplateAppRef t_vector (TArg_Other "CFloat") "std::vector<flo
 
 classA =
   Class cabal "A" [ deletable ] mempty Nothing
-    [ Constructor [ ] Nothing
-    ]
+    [ Constructor [ ] Nothing ]
+    [ Variable cint_ "member" ]
 
 classB =
   Class cabal "B" [ deletable ] mempty Nothing
@@ -128,7 +130,7 @@ classB =
     , Virtual void_ "call" [ (vectorfloatref_, "vec") ] Nothing
     , Virtual vectorfloat_ "call2" [] Nothing
     ]
-
+    [ ]
 
 classes = [ classA, classB ]
 

--- a/test/testpkg-gen/test.hs
+++ b/test/testpkg-gen/test.hs
@@ -17,6 +17,7 @@ import           STD.Vector.TH
 
 import           TestPkg (test)
 import           TestPkg.A
+import           TestPkg.A.Implementation
 import           TestPkg.B
 
 $(genVectorInstanceFor ''CFloat "float")
@@ -28,6 +29,9 @@ main = do
   test v
 
   a <- newA
+  a_member_set a 3772
+  m <- a_member_get a
+  print m
   ptr <- newUniquePtr a
   deleteUniquePtr ptr
   -- delete a


### PR DESCRIPTION
At last, we have member variable accessors. 
For example, if we have the following class
```
class A {
public: 
  int member;
};
```
`a_member_get :: A -> IO CInt` and `a_member_set :: A -> CInt -> IO ()` are generated.