### PR TITLE
Unify mkTFunc, mkMember, mkNew. so that we can associate arbitrary type with C++ template param.

### DIFF
--- a/fficxx-runtime/lib/FFICXX/Runtime/Function/TH.hs
+++ b/fficxx-runtime/lib/FFICXX/Runtime/Function/TH.hs
@@ -9,19 +9,6 @@ import Language.Haskell.TH.Syntax
 import FFICXX.Runtime.TH
 import FFICXX.Runtime.Function.Template
 
-{-
-mkTFunc' :: (Type, String, String -> String, Type -> Q Type) -> Q Exp
-mkTFunc' (typ, suffix, nf, tyf)
-  = do let fn = nf suffix
-       let fn' = "c_" <> fn
-       n <- newName fn'
-       let fn'' = "wrap_" <> fn
-       n_wrap <- newName fn''
-       d <- forImpD CCall safe fn n (tyf typ)
-       d_wrap <- forImpD CCall safe "wrapper" n_wrap (pure typ)
-       addTopDecls [d]
-       [| $( varE n ) |]
--}
 
 mkWrapper :: (Type,String) -> Q Dec
 mkWrapper (typ,suffix)
@@ -32,23 +19,6 @@ mkWrapper (typ,suffix)
        pure $
          FunD (mkNameS "wrapFunPtr") [ Clause [] (NormalB (VarE n)) [] ]
 
-{-
-mkNew' :: String -> (Type -> String -> Q Exp) -> Type -> String -> Q Dec
-mkNew' fname f typ suffix = do
-  e <- f typ suffix
-  pure $
-    FunD (mkNameS fname)
-      [ Clause [] (NormalB e) [] ]
--}
-
-{-
-mkMember' :: String -> (Type -> String -> Q Exp) -> Type -> String -> Q Dec
-mkMember' fname f typ suffix = do
-  let x = mkNameS "x"
-  e <- f typ suffix
-  pure $
-    FunD (mkNameS fname) [ Clause [VarP x] (NormalB (AppE e (VarE x))) [] ]
--}
 
 t_newFunction :: Type -> String -> ExpQ
 t_newFunction typ suffix

--- a/fficxx-runtime/lib/FFICXX/Runtime/TH.hs
+++ b/fficxx-runtime/lib/FFICXX/Runtime/TH.hs
@@ -23,19 +23,10 @@ import Language.Haskell.TH.Syntax
 con :: String -> Type
 con = ConT . mkNameS
 
+
 mkInstance :: Cxt -> Type -> [Dec] -> Dec
 mkInstance = InstanceD Nothing
 
-{-
-mkTFunc :: (Name, String, String -> String, Name -> Q Type) -> ExpQ
-mkTFunc (nty, ncty, nf, tyf)
-  = do let fn = nf ncty
-       let fn' = "c_" <> fn
-       n <- newName fn'
-       d <- forImpD CCall safe fn n (tyf nty)
-       addTopDecls [d]
-       [| $( varE n ) |]
--}
 
 mkTFunc :: (Type, String, String -> String, Type -> Q Type) -> Q Exp
 mkTFunc (typ, suffix, nf, tyf)
@@ -50,15 +41,6 @@ mkTFunc (typ, suffix, nf, tyf)
        [| $( varE n ) |]
 
 
-{-
-mkMember :: String -> (Name -> String -> Q Exp) -> Name -> String -> Q Dec
-mkMember fname f n ctyp = do
-  let x = mkNameS "x"
-  e <- f n ctyp
-  return $
-    FunD (mkNameS fname) [ Clause [VarP x] (NormalB (AppE e (VarE x))) [] ]
--}
-
 mkMember :: String -> (Type -> String -> Q Exp) -> Type -> String -> Q Dec
 mkMember fname f typ suffix = do
   let x = mkNameS "x"
@@ -66,15 +48,6 @@ mkMember fname f typ suffix = do
   pure $
     FunD (mkNameS fname) [ Clause [VarP x] (NormalB (AppE e (VarE x))) [] ]
 
-
-{-
-mkNew :: String -> (Name -> String -> Q Exp) -> Name -> String -> Q Dec
-mkNew fname f n ctyp = do
-  e <- f n ctyp
-  return $
-    FunD (mkNameS fname)
-      [ Clause [] (NormalB e) [] ]
--}
 
 mkNew :: String -> (Type -> String -> Q Exp) -> Type -> String -> Q Dec
 mkNew fname f typ suffix = do

--- a/fficxx-runtime/lib/FFICXX/Runtime/TH.hs
+++ b/fficxx-runtime/lib/FFICXX/Runtime/TH.hs
@@ -26,6 +26,7 @@ con = ConT . mkNameS
 mkInstance :: Cxt -> Type -> [Dec] -> Dec
 mkInstance = InstanceD Nothing
 
+{-
 mkTFunc :: (Name, String, String -> String, Name -> Q Type) -> ExpQ
 mkTFunc (nty, ncty, nf, tyf)
   = do let fn = nf ncty
@@ -34,22 +35,54 @@ mkTFunc (nty, ncty, nf, tyf)
        d <- forImpD CCall safe fn n (tyf nty)
        addTopDecls [d]
        [| $( varE n ) |]
+-}
+
+mkTFunc :: (Type, String, String -> String, Type -> Q Type) -> Q Exp
+mkTFunc (typ, suffix, nf, tyf)
+  = do let fn = nf suffix
+       let fn' = "c_" <> fn
+       n <- newName fn'
+       let fn'' = "wrap_" <> fn
+       n_wrap <- newName fn''
+       d <- forImpD CCall safe fn n (tyf typ)
+       d_wrap <- forImpD CCall safe "wrapper" n_wrap (pure typ)
+       addTopDecls [d]
+       [| $( varE n ) |]
 
 
-
+{-
 mkMember :: String -> (Name -> String -> Q Exp) -> Name -> String -> Q Dec
 mkMember fname f n ctyp = do
   let x = mkNameS "x"
   e <- f n ctyp
   return $
     FunD (mkNameS fname) [ Clause [VarP x] (NormalB (AppE e (VarE x))) [] ]
+-}
 
+mkMember :: String -> (Type -> String -> Q Exp) -> Type -> String -> Q Dec
+mkMember fname f typ suffix = do
+  let x = mkNameS "x"
+  e <- f typ suffix
+  pure $
+    FunD (mkNameS fname) [ Clause [VarP x] (NormalB (AppE e (VarE x))) [] ]
+
+
+{-
 mkNew :: String -> (Name -> String -> Q Exp) -> Name -> String -> Q Dec
 mkNew fname f n ctyp = do
   e <- f n ctyp
   return $
     FunD (mkNameS fname)
       [ Clause [] (NormalB e) [] ]
+-}
 
-mkDelete :: String -> (Name -> String -> Q Exp) -> Name -> String -> Q Dec
+mkNew :: String -> (Type -> String -> Q Exp) -> Type -> String -> Q Dec
+mkNew fname f typ suffix = do
+  e <- f typ suffix
+  pure $
+    FunD (mkNameS fname)
+      [ Clause [] (NormalB e) [] ]
+
+
+mkDelete :: String -> (Type -> String -> Q Exp) -> Type -> String -> Q Dec
 mkDelete = mkMember

--- a/test/testpkg-gen/Gen.hs
+++ b/test/testpkg-gen/Gen.hs
@@ -18,6 +18,7 @@ import FFICXX.Generate.Type.PackageInterface
 
 -- import from stdcxx
 stdcxx_cabal = Cabal { cabal_pkgname = CabalName "stdcxx"
+                     , cabal_version = "0.5"
                      , cabal_cheaderprefix = "STD"
                      , cabal_moduleprefix = "STD"
                      , cabal_additional_c_incs = []
@@ -32,13 +33,14 @@ deletable =
   AbstractClass stdcxx_cabal "Deletable" [] mempty Nothing
   [ Destructor Nothing ]
   []
-
+  []
 
 -- import from stdcxx
 string :: Class
 string =
   Class stdcxx_cabal "string" [ ] mempty
   (Just (ClassAlias { caHaskellName = "CppString", caFFIName = "string"}))
+  []
   []
   []
 
@@ -105,6 +107,7 @@ testCpp  =
 
 
 cabal = Cabal { cabal_pkgname = CabalName "testpkg"
+              , cabal_version = "0.0"
               , cabal_cheaderprefix = "TestPkg"
               , cabal_moduleprefix = "TestPkg"
               , cabal_additional_c_incs = [
@@ -124,9 +127,21 @@ cabal = Cabal { cabal_pkgname = CabalName "testpkg"
 
 extraDep = [ ]
 
-vectorfloat_ = TemplateApp t_vector (TArg_Other "CFloat") "std::vector<float>"
+vectorfloat_ =
+  TemplateApp
+    (TemplateAppInfo {
+       tapp_hstemplate = t_vector
+     , tapp_HsTypeForParam = TArg_Other "CFloat"
+     , tapp_CppTypeForParam = "std::vector<float>"
+     })
 
-vectorfloatref_ = TemplateAppRef t_vector (TArg_Other "CFloat") "std::vector<float>"
+vectorfloatref_ =
+  TemplateAppRef
+    (TemplateAppInfo {
+       tapp_hstemplate = t_vector
+     , tapp_HsTypeForParam = TArg_Other "CFloat"
+     , tapp_CppTypeForParam = "std::vector<float>"
+     })
 
 classA =
   Class cabal "A" [ deletable ] mempty Nothing
@@ -136,6 +151,7 @@ classA =
     [ Variable cint_ "member"
     , Variable (cppclasscopy_ string) "member2"
     ]
+    []
 
 classB =
   Class cabal "B" [ deletable ] mempty Nothing
@@ -143,7 +159,8 @@ classB =
     , Virtual void_ "call" [ (vectorfloatref_, "vec") ] Nothing
     , Virtual vectorfloat_ "call2" [] Nothing
     ]
-    [ ]
+    []
+    []
 
 classes = [ classA, classB ]
 

--- a/test/testpkg-gen/build.sh
+++ b/test/testpkg-gen/build.sh
@@ -6,6 +6,6 @@ ghc Gen.hs && ./Gen && cd testpkg && cabal clean && cd ..
 
 cabal sandbox delete && cabal sandbox init && cabal sandbox add-source testpkg && cabal install testpkg \
 
-g++ -c stub.cc -I${BASEDIR}/stdcxx-0.0/include -I${BASEDIR}/fficxx-runtime-0.3/include -Itestpkg/csrc
+g++ -c stub.cc -I${BASEDIR}/stdcxx-0.5/include -I${BASEDIR}/fficxx-runtime-0.5/include -Itestpkg/csrc
 cabal exec -- ghc -c test.hs
 cabal exec -- ghc test.hs stub.o

--- a/test/testpkg-gen/test.hs
+++ b/test/testpkg-gen/test.hs
@@ -20,8 +20,8 @@ import           TestPkg.A
 import           TestPkg.A.Implementation
 import           TestPkg.B
 
-$(genVectorInstanceFor ''CFloat "float")
-$(genUniquePtrInstanceFor ''A "A")
+$(genVectorInstanceFor [t|CFloat|] "float")
+$(genUniquePtrInstanceFor [t|A|] "A")
 
 main = do
   v :: Vector CFloat <- newVector

--- a/test/unique_ptr/build.sh
+++ b/test/unique_ptr/build.sh
@@ -1,6 +1,6 @@
 GHCDIR=$(dirname $(which ghc))
 BASEDIR=${GHCDIR}/../lib/ghc-8.0.2
 
-g++ -c stub.cc -I${BASEDIR}/stdcxx-0.0/include -I${BASEDIR}/fficxx-runtime-0.3/include
+g++ -c stub.cc -I${BASEDIR}/stdcxx-0.5/include -I${BASEDIR}/fficxx-runtime-0.5/include
 ghc -c test.hs
 ghc test.hs stub.o

--- a/test/unique_ptr/test.hs
+++ b/test/unique_ptr/test.hs
@@ -13,7 +13,7 @@ import           STD.CppString
 import           STD.UniquePtr.Template
 import qualified STD.UniquePtr.TH as TH
 
-$(TH.genUniquePtrInstanceFor ''CppString "string")
+$(TH.genUniquePtrInstanceFor [t|CppString|] "string")
 
 main = do
   putStrLn "test"

--- a/test/vector/test.hs
+++ b/test/vector/test.hs
@@ -12,8 +12,8 @@ import           STD.CppString
 import           STD.Vector.Template
 import qualified STD.Vector.TH as TH
 
-$(TH.genVectorInstanceFor ''CInt "int")
-$(TH.genVectorInstanceFor ''CppString "string")
+$(TH.genVectorInstanceFor [t|CInt|] "int")
+$(TH.genVectorInstanceFor [t|CppString|] "string")
 
 
 test1 = do


### PR DESCRIPTION
In this PR, I unified the approach used in FFICXX.Runtime.Function.TH to all template generation code.
Now TH code is using Q Type. i.e. in the following examples:
```
$(genVectorInstanceFor [t|CFloat|] "float")
$(genUniquePtrInstanceFor [t|A|] "A")
```
we use `[t|CFloat|]` and `[t|A|]` instead of `''CFloat` and `''A`, respectively. Note that this allows for associating more complex Haskell types with C++ template parameters.