### PR TITLE
Dependency adjustment for member accessor

### DIFF
--- a/fficxx/lib/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Cpp.hs
@@ -431,11 +431,11 @@ accessorToDef :: Variable -> Accessor -> String
 accessorToDef v a =
   let csig = accessorCFunSig (var_type v) a
       declstr = accessorToDecl v a
-      varstr = "to_nonconst<Type,Type ## _t>(p)->" <> var_name v
-      body Getter = returnCpp False (cRetType csig) varstr
-      body Setter =    varstr
+      varexp = "to_nonconst<Type,Type ## _t>(p)->" <> var_name v
+      body Getter = "return (" <> castCpp2C (var_type v) varexp <> ");"
+      body Setter =    varexp
                     <> " = "
-                    <> argToCallString (var_type v,"x")
+                    <> castC2Cpp (var_type v) "x"  -- TODO: somehow clean up this hard-coded "x".
                     <> ";"
   in  intercalate "\\\n" [declstr, "{", body a, "}"]
 

--- a/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
@@ -196,9 +196,11 @@ mkModuleDepHighSource y@(Left t) =
 mkModuleDepCpp :: Either TemplateClass Class -> [Either TemplateClass Class]
 mkModuleDepCpp y@(Right c) =
   let fs = class_funcs c
+      vs = class_vars c
   in  nub . filter (/= y)  $
            concatMap (returnDependency.extractClassDep) fs
         <> concatMap (argumentDependency.extractClassDep) fs
+        <> concatMap (extractClassFromType . var_type) vs
         <> getparents y
 mkModuleDepCpp y@(Left t) =
   let fs = tclass_funcs t

--- a/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
@@ -208,21 +208,21 @@ mkModuleDepCpp y@(Left t) =
         <> getparents y
 
 -- |
-mkModuleDepFFI4One :: Either TemplateClass Class -> [Either TemplateClass Class]
-mkModuleDepFFI4One (Right c) =
-  let fs = class_funcs c
-  in concatMap (returnDependency.extractClassDep) fs <> concatMap (argumentDependency.extractClassDep) fs
-mkModuleDepFFI4One (Left t) =
-  let fs = tclass_funcs t
-  in concatMap (returnDependency.extractClassDepForTmplFun) fs <>
-     concatMap (argumentDependency.extractClassDepForTmplFun) fs
-
+mkModuleDepFFI1 :: Either TemplateClass Class -> [Either TemplateClass Class]
+mkModuleDepFFI1 (Right c) = let fs = class_funcs c
+                                vs = class_vars c
+                            in    concatMap (returnDependency.extractClassDep) fs
+                               <> concatMap (argumentDependency.extractClassDep) fs
+                               <> concatMap (extractClassFromType . var_type) vs
+mkModuleDepFFI1 (Left t)  = let fs = tclass_funcs t
+                            in    concatMap (returnDependency.extractClassDepForTmplFun) fs
+                               <> concatMap (argumentDependency.extractClassDepForTmplFun) fs
 
 -- |
 mkModuleDepFFI :: Either TemplateClass Class -> [Either TemplateClass Class]
 mkModuleDepFFI y@(Right c) =
   let ps = map Right (class_allparents c)
-      alldeps' = (concatMap mkModuleDepFFI4One ps) <> mkModuleDepFFI4One y
+      alldeps' = (concatMap mkModuleDepFFI1 ps) <> mkModuleDepFFI1 y
   in nub (filter (/= y) alldeps')
 mkModuleDepFFI (Left _) = []
 

--- a/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
@@ -259,13 +259,17 @@ argToString (CPT (CPTClassRef c) isconst, varname) = case isconst of
     Const   -> "const_" <> cname <> "_p " <> varname
     NoConst -> cname <> "_p " <> varname
   where cname = ffiClassName c
+argToString (CPT (CPTClassCopy c) isconst, varname) = case isconst of
+    Const   -> "const_" <> cname <> "_p " <> varname
+    NoConst -> cname <> "_p " <> varname
+  where cname = ffiClassName c
 argToString (CPT (CPTClassMove c) isconst, varname) = case isconst of
     Const   -> "const_" <> cname <> "_p " <> varname
     NoConst -> cname <> "_p " <> varname
   where cname = ffiClassName c
 argToString (TemplateApp _ _ _,varname) = "void* " <> varname
 argToString (TemplateAppRef _ _ _,varname) = "void* " <> varname
-argToString _ = error "undefined argToString"
+argToString t = error ("argToString: " <> show t)
 
 argsToString :: Args -> String
 argsToString args =
@@ -300,21 +304,55 @@ rettypeToString (TemplateParamPointer _) = "Type ## _p"
 
 
 
-  -- TODO: Rewrite this with static_cast
+-- TODO: Rewrite this with static_cast
 castC2Cpp :: Types -> String -> String
 castC2Cpp t e =
-    case t of
-      CT  (CRef _)         _ -> "(*"<> e <> ")"
-      CPT (CPTClass     c) _ -> "to_nonconst<" <> f <> "," <> f <> "_t>(" <> e <> ")"
-                                where f = ffiClassName c
-      CPT (CPTClassRef  c) _ -> "to_nonconstref<" <> f <> "," <> f <> "_t>(*" <> e <> ")"
-                                where f = ffiClassName c
-      CPT (CPTClassMove c) _ -> "std::move(to_nonconstref<" <> f <> "," <> f<> "_t>(*" <> e <> "))"
-                                where f = ffiClassName c
-      TemplateApp    _ _ g   -> "to_nonconst<" <> g <> ",void>(" <> e <> ")"
-      TemplateAppRef _ _ g   -> "*( (" <> g <> "*) " <> e <> ")"
-      _                      -> e
-  where
+  case t of
+    CT  (CRef _)         _ -> "(*"<> e <> ")"
+    CPT (CPTClass     c) _ -> "to_nonconst<" <> f <> "," <> f <> "_t>(" <> e <> ")"
+                              where f = ffiClassName c
+    CPT (CPTClassRef  c) _ -> "to_nonconstref<" <> f <> "," <> f <> "_t>(*" <> e <> ")"
+                              where f = ffiClassName c
+    CPT (CPTClassCopy c) _ -> "*(to_nonconst<" <> f <> "," <> f <> "_t>(" <> e <> "))"
+                              where f = ffiClassName c
+    CPT (CPTClassMove c) _ -> "std::move(to_nonconstref<" <> f <> "," <> f<> "_t>(*" <> e <> "))"
+                              where f = ffiClassName c
+    TemplateApp    _ _ g   -> "to_nonconst<" <> g <> ",void>(" <> e <> ")"
+    TemplateAppRef _ _ g   -> "*( (" <> g <> "*) " <> e <> ")"
+    _                      -> e
+
+
+-- TODO: Rewrite this with static_cast
+--       Merge this with returnCpp after Void and simple type adjustment
+castCpp2C :: Types -> String -> String
+castCpp2C t e =
+  case t of
+    Void                   -> ""
+    SelfType               -> "to_nonconst<Type ## _t, Type>((Type *)" <> e <> ")"
+    CT (CRef _) _          -> "&(" <> e <> ")"
+    CT _ _                 -> e
+    CPT (CPTClass c) _     -> "to_nonconst<" <> f <> "_t," <> f <> ">((" <> f <> "*)" <> e <> ")"
+                               where f = ffiClassName c
+    CPT (CPTClassRef c) _  -> "to_nonconst<" <> f <> "_t," <> f <> ">(&(" <> e <> "))"
+                               where f = ffiClassName c
+    CPT (CPTClassCopy c) _ -> "to_nonconst<" <> f <> "_t," <> f <> ">(new " <> f <> "(" <> e <> "))"
+                               where f = ffiClassName c
+    CPT (CPTClassMove c) _ -> "std::move(to_nonconst<" <> f <> "_t," <> f <>">(&(" <> e <> ")))"
+                               where f = ffiClassName c
+    TemplateApp _ _ g      -> error "castCpp2C: TemplateApp"
+                              -- g <> "* r = new " <> g <> "(" <> e <> "); "
+                              --  <> "return (static_cast<void*>(r));"
+    TemplateAppRef _ _ g   -> error "castCpp2C: TemplateAppRef"
+                              -- g <> "* r = new " <> g <> "(" <> e <> "); "
+                              -- <> "return (static_cast<void*>(r));"
+    TemplateType _         -> error "castCpp2C: TemplateType"
+    TemplateParam _        -> error "castCpp2C: TemplateParam"
+                              -- if b then e
+                              --      else "to_nonconst<Type ## _t, Type>((Type *)&(" <> e <> "))"
+    TemplateParamPointer _ -> error "castCpp2C: TemplateParamPointer"
+                              -- if b then "(" <> callstr <> ");"
+                              --      else "to_nonconst<Type ## _t, Type>(" <> e <> ") ;"
+
 
 
 tmplArgToString :: Bool -> TemplateClass -> (Types,String) -> String


### PR DESCRIPTION
Importing dependency module in FFI and C++ code for classes used in member accessors were not implemented previously, so this PR implemented it. 
In addition, type casting was also incorrect for non-primitive types. I introduce castCpp2C and castC2Cpp for correcting this. In addition, these functions will replace `argToCallString` and `returnCpp` later (not yet).