### PR TITLE
Alias for template functions

### DIFF
--- a/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
@@ -139,7 +139,7 @@ extractClassDep (Destructor _) =
 extractClassDepForTmplFun :: TemplateFunction -> Dep4Func
 extractClassDepForTmplFun (TFun ret  _ _ args _) =
     Dep4Func (extractClassFromType ret) (concatMap (extractClassFromType.fst) args)
-extractClassDepForTmplFun (TFunNew args) =
+extractClassDepForTmplFun (TFunNew args _) =
     Dep4Func [] (concatMap (extractClassFromType.fst) args)
 extractClassDepForTmplFun TFunDelete =
     Dep4Func [] []

--- a/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
@@ -598,6 +598,14 @@ hsTmplFuncNameTH :: TemplateClass -> TemplateFunction -> String
 hsTmplFuncNameTH t f = "t_" <> hsTmplFuncName t f
 
 
+ffiTmplFuncName :: TemplateFunction -> String
+ffiTmplFuncName f =
+  case f of
+    TFun {..}    -> fromMaybe tfun_name tfun_alias
+    TFunNew {..} -> fromMaybe "new" tfun_new_alias
+    TFunDelete   -> "delete"
+
+
 cppTmplFuncName :: TemplateFunction -> String
 cppTmplFuncName f =
   case f of

--- a/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
@@ -585,6 +585,26 @@ aliasedFuncName c f =
     Static _ str _ a     -> fromMaybe (nonvirtualName c str) a
     Destructor a         -> fromMaybe destructorName a
 
+
+hsTmplFuncName :: TemplateClass -> TemplateFunction -> String
+hsTmplFuncName t f =
+  case f of
+    TFun {..}    -> tfun_name  -- TODO: alias
+    TFunNew {..} -> fromMaybe ("new"<> tclass_name t) tfun_new_alias
+    TFunDelete   -> "delete" <> tclass_name t
+
+
+hsTmplFuncNameTH :: TemplateClass -> TemplateFunction -> String
+hsTmplFuncNameTH t f = "t_" <> hsTmplFuncName t f
+
+
+cppTmplFuncName :: TemplateFunction -> String
+cppTmplFuncName f =
+  case f of
+    TFun {..}    -> tfun_name
+    TFunNew {..} -> "new"
+    TFunDelete   -> "delete"
+
 accessorName :: Class -> Variable -> Accessor -> String
 accessorName c v a =    nonvirtualName c (var_name v)
                      <> "_"

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -199,7 +199,9 @@ data TemplateFunction = TFun { tfun_ret :: Types
                              , tfun_oname :: String
                              , tfun_args :: Args
                              , tfun_alias :: Maybe String }
-                      | TFunNew { tfun_new_args :: Args }
+                      | TFunNew { tfun_new_args :: Args
+                                , tfun_new_alias :: Maybe String
+                                }
                       | TFunDelete
 
 

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -62,7 +62,7 @@ classes = [ deletable
 toplevelfunctions = [ ]
 
 t_vector = TmplCls cabal "Vector" "std::vector" "t"
-             [ TFunNew []
+             [ TFunNew [] Nothing
              , TFun void_ "push_back" "push_back" [(TemplateParam "t","x")] Nothing
              , TFun void_ "pop_back"  "pop_back"  []                        Nothing
              , TFun (TemplateParam "t") "at" "at" [int "n"]                 Nothing
@@ -71,7 +71,7 @@ t_vector = TmplCls cabal "Vector" "std::vector" "t"
              ]
 
 t_unique_ptr = TmplCls cabal "UniquePtr" "std::unique_ptr" "t"
-             [ TFunNew [(TemplateParamPointer "t", "p")]
+             [ TFunNew [(TemplateParamPointer "t", "p")] Nothing
              , TFun (TemplateParamPointer "t") "get" "get" [] Nothing
              , TFun (TemplateParamPointer "t") "release" "release" [] Nothing
              , TFun void_ "reset" "reset" [] Nothing

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -71,7 +71,8 @@ t_vector = TmplCls cabal "Vector" "std::vector" "t"
              ]
 
 t_unique_ptr = TmplCls cabal "UniquePtr" "std::unique_ptr" "t"
-             [ TFunNew [(TemplateParamPointer "t", "p")] Nothing
+             [ TFunNew [] (Just "newUniquePtr0")
+             , TFunNew [(TemplateParamPointer "t", "p")] Nothing
              , TFun (TemplateParamPointer "t") "get" "get" [] Nothing
              , TFun (TemplateParamPointer "t") "release" "release" [] Nothing
              , TFun void_ "reset" "reset" [] Nothing


### PR DESCRIPTION
For name conflict resolution, user can provide a alias name for template functions. 