### PR TITLE
Module reorganization. HsTemplate and HsCast

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,7 @@ C++ Template tricks
 * https://en.cppreference.com/w/cpp/language/template_argument_deduction
 * http://anderberg.me/2016/08/01/c-variadic-templates/
 * https://crascit.com/2015/03/21/practical-uses-for-variadic-templates/
+
+C++ Template Peculiarity
+========================
+* https://stackoverflow.com/questions/2354210/can-a-c-class-member-function-template-be-virtual

--- a/fficxx/fficxx.cabal
+++ b/fficxx/fficxx.cabal
@@ -43,8 +43,10 @@ Library
                    FFICXX.Generate.Builder
                    FFICXX.Generate.Config
                    FFICXX.Generate.Code.Cpp
+                   FFICXX.Generate.Code.HsCast
                    FFICXX.Generate.Code.HsFrontEnd
                    FFICXX.Generate.Code.HsFFI
+                   FFICXX.Generate.Code.HsTemplate
                    FFICXX.Generate.Code.Cabal
                    FFICXX.Generate.Code.Primitive
                    FFICXX.Generate.ContentMaker

--- a/fficxx/fficxx.cabal
+++ b/fficxx/fficxx.cabal
@@ -46,9 +46,9 @@ Library
                    FFICXX.Generate.Code.HsFrontEnd
                    FFICXX.Generate.Code.HsFFI
                    FFICXX.Generate.Code.Cabal
-                   FFICXX.Generate.Code.Dependency
                    FFICXX.Generate.Code.Primitive
                    FFICXX.Generate.ContentMaker
+                   FFICXX.Generate.Dependency
                    FFICXX.Generate.QQ.Verbatim
                    FFICXX.Generate.Util
                    FFICXX.Generate.Util.HaskellSrcExts

--- a/fficxx/fficxx.cabal
+++ b/fficxx/fficxx.cabal
@@ -58,7 +58,7 @@ Library
                    FFICXX.Generate.Type.Class
                    FFICXX.Generate.Type.Module
                    FFICXX.Generate.Type.PackageInterface
-  ghc-options:     -Wall -Werror
+  ghc-options:     -Wall
                    -funbox-strict-fields
                    -fno-warn-unused-do-bind
                    -fno-warn-missing-signatures

--- a/fficxx/lib/FFICXX/Generate/Builder.hs
+++ b/fficxx/lib/FFICXX/Generate/Builder.hs
@@ -28,7 +28,7 @@ import           System.IO                               ( hPutStrLn, withFile, 
 import           System.Process                          ( readProcess, system )
 --
 import           FFICXX.Generate.Code.Cabal
-import           FFICXX.Generate.Code.Dependency
+import           FFICXX.Generate.Dependency
 import           FFICXX.Generate.Config
 import           FFICXX.Generate.ContentMaker
 import           FFICXX.Generate.Type.Cabal (Cabal(..),AddCInc(..),AddCSrc(..),CabalName(..))

--- a/fficxx/lib/FFICXX/Generate/Code/HsCast.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/HsCast.hs
@@ -1,0 +1,37 @@
+module FFICXX.Generate.Code.HsCast where
+
+import Language.Haskell.Exts.Build             (app)
+import Language.Haskell.Exts.Syntax            (Decl(..),InstDecl(..))
+--
+import FFICXX.Generate.Code.Primitive          (hsClassName,typeclassName)
+import FFICXX.Generate.Type.Class              (Class(..),isAbstractClass)
+import FFICXX.Generate.Util.HaskellSrcExts     (classA
+                                               ,cxEmpty,cxTuple,insDecl
+                                               ,mkBind1,mkInstance,mkPVar,mkTVar,mkVar
+                                               ,tyapp,tycon,tyPtr
+                                               ,unqual)
+-----
+
+castBody :: [InstDecl ()]
+castBody =
+  [ insDecl (mkBind1 "cast" [mkPVar "x",mkPVar "f"] (app (mkVar "f") (app (mkVar "castPtr") (app (mkVar "get_fptr") (mkVar "x")))) Nothing)
+  , insDecl (mkBind1 "uncast" [mkPVar "x",mkPVar "f"] (app (mkVar "f") (app (mkVar "cast_fptr_to_obj") (app (mkVar "castPtr") (mkVar "x")))) Nothing)
+  ]
+
+genHsFrontInstCastable :: Class -> Maybe (Decl ())
+genHsFrontInstCastable c
+  | (not.isAbstractClass) c =
+    let iname = typeclassName c
+        (_,rname) = hsClassName c
+        a = mkTVar "a"
+        ctxt = cxTuple [ classA (unqual iname) [a], classA (unqual "FPtr") [a] ]
+    in Just (mkInstance ctxt "Castable" [a,tyapp tyPtr (tycon rname)] castBody)
+  | otherwise = Nothing
+
+genHsFrontInstCastableSelf :: Class -> Maybe (Decl ())
+genHsFrontInstCastableSelf c
+  | (not.isAbstractClass) c =
+    let (cname,rname) = hsClassName c
+    in Just (mkInstance cxEmpty "Castable" [tycon cname, tyapp tyPtr (tycon rname)] castBody)
+  | otherwise = Nothing
+

--- a/fficxx/lib/FFICXX/Generate/Code/HsFFI.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/HsFFI.hs
@@ -20,9 +20,6 @@ import Data.Monoid                             ((<>))
 import Language.Haskell.Exts.Syntax            (Decl(..),ImportDecl(..))
 import System.FilePath                         ((<.>))
 --
-import FFICXX.Generate.Code.Dependency         (class_allparents
-                                               ,getClassModuleBase
-                                               ,getTClassModuleBase)
 import FFICXX.Generate.Code.Primitive          (CFunSig(..)
                                                ,accessorCFunSig
                                                ,aliasedFuncName
@@ -32,6 +29,9 @@ import FFICXX.Generate.Code.Primitive          (CFunSig(..)
                                                ,hscAccessorName
                                                ,hscFuncName
                                                ,hsFFIFuncTyp)
+import FFICXX.Generate.Dependency              (class_allparents
+                                               ,getClassModuleBase
+                                               ,getTClassModuleBase)
 import FFICXX.Generate.Type.Class
 import FFICXX.Generate.Type.Module
 import FFICXX.Generate.Type.PackageInterface

--- a/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
@@ -17,25 +17,29 @@
 
 module FFICXX.Generate.Code.HsFrontEnd where
 
-import           Control.Monad.Reader
-import           Data.Either                             (lefts,rights)
-import           Data.List
-import           Data.Monoid                             ((<>))
-import           Language.Haskell.Exts.Build             (app,binds,doE,letE,letStmt
-                                                         ,name,pApp
-                                                         ,qualStmt,strE,tuple)
-import           Language.Haskell.Exts.Syntax            (Decl(..)
-                                                         ,ExportSpec(..)
-                                                         ,ImportDecl(..),InstDecl(..))
-import           System.FilePath                         ((<.>))
+import Control.Monad.Reader
+import Data.Either                             (lefts,rights)
+import Data.List
+import Data.Monoid                             ((<>))
+import Language.Haskell.Exts.Build             (app,binds,doE,letE,letStmt
+                                               ,name,pApp
+                                               ,qualStmt,strE,tuple)
+import Language.Haskell.Exts.Syntax            (Decl(..)
+                                               ,ExportSpec(..)
+                                               ,ImportDecl(..),InstDecl(..))
+import System.FilePath                         ((<.>))
 --
-import           FFICXX.Generate.Code.Dependency
-import           FFICXX.Generate.Code.Primitive
-import           FFICXX.Generate.Type.Class
-import           FFICXX.Generate.Type.Annotate
-import           FFICXX.Generate.Type.Module
-import           FFICXX.Generate.Util
-import           FFICXX.Generate.Util.HaskellSrcExts
+import FFICXX.Generate.Code.Primitive
+import FFICXX.Generate.Dependency              (class_allparents
+                                               ,extractClassDepForTopLevelFunction
+                                               ,getClassModuleBase,getTClassModuleBase
+                                               ,argumentDependency,returnDependency
+                                               )
+import FFICXX.Generate.Type.Class
+import FFICXX.Generate.Type.Annotate
+import FFICXX.Generate.Type.Module
+import FFICXX.Generate.Util
+import FFICXX.Generate.Util.HaskellSrcExts
 
 
 genHsFrontDecl :: Class -> Reader AnnotateMap (Decl ())

--- a/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/HsFrontEnd.hs
@@ -21,12 +21,8 @@ import Control.Monad.Reader
 import Data.Either                             (lefts,rights)
 import Data.List
 import Data.Monoid                             ((<>))
-import Language.Haskell.Exts.Build             (app,binds,doE,letE,letStmt
-                                               ,name,pApp
-                                               ,qualStmt,strE,tuple)
-import Language.Haskell.Exts.Syntax            (Decl(..)
-                                               ,ExportSpec(..)
-                                               ,ImportDecl(..),InstDecl(..))
+import Language.Haskell.Exts.Build             (app,letE,name,pApp)
+import Language.Haskell.Exts.Syntax            (Decl(..),ExportSpec(..),ImportDecl(..))
 import System.FilePath                         ((<.>))
 --
 import FFICXX.Generate.Code.Primitive
@@ -110,30 +106,6 @@ genHsFrontInstVariables c =
        <> mkFun (accessorName c v Setter) (accessorSignature c v Setter) [] (rhs Setter) Nothing
 
 
------
-
-castBody :: [InstDecl ()]
-castBody =
-  [ insDecl (mkBind1 "cast" [mkPVar "x",mkPVar "f"] (app (mkVar "f") (app (mkVar "castPtr") (app (mkVar "get_fptr") (mkVar "x")))) Nothing)
-  , insDecl (mkBind1 "uncast" [mkPVar "x",mkPVar "f"] (app (mkVar "f") (app (mkVar "cast_fptr_to_obj") (app (mkVar "castPtr") (mkVar "x")))) Nothing)
-  ]
-
-genHsFrontInstCastable :: Class -> Maybe (Decl ())
-genHsFrontInstCastable c
-  | (not.isAbstractClass) c =
-    let iname = typeclassName c
-        (_,rname) = hsClassName c
-        a = mkTVar "a"
-        ctxt = cxTuple [ classA (unqual iname) [a], classA (unqual "FPtr") [a] ]
-    in Just (mkInstance ctxt "Castable" [a,tyapp tyPtr (tycon rname)] castBody)
-  | otherwise = Nothing
-
-genHsFrontInstCastableSelf :: Class -> Maybe (Decl ())
-genHsFrontInstCastableSelf c
-  | (not.isAbstractClass) c =
-    let (cname,rname) = hsClassName c
-    in Just (mkInstance cxEmpty "Castable" [tycon cname, tyapp tyPtr (tycon rname)] castBody)
-  | otherwise = Nothing
 
 
 --------------------------
@@ -331,93 +303,3 @@ genImportInTopLevel modname (mods,tmods) tih =
              ++ map (\m -> mkImport (tcmModule m <.> "Template")) tmods
              ++ concatMap genImportForTopLevelFunction tfns
 
---------------
--- Template --
---------------
-
-genTmplInterface :: TemplateClass -> [Decl ()]
-genTmplInterface t =
-  [ mkData rname [mkTBind tp] [] Nothing
-  , mkNewtype hname [mkTBind tp]
-      [ qualConDecl Nothing Nothing (conDecl hname [tyapp tyPtr rawtype]) ] Nothing
-  , mkClass cxEmpty (typeclassNameT t) [mkTBind tp] methods
-  , mkInstance cxEmpty "FPtr" [ hightype ] fptrbody
-  , mkInstance cxEmpty "Castable" [ hightype, tyapp tyPtr rawtype ] castBody
-  ]
- where (hname,rname) = hsTemplateClassName t
-       tp = tclass_param t
-       fs = tclass_funcs t
-       rawtype = tyapp (tycon rname) (mkTVar tp)
-       hightype = tyapp (tycon hname) (mkTVar tp)
-       sigdecl f = mkFunSig (hsTmplFuncName t f) (functionSignatureT t f)
-       methods = map (clsDecl . sigdecl) fs
-       fptrbody = [ insType (tyapp (tycon "Raw") hightype) rawtype
-                  , insDecl (mkBind1 "get_fptr" [pApp (name hname) [mkPVar "ptr"]] (mkVar "ptr") Nothing)
-                  , insDecl (mkBind1 "cast_fptr_to_obj" [] (con hname) Nothing)
-                  ]
-
-
-genTmplImplementation :: TemplateClass -> [Decl ()]
-genTmplImplementation t = concatMap gen (tclass_funcs t)
-  where
-    gen f = mkFun nh sig [p "nty", p "ncty"] rhs (Just bstmts)
-      where nh = hsTmplFuncNameTH t f
-            nc = ffiTmplFuncName f
-            sig = tycon "Name" `tyfun` (tycon "String" `tyfun` tycon "ExpQ")
-            v = mkVar
-            p = mkPVar
-            tp = tclass_param t
-            prefix = tclass_name t
-            lit' = strE (prefix<>"_"<>nc<>"_")
-            lam = lambda [p "n"] ( lit' `app` v "<>" `app` v "n")
-            rhs = app (v "mkTFunc") (tuple [v "nty", v "ncty", lam, v "tyf"])
-            sig' = functionSignatureTT t f
-            bstmts = binds [ mkBind1 "tyf" [mkPVar "n"]
-                               (letE [ pbind (p tp) (v "return" `app` (con "ConT" `app` v "n")) Nothing ]
-                                  (bracketExp (typeBracket sig')))
-                               Nothing
-                           ]
-
-
-genTmplInstance :: TemplateClass -> [TemplateFunction] -> [Decl ()]
-genTmplInstance t fs = mkFun fname sig [p "n", p "ctyp"] rhs Nothing
-  where tname = tclass_name t
-        fname = "gen" <> tname <> "InstanceFor"
-        p = mkPVar
-        v = mkVar
-        sig = tycon "Name" `tyfun` (tycon "String" `tyfun` (tyapp (tycon "Q") (tylist (tycon "Dec"))))
-
-        nfs = zip ([1..] :: [Int]) fs
-        rhs = doE (map genstmt nfs <> [letStmt (lststmt nfs), qualStmt retstmt])
-
-        genstmt (n,f@TFun    {..}) = generator
-                                       (p ("f"<>show n))
-                                       (v "mkMember" `app` strE (hsTmplFuncName t f)
-                                                     `app` v    (hsTmplFuncNameTH t f)
-                                                     `app` v    "n"
-                                                     `app` v    "ctyp"
-                                       )
-        genstmt (n,f@TFunNew {..}) = generator
-                                       (p ("f"<>show n))
-                                       (v "mkNew"    `app` strE (hsTmplFuncName t f)
-                                                     `app` v    (hsTmplFuncNameTH t f)
-                                                     `app` v    "n"
-                                                     `app` v    "ctyp"
-                                       )
-        genstmt (n,f@TFunDelete)   = generator
-                                       (p ("f"<>show n))
-                                       (v "mkDelete" `app` strE (hsTmplFuncName t f)
-                                                     `app` v    (hsTmplFuncNameTH t f)
-                                                     `app` v    "n"
-                                                     `app` v    "ctyp"
-                                       )
-        lststmt xs = [ pbind (p "lst") (list (map (v . (\n->"f"<>show n) . fst) xs)) Nothing ]
-        retstmt = v "return"
-                  `app` list [ v "mkInstance"
-                               `app` list []
-                               `app` (con "AppT"
-                                      `app` (v "con" `app` strE (typeclassNameT t))
-                                      `app` (con "ConT" `app` (v "n"))
-                                     )
-                               `app` (v "lst")
-                             ]

--- a/fficxx/lib/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/HsTemplate.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE RecordWildCards   #-}
+module FFICXX.Generate.Code.HsTemplate where
+
+import Data.Monoid                             ((<>))
+import Language.Haskell.Exts.Build             (app,binds,doE,letE,letStmt
+                                               ,name,pApp
+                                               ,qualStmt,strE,tuple)
+import Language.Haskell.Exts.Syntax            (Decl(..))
+--
+import FFICXX.Generate.Code.Primitive          (ffiTmplFuncName
+                                               ,functionSignatureT,functionSignatureTT
+                                               ,hsTemplateClassName
+                                               ,hsTmplFuncName,hsTmplFuncNameTH
+                                               ,typeclassNameT)
+import FFICXX.Generate.Code.HsCast             (castBody)
+import FFICXX.Generate.Type.Class              (TemplateClass(..),TemplateFunction(..))
+import FFICXX.Generate.Util.HaskellSrcExts     (bracketExp
+                                               ,con,conDecl,cxEmpty
+                                               ,generator
+                                               ,clsDecl,insDecl,insType
+                                               ,lambda,list
+                                               ,mkBind1,mkTBind,mkData,mkNewtype
+                                               ,mkFun,mkFunSig,mkClass,mkInstance
+                                               ,mkPVar,mkTVar,mkVar
+                                               ,pbind,qualConDecl
+                                               ,tyapp,tycon,tyfun,tylist,tyPtr
+                                               ,typeBracket)
+
+
+--------------
+-- Template --
+--------------
+
+genTmplInterface :: TemplateClass -> [Decl ()]
+genTmplInterface t =
+  [ mkData rname [mkTBind tp] [] Nothing
+  , mkNewtype hname [mkTBind tp]
+      [ qualConDecl Nothing Nothing (conDecl hname [tyapp tyPtr rawtype]) ] Nothing
+  , mkClass cxEmpty (typeclassNameT t) [mkTBind tp] methods
+  , mkInstance cxEmpty "FPtr" [ hightype ] fptrbody
+  , mkInstance cxEmpty "Castable" [ hightype, tyapp tyPtr rawtype ] castBody
+  ]
+ where (hname,rname) = hsTemplateClassName t
+       tp = tclass_param t
+       fs = tclass_funcs t
+       rawtype = tyapp (tycon rname) (mkTVar tp)
+       hightype = tyapp (tycon hname) (mkTVar tp)
+       sigdecl f = mkFunSig (hsTmplFuncName t f) (functionSignatureT t f)
+       methods = map (clsDecl . sigdecl) fs
+       fptrbody = [ insType (tyapp (tycon "Raw") hightype) rawtype
+                  , insDecl (mkBind1 "get_fptr" [pApp (name hname) [mkPVar "ptr"]] (mkVar "ptr") Nothing)
+                  , insDecl (mkBind1 "cast_fptr_to_obj" [] (con hname) Nothing)
+                  ]
+
+
+genTmplImplementation :: TemplateClass -> [Decl ()]
+genTmplImplementation t = concatMap gen (tclass_funcs t)
+  where
+    gen f = mkFun nh sig [p "nty", p "ncty"] rhs (Just bstmts)
+      where nh = hsTmplFuncNameTH t f
+            nc = ffiTmplFuncName f
+            sig = tycon "Name" `tyfun` (tycon "String" `tyfun` tycon "ExpQ")
+            v = mkVar
+            p = mkPVar
+            tp = tclass_param t
+            prefix = tclass_name t
+            lit' = strE (prefix<>"_"<>nc<>"_")
+            lam = lambda [p "n"] ( lit' `app` v "<>" `app` v "n")
+            rhs = app (v "mkTFunc") (tuple [v "nty", v "ncty", lam, v "tyf"])
+            sig' = functionSignatureTT t f
+            bstmts = binds [ mkBind1 "tyf" [mkPVar "n"]
+                               (letE [ pbind (p tp) (v "return" `app` (con "ConT" `app` v "n")) Nothing ]
+                                  (bracketExp (typeBracket sig')))
+                               Nothing
+                           ]
+
+
+genTmplInstance :: TemplateClass -> [TemplateFunction] -> [Decl ()]
+genTmplInstance t fs = mkFun fname sig [p "n", p "ctyp"] rhs Nothing
+  where tname = tclass_name t
+        fname = "gen" <> tname <> "InstanceFor"
+        p = mkPVar
+        v = mkVar
+        sig = tycon "Name" `tyfun` (tycon "String" `tyfun` (tyapp (tycon "Q") (tylist (tycon "Dec"))))
+
+        nfs = zip ([1..] :: [Int]) fs
+        rhs = doE (map genstmt nfs <> [letStmt (lststmt nfs), qualStmt retstmt])
+
+        genstmt (n,f@TFun    {..}) = generator
+                                       (p ("f"<>show n))
+                                       (v "mkMember" `app` strE (hsTmplFuncName t f)
+                                                     `app` v    (hsTmplFuncNameTH t f)
+                                                     `app` v    "n"
+                                                     `app` v    "ctyp"
+                                       )
+        genstmt (n,f@TFunNew {..}) = generator
+                                       (p ("f"<>show n))
+                                       (v "mkNew"    `app` strE (hsTmplFuncName t f)
+                                                     `app` v    (hsTmplFuncNameTH t f)
+                                                     `app` v    "n"
+                                                     `app` v    "ctyp"
+                                       )
+        genstmt (n,f@TFunDelete)   = generator
+                                       (p ("f"<>show n))
+                                       (v "mkDelete" `app` strE (hsTmplFuncName t f)
+                                                     `app` v    (hsTmplFuncNameTH t f)
+                                                     `app` v    "n"
+                                                     `app` v    "ctyp"
+                                       )
+        lststmt xs = [ pbind (p "lst") (list (map (v . (\n->"f"<>show n) . fst) xs)) Nothing ]
+        retstmt = v "return"
+                  `app` list [ v "mkInstance"
+                               `app` list []
+                               `app` (con "AppT"
+                                      `app` (v "con" `app` strE (typeclassNameT t))
+                                      `app` (con "ConT" `app` (v "n"))
+                                     )
+                               `app` (v "lst")
+                             ]

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -30,10 +30,13 @@ import           Language.Haskell.Exts.Syntax           (Module(..),Decl(..))
 import           System.FilePath
 --
 import           FFICXX.Generate.Code.Cpp
+import           FFICXX.Generate.Code.HsCast            (genHsFrontInstCastable
+                                                        ,genHsFrontInstCastableSelf)
 import           FFICXX.Generate.Code.HsFFI             (genHsFFI
                                                         ,genImportInFFI
                                                         ,genTopLevelFuncFFI)
 import           FFICXX.Generate.Code.HsFrontEnd
+import           FFICXX.Generate.Code.HsTemplate
 import           FFICXX.Generate.Code.Primitive
 import           FFICXX.Generate.Dependency
 import           FFICXX.Generate.Type.Annotate

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -30,12 +30,12 @@ import           Language.Haskell.Exts.Syntax           (Module(..),Decl(..))
 import           System.FilePath
 --
 import           FFICXX.Generate.Code.Cpp
-import           FFICXX.Generate.Code.Dependency
 import           FFICXX.Generate.Code.HsFFI             (genHsFFI
                                                         ,genImportInFFI
                                                         ,genTopLevelFuncFFI)
 import           FFICXX.Generate.Code.HsFrontEnd
 import           FFICXX.Generate.Code.Primitive
+import           FFICXX.Generate.Dependency
 import           FFICXX.Generate.Type.Annotate
 import           FFICXX.Generate.Type.Class
 import           FFICXX.Generate.Type.Module

--- a/fficxx/lib/FFICXX/Generate/Dependency.hs
+++ b/fficxx/lib/FFICXX/Generate/Dependency.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE RecordWildCards #-}
 -----------------------------------------------------------------------------
 -- |
--- Module      : FFICXX.Generate.Code.Dependency
+-- Module      : FFICXX.Generate.Dependency
 -- Copyright   : (c) 2011-2018 Ian-Woo Kim
 --
 -- License     : BSD3
@@ -11,7 +11,7 @@
 --
 -----------------------------------------------------------------------------
 
-module FFICXX.Generate.Code.Dependency where
+module FFICXX.Generate.Dependency where
 
 --
 -- fficxx generates one module per one C++ class, and C++ class depends on other classes,

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -106,6 +106,17 @@ data Variable = Variable { var_type :: Types
                          }
               deriving Show
 
+data TemplateMemberFunction =
+       TemplateMemberFunction {
+         tmf_param :: String
+       , tmf_ret :: Types
+       , tmf_name :: String
+       , tmf_args :: Args
+       , tmf_alias :: Maybe String
+       }
+       deriving Show
+
+
 data TopLevelFunction = TopLevelFunction { toplevelfunc_ret :: Types
                                          , toplevelfunc_name :: String
                                          , toplevelfunc_args :: Args
@@ -166,22 +177,26 @@ data ClassAlias = ClassAlias { caHaskellName :: String
                              }
 
 -- TODO: partial record must be avoided.
-data Class = Class { class_cabal :: Cabal
-                   , class_name :: String
-                   , class_parents :: [Class]
-                   , class_protected :: ProtectedMethod
-                   , class_alias :: Maybe ClassAlias
-                   , class_funcs :: [Function]
-                   , class_vars :: [Variable]
-                   }
-           | AbstractClass { class_cabal :: Cabal
-                           , class_name :: String
-                           , class_parents :: [Class]
-                           , class_protected :: ProtectedMethod
-                           , class_alias :: Maybe ClassAlias
-                           , class_funcs :: [Function]
-                           , class_vars :: [Variable]
-                           }
+data Class = Class {
+               class_cabal :: Cabal
+             , class_name :: String
+             , class_parents :: [Class]
+             , class_protected :: ProtectedMethod
+             , class_alias :: Maybe ClassAlias
+             , class_funcs :: [Function]
+             , class_vars :: [Variable]
+             , class_tmpl_funcs :: [TemplateMemberFunction]
+             }
+           | AbstractClass {
+               class_cabal :: Cabal
+             , class_name :: String
+             , class_parents :: [Class]
+             , class_protected :: ProtectedMethod
+             , class_alias :: Maybe ClassAlias
+             , class_funcs :: [Function]
+             , class_vars :: [Variable]
+             , class_tmpl_funcs :: [TemplateMemberFunction]
+             }
 
 -- TODO: we had better not override standard definitions
 instance Show Class where

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -35,6 +35,7 @@ deletable =
   AbstractClass cabal "Deletable" [] mempty Nothing
   [ Destructor Nothing ]
   []
+  []
 
 string :: Class
 string =
@@ -46,11 +47,12 @@ string =
     , NonVirtual (cppclassref_ string) "erase" [] Nothing
     ]
     []
-
+    []
 
 ostream :: Class
 ostream = Class cabal "ostream" [] mempty
                 (Just (ClassAlias { caHaskellName = "Ostream", caFFIName = "ostream" }))
+                []
                 []
                 []
 


### PR DESCRIPTION
`FFICXX.Generate.Code.Dependency` -> `FFICXX.Generate.Dependency`
`FFICXX.Generate.Code.HsFrontEnd` -> `FFICXX.Generate.Code.(HsFrontEnd,HsCast,HsTemplate)`