### PR TITLE
shared_ptr interface generation

### DIFF
--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -80,9 +80,20 @@ t_unique_ptr = TmplCls cabal "UniquePtr" "std::unique_ptr" "t"
              ]
 
 
+t_shared_ptr = TmplCls cabal "SharedPtr" "std::shared_ptr" "t"
+             [ TFunNew [] (Just "newSharedPtr0")
+             , TFunNew [(TemplateParamPointer "t", "p")] Nothing
+             , TFun (TemplateParamPointer "t") "get" "get" [] Nothing
+             , TFun void_ "reset" "reset" [] Nothing
+             , TFun int_ "use_count" "use_count" [] Nothing
+             , TFunDelete
+             ]
+
+
 
 templates = [ (t_vector, HdrName "Vector.h")
             , (t_unique_ptr, HdrName "UniquePtr.h")
+            , (t_shared_ptr, HdrName "SharedPtr.h")
             ]
 
 

--- a/test/shared_ptr/build.sh
+++ b/test/shared_ptr/build.sh
@@ -1,0 +1,6 @@
+GHCDIR=$(dirname $(which ghc))
+BASEDIR=${GHCDIR}/../lib/ghc-8.0.2
+
+g++ -c stub.cc -I${BASEDIR}/stdcxx-0.0/include -I${BASEDIR}/fficxx-runtime-0.3/include
+ghc -c -threaded test.hs
+ghc -threaded test.hs stub.o

--- a/test/shared_ptr/stub.cc
+++ b/test/shared_ptr/stub.cc
@@ -1,0 +1,9 @@
+#include <MacroPatternMatch.h>
+#include <memory>
+#include <string>
+#include "SharedPtr.h"
+#include "stdcxxType.h"
+
+using namespace std;
+
+SharedPtr_instance(string)

--- a/test/shared_ptr/test.hs
+++ b/test/shared_ptr/test.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Main where
+
+import Control.Concurrent (forkOS,threadDelay)
+import qualified Data.ByteString.Char8 as B
+
+import Foreign.C.Types
+import Foreign.Ptr
+import Foreign.C.String
+
+
+import           STD.CppString
+import           STD.SharedPtr.Template
+import qualified STD.SharedPtr.TH as TH
+
+$(TH.genSharedPtrInstanceFor ''CppString "string")
+
+printString :: CppString -> IO ()
+printString cppstr = do
+  cstr <- cppString_c_str cppstr
+  bstr <- B.packCString cstr
+  print bstr
+
+worker :: SharedPtr CppString -> IO ()
+worker ptr = do
+  threadDelay 1000000
+  c <- use_count ptr
+  print c
+  cppstr' <- get ptr
+  printString cppstr'
+
+main = do
+  putStrLn "test"
+  withCString "hello" $ \cstr -> do
+    cppstr <- newCppString cstr
+    ptr <- newSharedPtr cppstr
+
+    forkOS $ worker ptr
+    forkOS $ worker ptr
+
+    threadDelay 10000000
+
+    deleteSharedPtr ptr

--- a/test/shared_ptr/test.hs
+++ b/test/shared_ptr/test.hs
@@ -4,7 +4,7 @@
 
 module Main where
 
-import Control.Concurrent (forkOS,threadDelay)
+import Control.Concurrent (forkIO,forkOS,threadDelay)
 import qualified Data.ByteString.Char8 as B
 
 import Foreign.C.Types
@@ -38,7 +38,7 @@ main = do
     cppstr <- newCppString cstr
     ptr <- newSharedPtr cppstr
 
-    forkOS $ worker ptr
+    forkIO $ worker ptr
     forkOS $ worker ptr
 
     threadDelay 10000000

--- a/test/unique_ptr/build.sh
+++ b/test/unique_ptr/build.sh
@@ -1,3 +1,6 @@
-g++ -c stub.cc -I../../stdcxx/csrc
+GHCDIR=$(dirname $(which ghc))
+BASEDIR=${GHCDIR}/../lib/ghc-8.0.2
+
+g++ -c stub.cc -I${BASEDIR}/stdcxx-0.0/include -I${BASEDIR}/fficxx-runtime-0.3/include
 ghc -c test.hs
 ghc test.hs stub.o


### PR DESCRIPTION
This implements shared_ptr generation. I also provide a test.
To test some non-trivial shared_ptr function, we need to implement assignment operator. That is tracked by another task wavewave/fficxx#23. 