### PR TITLE
TemplateAppMove to support move constructor for applied template type

### DIFF
--- a/fficxx/fficxx.cabal
+++ b/fficxx/fficxx.cabal
@@ -58,7 +58,7 @@ Library
                    FFICXX.Generate.Type.Class
                    FFICXX.Generate.Type.Module
                    FFICXX.Generate.Type.PackageInterface
-  ghc-options:     -Wall
+  ghc-options:     -Wall -Werror
                    -funbox-strict-fields
                    -fno-warn-unused-do-bind
                    -fno-warn-missing-signatures

--- a/fficxx/lib/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Cpp.hs
@@ -291,6 +291,9 @@ returnCpp b ret callstr =
     TemplateAppRef (TemplateAppInfo _ _ cpptype) ->
          cpptype <> "* r = new " <> cpptype <> "(" <> callstr <> "); "
       <> "return (static_cast<void*>(r));"
+    TemplateAppMove (TemplateAppInfo _ _ cpptype) ->
+         cpptype <> "* r = new " <> cpptype <> "(" <> callstr <> "); "
+      <> "return std::move(static_cast<void*>(r));"
     TemplateType _          -> error "returnCpp: TemplateType"
     TemplateParam _         ->
       if b then "return (" <> callstr <> ");"

--- a/fficxx/lib/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Cpp.hs
@@ -285,10 +285,12 @@ returnCpp b ret callstr =
                                "return std::move(to_nonconst<"<>str<>"_t,"<>str
                                <>">(&("<>callstr<>")));"
                                where str = ffiClassName c'
-    TemplateApp _ _ cpptype -> cpptype <> "* r = new " <> cpptype <> "(" <> callstr <> "); "
-                               <> "return (static_cast<void*>(r));"
-    TemplateAppRef _ _ cpptype -> cpptype <> "* r = new " <> cpptype <> "(" <> callstr <> "); "
-                                  <> "return (static_cast<void*>(r));"
+    TemplateApp (TemplateAppInfo _ _ cpptype) ->
+         cpptype <> "* r = new " <> cpptype <> "(" <> callstr <> "); "
+      <> "return (static_cast<void*>(r));"
+    TemplateAppRef (TemplateAppInfo _ _ cpptype) ->
+         cpptype <> "* r = new " <> cpptype <> "(" <> callstr <> "); "
+      <> "return (static_cast<void*>(r));"
     TemplateType _          -> error "returnCpp: TemplateType"
     TemplateParam _         ->
       if b then "return (" <> callstr <> ");"
@@ -421,7 +423,7 @@ accessorsToDecls vs =
 
 accessorToDef :: Variable -> Accessor -> String
 accessorToDef v a =
-  let csig = accessorCFunSig (var_type v) a
+  let -- csig = accessorCFunSig (var_type v) a
       declstr = accessorToDecl v a
       varexp = "to_nonconst<Type,Type ## _t>(p)->" <> var_name v
       body Getter = "return (" <> castCpp2C (var_type v) varexp <> ");"

--- a/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
@@ -78,6 +78,10 @@ extractClassFromType (TemplateAppRef (TemplateAppInfo t p _))   =
   (Left t): case p of
               TArg_Class c -> [Right c]
               _            -> []
+extractClassFromType (TemplateAppMove (TemplateAppInfo t p _))   =
+  (Left t): case p of
+              TArg_Class c -> [Right c]
+              _            -> []
 extractClassFromType (TemplateType t)         = [Left t]
 extractClassFromType (TemplateParam _)        = []
 extractClassFromType (TemplateParamPointer _) = []

--- a/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Dependency.hs
@@ -70,12 +70,14 @@ extractClassFromType (CPT (CPTClass c) _)     = [Right c]
 extractClassFromType (CPT (CPTClassRef c) _)  = [Right c]
 extractClassFromType (CPT (CPTClassCopy c) _) = [Right c]
 extractClassFromType (CPT (CPTClassMove c) _) = [Right c]
-extractClassFromType (TemplateApp t p _)      = (Left t): case p of
-                                                            TArg_Class c -> [Right c]
-                                                            _            -> []
-extractClassFromType (TemplateAppRef t p _)   = (Left t): case p of
-                                                            TArg_Class c -> [Right c]
-                                                            _            -> []
+extractClassFromType (TemplateApp (TemplateAppInfo t p _)) =
+  (Left t): case p of
+              TArg_Class c -> [Right c]
+              _            -> []
+extractClassFromType (TemplateAppRef (TemplateAppInfo t p _))   =
+  (Left t): case p of
+              TArg_Class c -> [Right c]
+              _            -> []
 extractClassFromType (TemplateType t)         = [Left t]
 extractClassFromType (TemplateParam _)        = []
 extractClassFromType (TemplateParamPointer _) = []

--- a/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
@@ -218,7 +218,7 @@ genTopLevelFuncDef f@TopLevelFunction {..} =
 genTopLevelFuncDef v@TopLevelVariable {..} =
     let fname = hsFrontNameForTopLevelFunction v
         cfname = "c_" <> toLowers fname
-        rtyp = (tycon . ctypToHsTyp Nothing) toplevelvar_ret
+        rtyp = convertCpp2HS Nothing toplevelvar_ret
         sig = tyapp (tycon "IO") rtyp
         rhs = app (mkVar "xformnull") (mkVar cfname)
 

--- a/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
@@ -468,8 +468,8 @@ convertCpp2HS _c (CPT (CPTClass c') _)     = (tycon . fst . hsClassName) c'
 convertCpp2HS _c (CPT (CPTClassRef c') _)  = (tycon . fst . hsClassName) c'
 convertCpp2HS _c (CPT (CPTClassCopy c') _) = (tycon . fst . hsClassName) c'
 convertCpp2HS _c (CPT (CPTClassMove c') _) = (tycon . fst . hsClassName) c'
-convertCpp2HS _c (TemplateApp x) = tyapp (tycon (tclass_name (tapp_hstemplate x))) (tycon (hsClassNameForTArg (tapp_HaskellTypeForParam x)))
-convertCpp2HS _c (TemplateAppRef x) = tyapp (tycon (tclass_name (tapp_hstemplate x))) (tycon (hsClassNameForTArg (tapp_HaskellTypeForParam x)))
+convertCpp2HS _c (TemplateApp x) = tyapp (tycon (tclass_name (tapp_hstemplate x))) (tycon (hsClassNameForTArg (tapp_HsTypeForParam x)))
+convertCpp2HS _c (TemplateAppRef x) = tyapp (tycon (tclass_name (tapp_hstemplate x))) (tycon (hsClassNameForTArg (tapp_HsTypeForParam x)))
 convertCpp2HS _c (TemplateType t)          = tyapp (tycon (tclass_name t)) (mkTVar (tclass_param t))
 convertCpp2HS _c (TemplateParam p)         = mkTVar p
 convertCpp2HS _c (TemplateParamPointer p)  = mkTVar p
@@ -662,8 +662,8 @@ extractArgRetTypes mc isvirtual (CFunSig args ret) =
            CPT (CPTClassCopy c') _ -> addclass c'
            CPT (CPTClassMove c') _ -> addclass c'
            -- it is not clear whether the following is okay or not.
-           (TemplateApp x)    -> return (tyapp (tycon (tclass_name (tapp_hstemplate x))) (tycon (hsClassNameForTArg (tapp_HaskellTypeForParam x))))
-           (TemplateAppRef x) -> return (tyapp (tycon (tclass_name (tapp_hstemplate x))) (tycon (hsClassNameForTArg (tapp_HaskellTypeForParam x))))
+           (TemplateApp x)    -> return (tyapp (tycon (tclass_name (tapp_hstemplate x))) (tycon (hsClassNameForTArg (tapp_HsTypeForParam x))))
+           (TemplateAppRef x) -> return (tyapp (tycon (tclass_name (tapp_hstemplate x))) (tycon (hsClassNameForTArg (tapp_HsTypeForParam x))))
            (TemplateType t)       -> return (tyapp (tycon (tclass_name t)) (mkTVar (tclass_param t)))
            (TemplateParam p)      -> return (mkTVar p)
            Void -> return unit_tycon
@@ -755,9 +755,9 @@ hsFFIFuncTyp msc (CFunSig args ret) =
           where rawname = snd (hsClassName d)
         hsargtype (CPT (CPTClassCopy d) _)    = tyapp tyPtr (tycon rawname)
           where rawname = snd (hsClassName d)
-        hsargtype (TemplateApp x)   = tyapp tyPtr (tyapp (tycon rawname) (tycon (hsClassNameForTArg (tapp_HaskellTypeForParam x))))
+        hsargtype (TemplateApp x)   = tyapp tyPtr (tyapp (tycon rawname) (tycon (hsClassNameForTArg (tapp_HsTypeForParam x))))
           where rawname = snd (hsTemplateClassName (tapp_hstemplate x))
-        hsargtype (TemplateAppRef x) = tyapp tyPtr (tyapp (tycon rawname) (tycon (hsClassNameForTArg (tapp_HaskellTypeForParam x))))
+        hsargtype (TemplateAppRef x) = tyapp tyPtr (tyapp (tycon rawname) (tycon (hsClassNameForTArg (tapp_HsTypeForParam x))))
           where rawname = snd (hsTemplateClassName (tapp_hstemplate x))
 
         hsargtype (TemplateType t)           = tyapp tyPtr (tyapp (tycon rawname) (mkTVar (tclass_param t)))
@@ -777,9 +777,9 @@ hsFFIFuncTyp msc (CFunSig args ret) =
           where rawname = snd (hsClassName d)
         hsrettype (CPT (CPTClassMove d) _)   = tyapp tyPtr (tycon rawname)
           where rawname = snd (hsClassName d)
-        hsrettype (TemplateApp x) = tyapp tyPtr (tyapp (tycon rawname) (tycon (hsClassNameForTArg (tapp_HaskellTypeForParam x))))
+        hsrettype (TemplateApp x) = tyapp tyPtr (tyapp (tycon rawname) (tycon (hsClassNameForTArg (tapp_HsTypeForParam x))))
           where rawname = snd (hsTemplateClassName (tapp_hstemplate x))
-        hsrettype (TemplateAppRef x) = tyapp tyPtr (tyapp (tycon rawname) (tycon (hsClassNameForTArg (tapp_HaskellTypeForParam x))))
+        hsrettype (TemplateAppRef x) = tyapp tyPtr (tyapp (tycon rawname) (tycon (hsClassNameForTArg (tapp_HsTypeForParam x))))
           where rawname = snd (hsTemplateClassName (tapp_hstemplate x))
         hsrettype (TemplateType t)           = tyapp tyPtr (tyapp (tycon rawname) (mkTVar (tclass_param t)))
           where rawname = snd (hsTemplateClassName t)

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -69,6 +69,7 @@ data Types = Void
            | CPT CPPTypes IsConst
            | TemplateApp     TemplateAppInfo     -- ^ like vector<float>*
            | TemplateAppRef  TemplateAppInfo     -- ^ like vector<float>&
+           | TemplateAppMove TemplateAppInfo     -- ^ like unique_ptr<float> (using std::move)
            | TemplateType    TemplateClass       -- ^ template self? TODO: clarify this.
            | TemplateParam   String
            | TemplateParamPointer String -- ^ this is A* with template<A>

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -56,20 +56,21 @@ data TemplateArgType = TArg_Class Class
                      | TArg_Other String
                      deriving Show
 
+data TemplateAppInfo = TemplateAppInfo {
+                         tapp_hstemplate :: TemplateClass
+                       , tapp_HaskellTypeForParam :: TemplateArgType
+                       , tapp_CppTypeForParam :: String
+                       }
+                     deriving Show
+
 data Types = Void
            | SelfType
            | CT  CTypes IsConst
            | CPT CPPTypes IsConst
-           | TemplateApp { tapp_hstemplate :: TemplateClass
-                         , tapp_HaskellTypeForParam :: TemplateArgType
-                         , tapp_CppTypeForParam :: String }
-             -- ^ like vector<float>
-           | TemplateAppRef { tappref_hstemplate :: TemplateClass
-                            , tappref_HaskellTypeForParam :: TemplateArgType
-                            , tappref_CppTypeForParam :: String }
-             -- ^ like vector<float>&
-           | TemplateType TemplateClass  -- ^ template self? TODO: clarify this.
-           | TemplateParam String
+           | TemplateApp     TemplateAppInfo     -- ^ like vector<float>*
+           | TemplateAppRef  TemplateAppInfo     -- ^ like vector<float>&
+           | TemplateType    TemplateClass       -- ^ template self? TODO: clarify this.
+           | TemplateParam   String
            | TemplateParamPointer String -- ^ this is A* with template<A>
            deriving Show
 

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -58,7 +58,7 @@ data TemplateArgType = TArg_Class Class
 
 data TemplateAppInfo = TemplateAppInfo {
                          tapp_hstemplate :: TemplateClass
-                       , tapp_HaskellTypeForParam :: TemplateArgType
+                       , tapp_HsTypeForParam :: TemplateArgType
                        , tapp_CppTypeForParam :: String
                        }
                      deriving Show


### PR DESCRIPTION
When we use `unique_ptr<A>` in the parameter, we have to use move constructor, i.e. we should explicitly write `std::move`. By adding a new case `TemplateAppMove`, fficxx support it.
I also refactor out `TemplateAppInfo`, a common parameter format for all `TemplateApp..` cases. 
Redundant ctypToHsTyp is removed as well.