### PR TITLE
Experiment template member function

### DIFF
--- a/fficxx-runtime/lib/FFICXX/Runtime/TH.hs
+++ b/fficxx-runtime/lib/FFICXX/Runtime/TH.hs
@@ -33,10 +33,7 @@ mkTFunc (typ, suffix, nf, tyf)
   = do let fn = nf suffix
        let fn' = "c_" <> fn
        n <- newName fn'
-       let fn'' = "wrap_" <> fn
-       n_wrap <- newName fn''
        d <- forImpD CCall safe fn n (tyf typ)
-       d_wrap <- forImpD CCall safe "wrapper" n_wrap (pure typ)
        addTopDecls [d]
        [| $( varE n ) |]
 

--- a/test/template-member/Gen.hs
+++ b/test/template-member/Gen.hs
@@ -1,0 +1,123 @@
+module Main where
+
+import qualified Data.HashMap.Strict as HM (fromList)
+import Data.Monoid (mempty)
+--
+import FFICXX.Generate.Builder
+import FFICXX.Generate.Code.Primitive
+import FFICXX.Generate.Type.Cabal (AddCInc(..),AddCSrc(..),Cabal(..),CabalName(..))
+import FFICXX.Generate.Type.Config (ModuleUnit(..),ModuleUnitMap(..)
+                                   ,ModuleUnitImports(..))
+import FFICXX.Generate.Type.Class
+import FFICXX.Generate.Type.Module
+import FFICXX.Generate.Type.PackageInterface
+
+-- -------------------------------------------------------------------
+-- import from stdcxx
+-- -------------------------------------------------------------------
+
+-- import from stdcxx
+stdcxx_cabal = Cabal { cabal_pkgname = CabalName "stdcxx"
+                     , cabal_version = "0.5"
+                     , cabal_cheaderprefix = "STD"
+                     , cabal_moduleprefix = "STD"
+                     , cabal_additional_c_incs = []
+                     , cabal_additional_c_srcs = []
+                     , cabal_additional_pkgdeps = []
+                     , cabal_pkg_config_depends = []
+                     }
+
+-- import from stdcxx
+deletable :: Class
+deletable =
+  AbstractClass stdcxx_cabal "Deletable" [] mempty Nothing
+  [ Destructor Nothing ]
+  []
+  []
+
+-- import from stdcxx
+string :: Class
+string =
+  Class stdcxx_cabal "string" [ ] mempty
+  (Just (ClassAlias { caHaskellName = "CppString", caFFIName = "string"}))
+  []
+  []
+  []
+
+t_vector = TmplCls stdcxx_cabal "Vector" "std::vector" "t" [ ]
+
+
+
+
+cabal_ testH testCpp =
+  Cabal { cabal_pkgname = CabalName "testpkg"
+        , cabal_version = "0.0"
+        , cabal_cheaderprefix = "TestPkg"
+        , cabal_moduleprefix = "TestPkg"
+        , cabal_additional_c_incs = [
+            AddCInc "test.h" testH
+          ]
+        , cabal_additional_c_srcs = [
+            AddCSrc "test.cpp" testCpp
+          ]
+        , cabal_additional_pkgdeps = [ CabalName "stdcxx" ]
+              , cabal_license = Just "BSD3"
+        , cabal_licensefile = Just "LICENSE"
+        , cabal_extraincludedirs = [ ]
+        , cabal_extralibdirs = []
+        , cabal_extrafiles = []
+        , cabal_pkg_config_depends = []
+        }
+
+extraDep = [ ]
+
+classA cabal =
+  Class cabal "A" [ deletable ] mempty Nothing
+    [ Constructor [ ] Nothing
+    ]
+    [ ]
+    [ ]
+
+classT1 cabal =
+  Class cabal "T1" [ deletable ] mempty Nothing
+    [ Constructor [ ] Nothing ]
+    [ ]
+    [ ]
+
+classes cabal = [ classA cabal, classT1 cabal ]
+
+toplevelfunctions = [ ]
+
+templates = [  ]
+
+headerMap =
+  ModuleUnitMap $
+    HM.fromList $
+      [ ( MU_Class "A"
+        , ModuleUnitImports {
+            muimports_namespaces = []
+          , muimports_headers = [HdrName "test.h"]
+          }
+        )
+      , ( MU_Class "T1"
+        , ModuleUnitImports {
+            muimports_namespaces = []
+          , muimports_headers = [HdrName "test.h"]
+          }
+        )
+      ]
+
+
+main :: IO ()
+main = do
+  cabal <- do
+    testH   <- readFile "test.h"
+    testCpp <- readFile "test.cpp"
+    pure (cabal_ testH testCpp)
+  
+  simpleBuilder
+    "TestPkg"
+    headerMap
+    (cabal,classes cabal,toplevelfunctions,templates)
+    [ ]
+    extraDep

--- a/test/template-member/Gen.hs
+++ b/test/template-member/Gen.hs
@@ -73,9 +73,7 @@ extraDep = [ ]
 
 classA cabal =
   Class cabal "A" [ deletable ] mempty Nothing
-    [ Constructor [ ] Nothing
-    , NonVirtual void_ "method<T1>" [ cppclass (classT1 cabal) "x" ] (Just "a_methodT1")
-    ]
+    [ Constructor [ ] Nothing ]
     [ ]
     [ ]
 
@@ -87,7 +85,15 @@ classT1 cabal =
     [ ]
     [ ]
 
-classes cabal = [ classA cabal, classT1 cabal ]
+classT2 cabal =
+  Class cabal "T2" [ deletable ] mempty Nothing
+    [ Constructor [ ] Nothing
+    , NonVirtual void_ "print" [ ] Nothing
+    ]
+    [ ]
+    [ ]
+
+classes cabal = [ classA cabal, classT1 cabal, classT2 cabal ]
 
 toplevelfunctions = [ ]
 
@@ -108,6 +114,13 @@ headerMap =
           , muimports_headers = [HdrName "test.h"]
           }
         )
+      , ( MU_Class "T2"
+        , ModuleUnitImports {
+            muimports_namespaces = []
+          , muimports_headers = [HdrName "test.h"]
+          }
+        )
+
       ]
 
 

--- a/test/template-member/Gen.hs
+++ b/test/template-member/Gen.hs
@@ -74,13 +74,16 @@ extraDep = [ ]
 classA cabal =
   Class cabal "A" [ deletable ] mempty Nothing
     [ Constructor [ ] Nothing
+    , NonVirtual void_ "method<T1>" [ cppclass (classT1 cabal) "x" ] (Just "a_methodT1")
     ]
     [ ]
     [ ]
 
 classT1 cabal =
   Class cabal "T1" [ deletable ] mempty Nothing
-    [ Constructor [ ] Nothing ]
+    [ Constructor [ ] Nothing
+    , NonVirtual void_ "print" [ ] Nothing
+    ]
     [ ]
     [ ]
 
@@ -114,7 +117,7 @@ main = do
     testH   <- readFile "test.h"
     testCpp <- readFile "test.cpp"
     pure (cabal_ testH testCpp)
-  
+
   simpleBuilder
     "TestPkg"
     headerMap

--- a/test/template-member/TH.hs
+++ b/test/template-member/TH.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE TemplateHaskell #-}
+module TH where
+
+import TestPkg.A
+
+import Data.Monoid
+import FFICXX.Runtime.TH
+import Language.Haskell.TH
+import Language.Haskell.TH.Syntax
+
+instance_a_method :: Q Type -> String -> Q [Dec]
+instance_a_method qtyp suffix
+  = do typ <- qtyp
+       f1 <- mkMember ("a_method_" <> suffix) t_method typ suffix
+       pure [f1]
+
+
+t_method :: Type -> String -> Q Exp
+t_method typ suffix
+  = mkTFunc (typ, suffix, \ n -> "A_method_" <> n, tyf)
+  where tyf n
+          = let t = pure typ in [t| A -> $( t ) -> IO () |]

--- a/test/template-member/app.hs
+++ b/test/template-member/app.hs
@@ -1,12 +1,18 @@
+{-# LANGUAGE TemplateHaskell #-}
 module Main where
 
 import TestPkg.A
+import TestPkg.A.Implementation
 import TestPkg.T1
+
+import TH
+
+$(instance_a_method [t|T1|] "T1")
 
 main :: IO ()
 main = do
   a <- newA
   t1 <- newT1
   t1_print t1
-  a_methodT1 a t1
+  a_method_T1 a t1
   pure ()

--- a/test/template-member/app.hs
+++ b/test/template-member/app.hs
@@ -7,5 +7,6 @@ main :: IO ()
 main = do
   a <- newA
   t1 <- newT1
-
+  t1_print t1
+  a_methodT1 a t1
   pure ()

--- a/test/template-member/app.hs
+++ b/test/template-member/app.hs
@@ -1,0 +1,11 @@
+module Main where
+
+import TestPkg.A
+import TestPkg.T1
+
+main :: IO ()
+main = do
+  a <- newA
+  t1 <- newT1
+
+  pure ()

--- a/test/template-member/app.hs
+++ b/test/template-member/app.hs
@@ -4,15 +4,21 @@ module Main where
 import TestPkg.A
 import TestPkg.A.Implementation
 import TestPkg.T1
+import TestPkg.T2
+
 
 import TH
 
 $(instance_a_method [t|T1|] "T1")
+$(instance_a_method [t|T2|] "T2")
+
 
 main :: IO ()
 main = do
   a <- newA
   t1 <- newT1
   t1_print t1
+  t2 <- newT2
   a_method_T1 a t1
+  a_method_T2 a t2
   pure ()

--- a/test/template-member/build.sh
+++ b/test/template-member/build.sh
@@ -1,13 +1,18 @@
-g++ -c test.cpp
-g++ -c main.cpp
-g++ -o main main.o test.o
+GHCDIR=$(dirname $(which ghc))
+BASEDIR=${GHCDIR}/../lib/ghc-8.0.2
 
-rm Gen.o
-rm -rf working
-ghc Gen.hs && ./Gen && cd testpkg && cabal clean && cd ..
+#g++ -c test.cpp
+#g++ -c main.cpp
+#g++ -o main main.o test.o
+
+#rm Gen.o
+#rm -rf working
+#ghc Gen.hs && ./Gen
+cd testpkg && cabal clean && cd ..
 
 cabal sandbox delete && cabal sandbox init && cabal sandbox add-source testpkg && cabal install testpkg
 
+g++ -c stub.cc -I${BASEDIR}/stdcxx-0.5/include -I${BASEDIR}/fficxx-runtime-0.5/include -Itestpkg/csrc
 cabal exec -- ghc -c app.hs
-cabal exec -- ghc app.hs
+cabal exec -- ghc app.hs stub.o
 

--- a/test/template-member/build.sh
+++ b/test/template-member/build.sh
@@ -1,5 +1,13 @@
-g++ -c test.cpp
+#g++ -c test.cpp
+#g++ -c main.cpp
+#g++ -o main main.o test.o
 
-g++ -c main.cpp
+rm Gen.o
+rm -rf working
+ghc Gen.hs && ./Gen && cd testpkg && cabal clean && cd ..
 
-g++ -o main main.o test.o
+cabal sandbox delete && cabal sandbox init && cabal sandbox add-source testpkg && cabal install testpkg
+
+cabal exec -- ghc -c app.hs
+cabal exec -- ghc app.hs
+

--- a/test/template-member/build.sh
+++ b/test/template-member/build.sh
@@ -1,6 +1,6 @@
-#g++ -c test.cpp
-#g++ -c main.cpp
-#g++ -o main main.o test.o
+g++ -c test.cpp
+g++ -c main.cpp
+g++ -o main main.o test.o
 
 rm Gen.o
 rm -rf working

--- a/test/template-member/build.sh
+++ b/test/template-member/build.sh
@@ -5,9 +5,9 @@ BASEDIR=${GHCDIR}/../lib/ghc-8.0.2
 #g++ -c main.cpp
 #g++ -o main main.o test.o
 
-#rm Gen.o
-#rm -rf working
-#ghc Gen.hs && ./Gen
+rm Gen.o
+rm -rf working
+ghc Gen.hs && ./Gen
 cd testpkg && cabal clean && cd ..
 
 cabal sandbox delete && cabal sandbox init && cabal sandbox add-source testpkg && cabal install testpkg

--- a/test/template-member/build.sh
+++ b/test/template-member/build.sh
@@ -1,0 +1,5 @@
+g++ -c test.cpp
+
+g++ -c main.cpp
+
+g++ -o main main.o test.o

--- a/test/template-member/main.cpp
+++ b/test/template-member/main.cpp
@@ -1,0 +1,12 @@
+#include "test.h"
+
+int main( int argc, char** argv ) {
+
+    A* a;
+    T1* t1;
+    a = new A();
+    t1 = new T1();
+
+    a-> method<T1>( t1 );
+
+}

--- a/test/template-member/stub.cc
+++ b/test/template-member/stub.cc
@@ -1,0 +1,18 @@
+#include <MacroPatternMatch.h>
+#include "TestPkgA.h"
+#include "test.h"
+
+#define A_method(Type)                                                  \
+    extern "C" {                                                        \
+        void A_method_##Type ( A_p p, Type##_p x );                     \
+    }                                                                   \
+    inline void A_method_##Type ( A_p p, Type##_p x )                    \
+    {                                                                   \
+        (to_nonconst<A,A_t>(p))->method<Type>(to_nonconst<Type,Type##_t>(x));  \
+    }                                                                   \
+    auto a_A_method_##Type = A_method_##Type  ;
+
+
+
+
+A_method(T1)

--- a/test/template-member/stub.cc
+++ b/test/template-member/stub.cc
@@ -1,5 +1,7 @@
 #include <MacroPatternMatch.h>
-#include "TestPkgA.h"
+//#include "TestPkgA.h"
+//#include "TestPkgB.h"
+#include "testpkgType.h"
 #include "test.h"
 
 #define A_method(Type)                                                  \
@@ -16,3 +18,5 @@
 
 
 A_method(T1)
+
+A_method(T2)

--- a/test/template-member/test.cpp
+++ b/test/template-member/test.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+#include "test.h"
+
+
+void T1::print() {
+    std::cout << "I am T1." << std::endl;
+}

--- a/test/template-member/test.cpp
+++ b/test/template-member/test.cpp
@@ -5,3 +5,7 @@
 void T1::print() {
     std::cout << "I am T1." << std::endl;
 }
+
+void T2::print() {
+    std::cout << "I am T2." << std::endl;
+}

--- a/test/template-member/test.h
+++ b/test/template-member/test.h
@@ -1,3 +1,5 @@
+#include <iostream>
+
 class A {
 public:
     A() {}
@@ -7,6 +9,7 @@ public:
 };
 
 template<typename T> void A::method( T* x ) {
+    std::cout << "in A::method" << std::endl;
     x->print();
 }
 

--- a/test/template-member/test.h
+++ b/test/template-member/test.h
@@ -1,0 +1,20 @@
+class A {
+public:
+    A() {}
+    ~A() {}
+
+    template<typename T> void method( T* x );
+};
+
+template<typename T> void A::method( T* x ) {
+    x->print();
+}
+
+
+class T1 {
+public:
+    T1() {}
+    ~T1() {}
+
+    void print();
+};

--- a/test/template-member/test.h
+++ b/test/template-member/test.h
@@ -21,3 +21,11 @@ public:
 
     void print();
 };
+
+class T2 {
+public:
+    T2() {}
+    ~T2() {}
+
+    void print();
+};


### PR DESCRIPTION
This is a preliminary step towards supporting a template member function generation. 
Class `A` has a template member function `method<T>`. I experimented invoking this method with two different classes, `T1` and `T2`. For `method`, I implemented a Template Haskell function `instance_a_method` that generates an instantiation of `method`, and used it for instantiating `method<T1>` and `method<T2>`. Corresponding C++ part is implemented as Macro function `A_method`.  

The generated code is tested by `app.hs`. Now generating `TH.hs` and the macro function is the remaining task.