### PR TITLE
Typedef generation for aliased C++ class at Top Level code gen

### DIFF
--- a/fficxx/lib/FFICXX/Generate/Type/Module.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Module.hs
@@ -54,13 +54,17 @@ data TemplateClassImportHeader = TCIH { tcihTClass :: TemplateClass
                                       , tcihSelfHeader :: HeaderName
                                       } deriving (Show)
 
-data TopLevelImportHeader = TopLevelImportHeader { tihHeaderFileName    :: String
-                                                 , tihClassDep          :: [ClassImportHeader]
-                                                 , tihFuncs             :: [TopLevelFunction]
-                                                 , tihNamespaces        :: [Namespace]
-                                                 , tihExtraHeadersInH   :: [HeaderName]
-                                                 , tihExtraHeadersInCPP :: [HeaderName]
-                                                 } deriving (Show)
+data TopLevelImportHeader = TopLevelImportHeader {
+                              tihHeaderFileName    :: String
+                            , tihClassDep          :: [ClassImportHeader]
+                            , tihExtraClassDep     :: [Either TemplateClass Class]
+                              -- ^ Extra class dependencies outside current package.
+                              --   NOTE: we cannot fully construct ClassImportHeader for them.
+                            , tihFuncs             :: [TopLevelFunction]
+                            , tihNamespaces        :: [Namespace]
+                            , tihExtraHeadersInH   :: [HeaderName]
+                            , tihExtraHeadersInCPP :: [HeaderName]
+                            } deriving (Show)
 
 data PackageConfig = PkgConfig { pcfg_classModules :: [ClassModule]
                                , pcfg_classImportHeaders :: [ClassImportHeader]


### PR DESCRIPTION
Aliased class like `ServerCore::Options` must have an aliased name on C++ side.
We use typedef statement for that. Previously each class module has automatic typedef generation, but not at the top level yet. So this PR fills the gap.