### PR TITLE
Add missing c-types of Foreign.C.Types and enum-type

### DIFF
--- a/fficxx-runtime/lib/FFICXX/Runtime/Cast.hs
+++ b/fficxx-runtime/lib/FFICXX/Runtime/Cast.hs
@@ -69,6 +69,10 @@ instance Castable () () where
   cast x f = f x
   uncast x f = f x
 
+instance Castable CChar CChar where
+  cast x f = f x
+  uncast x f = f x
+
 instance Castable CDouble CDouble where
   cast x f = f x
   uncast x f = f x

--- a/fficxx-runtime/lib/FFICXX/Runtime/Cast.hs
+++ b/fficxx-runtime/lib/FFICXX/Runtime/Cast.hs
@@ -27,6 +27,7 @@ import Control.Monad         ((>=>))
 import Data.ByteString.Char8 (ByteString,packCString, useAsCString)
 import Data.String
 import Data.Word
+import Data.Int
 import Foreign.C
 import Foreign.C.String
 import Foreign.ForeignPtr
@@ -58,15 +59,51 @@ class FunPtrWrappable a where
 
 class IsCType a where 
 
+instance IsCType CBool
 instance IsCType CChar
-instance IsCType CShort
+instance IsCType CClock
+instance IsCType CDouble
+instance IsCType CFile
+instance IsCType CFloat
+instance IsCType CFpos
 instance IsCType CInt
-instance IsCType CUInt 
-instance IsCType CString 
-instance IsCType CULong 
+instance IsCType CIntMax
+instance IsCType CIntPtr
+instance IsCType CJmpBuf
+instance IsCType CLLong
 instance IsCType CLong
+instance IsCType CPtrdiff
+instance IsCType CSChar
+instance IsCType CSUSeconds
+instance IsCType CShort
+instance IsCType CSigAtomic
+instance IsCType CSize
+instance IsCType CTime
+instance IsCType CUChar
+instance IsCType CUInt
+instance IsCType CUIntMax
+instance IsCType CUIntPtr
+instance IsCType CULLong
+instance IsCType CULong
+instance IsCType CUSeconds
+instance IsCType CUShort
+instance IsCType CWchar
+instance IsCType CString
+instance IsCType Int8
+instance IsCType Int16
+instance IsCType Int32
+instance IsCType Int64
+instance IsCType Word8
+instance IsCType Word16
+instance IsCType Word32
+instance IsCType Word64
+
 
 instance Castable () () where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CBool CBool where
   cast x f = f x
   uncast x f = f x
 
@@ -74,7 +111,7 @@ instance Castable CChar CChar where
   cast x f = f x
   uncast x f = f x
 
-instance Castable CShort CShort where
+instance Castable CClock CClock where
   cast x f = f x
   uncast x f = f x
 
@@ -82,23 +119,138 @@ instance Castable CDouble CDouble where
   cast x f = f x
   uncast x f = f x
 
-instance Castable CUInt CUInt where
-  cast x f = f x 
-  uncast x f = f x  
-
-instance Castable CInt CInt where 
-  cast x f = f x 
-  uncast x f = f x 
-
-instance Castable CLong CLong where
-  cast x f = f x 
+instance Castable CFile CFile where
+  cast x f = f x
   uncast x f = f x
 
-instance Castable CULong CULong where 
-  cast x f = f x 
-  uncast x f = f x 
+instance Castable CFloat CFloat where
+  cast x f = f x
+  uncast x f = f x
 
- 
+instance Castable CFpos CFpos where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CInt CInt where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CIntMax CIntMax where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CIntPtr CIntPtr where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CJmpBuf CJmpBuf where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CLLong CLLong where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CLong CLong where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CPtrdiff CPtrdiff where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CSChar CSChar where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CSUSeconds CSUSeconds where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CShort CShort where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CSigAtomic CSigAtomic where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CSize CSize where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CTime CTime where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CUChar CUChar where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CUInt CUInt where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CUIntMax CUIntMax where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CUIntPtr CUIntPtr where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CULLong CULLong where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CULong CULong where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CUSeconds CUSeconds where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CUShort CUShort where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CWchar CWchar where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable Int8 Int8 where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable Int16 Int16 where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable Int32 Int32 where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable Int64 Int64 where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable Word8 Word8 where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable Word16 Word16 where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable Word32 Word32 where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable Word64 Word64 where
+  cast x f = f x
+  uncast x f = f x
+
 instance Castable (Ptr CInt) (Ptr CInt) where 
   cast x f = f x
   uncast x f = f x 
@@ -133,6 +285,14 @@ instance Castable (Ptr ()) (Ptr ()) where
 
 
 instance Castable Int CInt where
+  cast x f = f (fromIntegral x)
+  uncast x f = f (fromIntegral x)
+
+instance Castable Int16 CShort where
+  cast x f = f (fromIntegral x)
+  uncast x f = f (fromIntegral x)
+
+instance Castable Int8 CChar where
   cast x f = f (fromIntegral x)
   uncast x f = f (fromIntegral x)
 

--- a/fficxx-runtime/lib/FFICXX/Runtime/Cast.hs
+++ b/fficxx-runtime/lib/FFICXX/Runtime/Cast.hs
@@ -59,6 +59,7 @@ class FunPtrWrappable a where
 class IsCType a where 
 
 instance IsCType CChar
+instance IsCType CShort
 instance IsCType CInt
 instance IsCType CUInt 
 instance IsCType CString 
@@ -70,6 +71,10 @@ instance Castable () () where
   uncast x f = f x
 
 instance Castable CChar CChar where
+  cast x f = f x
+  uncast x f = f x
+
+instance Castable CShort CShort where
   cast x f = f x
   uncast x f = f x
 

--- a/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
@@ -119,7 +119,7 @@ doublep_ :: Types
 doublep_ = CT (CPointer CTDouble) NoConst
 
 cfloat_ :: Types
-cfloat_ = CT CTFloat NoConst
+cfloat_ = CT CTFloat Const
 
 float_ :: Types
 float_ = CT CTFloat NoConst

--- a/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
@@ -24,20 +24,45 @@ cvarToStr ctyp isconst varname = ctypToStr ctyp isconst <> " " <> varname
 ctypToStr :: CTypes -> IsConst -> String
 ctypToStr ctyp isconst =
   let typword = case ctyp of
-        CTString -> "char*"
-        CTChar   -> "char"
-        CTShort  -> "short"
-        CTInt    -> "int"
-        CTUInt   -> "unsigned int"
-        CTLong   -> "signed long"
-        CTULong  -> "long unsigned int"
-        CTFloat  -> "float"
+        CTBool -> "bool"
+        CTChar -> "char"
+        CTClock -> "clock_t"
         CTDouble -> "double"
-        CTBool   -> "int"              -- Currently available solution
-        CTDoubleStar -> "double *"
+        CTFile -> "FILE"
+        CTFloat -> "float"
+        CTFpos -> "fpos_t"
+        CTInt -> "int"
+        CTIntMax -> "intmax_t"
+        CTIntPtr -> "intptr_t"
+        CTJmpBuf -> "jmp_buf"
+        CTLLong -> "long long"
+        CTLong -> "long"
+        CTPtrdiff -> "ptrdiff_t"
+        CTSChar -> "sized char"
+        CTSUSeconds -> "suseconds_t"
+        CTShort -> "short"
+        CTSigAtomic -> "sig_atomic_t"
+        CTSize -> "size_t"
+        CTTime -> "time_t"
+        CTUChar -> "unsized char"
+        CTUInt -> "unsized int"
+        CTUIntMax -> "uintmax_t"
+        CTUIntPtr -> "uintptr_t"
+        CTULLong -> "unsigned long long"
+        CTULong -> "unsigned long"
+        CTUSeconds -> "useconds_t"
+        CTUShort -> "unsigned short"
+        CTWchar -> "wchar_t"
+        CTInt8 -> "int8_t"
+        CTInt16 -> "int16_t"
+        CTInt32 -> "int32_t"
+        CTInt64 -> "int64_t"
+        CTUInt8 -> "uint8_t"
+        CTUInt16 -> "uint16_t"
+        CTUInt32 -> "uint32_t"
+        CTUInt64 -> "uint64_t"
+        CTString -> "char*"
         CTVoidStar -> "void*"
-        CTIntStar -> "int*"
-        CTCharStarStar -> "char**"
         CPointer s -> ctypToStr s NoConst <> "*"
         CRef s -> ctypToStr s NoConst <> "*"
   in case isconst of
@@ -78,7 +103,7 @@ char_ :: Types
 char_ = CT CTChar NoConst
 
 cshort_ :: Types
-cshort_ = CT CTShort NoConst
+cshort_ = CT CTShort Const
 
 short_ :: Types
 short_ = CT CTShort NoConst
@@ -90,7 +115,7 @@ double_ :: Types
 double_  = CT CTDouble NoConst
 
 doublep_ :: Types
-doublep_ = CT CTDoubleStar NoConst
+doublep_ = CT (CPointer CTDouble) NoConst
 
 cfloat_ :: Types
 cfloat_ = CT CTFloat NoConst
@@ -108,14 +133,14 @@ voidp_ :: Types
 voidp_ = CT CTVoidStar NoConst
 
 intp_ :: Types
-intp_ = CT CTIntStar NoConst
+intp_ = CT (CPointer CTInt) NoConst
 
 intref_ :: Types
 intref_ = CT (CRef CTInt) NoConst
 
 
 charpp_ :: Types
-charpp_ = CT CTCharStarStar NoConst
+charpp_ = CT (CPointer CTString) NoConst
 
 ref_ :: CTypes -> Types
 ref_ t = CT (CRef t) NoConst
@@ -499,20 +524,45 @@ tmplMemFuncRetTypeToString _ (TemplateParamPointer _) = "Type##_p"
 
 -- |
 convertC2HS :: CTypes -> Type ()
-convertC2HS CTString     = tycon "CString"
-convertC2HS CTChar       = tycon "CChar"
-convertC2HS CTShort      = tycon "CShort"
-convertC2HS CTInt        = tycon "CInt"
-convertC2HS CTUInt       = tycon "CUInt"
-convertC2HS CTLong       = tycon "CLong"
-convertC2HS CTULong      = tycon "CULong"
-convertC2HS CTFloat      = tycon "CFloat"
-convertC2HS CTDouble     = tycon "CDouble"
-convertC2HS CTDoubleStar = tyapp (tycon "Ptr") (tycon "CDouble")
-convertC2HS CTBool       = tycon "CInt"
+convertC2HS CTBool      = tycon "CBool"
+convertC2HS CTChar      = tycon "CChar"
+convertC2HS CTClock     = tycon "CClock"
+convertC2HS CTDouble    = tycon "CDouble"
+convertC2HS CTFile      = tycon "CFile"
+convertC2HS CTFloat     = tycon "CFloat"
+convertC2HS CTFpos      = tycon "CFpos"
+convertC2HS CTInt       = tycon "CInt"
+convertC2HS CTIntMax    = tycon "CIntMax"
+convertC2HS CTIntPtr    = tycon "CIntPtr"
+convertC2HS CTJmpBuf    = tycon "CJmpBuf"
+convertC2HS CTLLong     = tycon "CLLong"
+convertC2HS CTLong      = tycon "CLong"
+convertC2HS CTPtrdiff   = tycon "CPtrdiff"
+convertC2HS CTSChar     = tycon "CSChar"
+convertC2HS CTSUSeconds = tycon "CSUSeconds"
+convertC2HS CTShort     = tycon "CShort"
+convertC2HS CTSigAtomic = tycon "CSigAtomic"
+convertC2HS CTSize      = tycon "CSize"
+convertC2HS CTTime      = tycon "CTime"
+convertC2HS CTUChar     = tycon "CUChar"
+convertC2HS CTUInt      = tycon "CUInt"
+convertC2HS CTUIntMax   = tycon "CUIntMax"
+convertC2HS CTUIntPtr   = tycon "CUIntPtr"
+convertC2HS CTULLong    = tycon "CULLong"
+convertC2HS CTULong     = tycon "CULong"
+convertC2HS CTUSeconds  = tycon "CUSeconds"
+convertC2HS CTUShort    = tycon "CUShort"
+convertC2HS CTWchar     = tycon "CWchar"
+convertC2HS CTInt8      = tycon "Int8"
+convertC2HS CTInt16      = tycon "Int16"
+convertC2HS CTInt32      = tycon "Int32"
+convertC2HS CTInt64      = tycon "Int64"
+convertC2HS CTUInt8      = tycon "Word8"
+convertC2HS CTUInt16      = tycon "Word16"
+convertC2HS CTUInt32      = tycon "Word32"
+convertC2HS CTUInt64      = tycon "Word64"
+convertC2HS CTString    = tycon "CString"
 convertC2HS CTVoidStar   = tyapp (tycon "Ptr") unit_tycon
-convertC2HS CTIntStar    = tyapp (tycon "Ptr") (tycon "CInt")
-convertC2HS CTCharStarStar = tyapp (tycon "Ptr") (tycon "CString")
 convertC2HS (CPointer t) = tyapp (tycon "Ptr") (convertC2HS t)
 convertC2HS (CRef t)     = tyapp (tycon "Ptr") (convertC2HS t)
 

--- a/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
@@ -26,10 +26,12 @@ ctypToStr ctyp isconst =
   let typword = case ctyp of
         CTString -> "char*"
         CTChar   -> "char"
+        CTShort  -> "short"
         CTInt    -> "int"
         CTUInt   -> "unsigned int"
         CTLong   -> "signed long"
         CTULong  -> "long unsigned int"
+        CTFloat  -> "float"
         CTDouble -> "double"
         CTBool   -> "int"              -- Currently available solution
         CTDoubleStar -> "double *"
@@ -75,8 +77,11 @@ cchar_ = CT CTChar Const
 char_ :: Types
 char_ = CT CTChar NoConst
 
+cshort_ :: Types
+cshort_ = CT CTShort NoConst
+
 short_ :: Types
-short_ = int_
+short_ = CT CTShort NoConst
 
 cdouble_ :: Types
 cdouble_ = CT CTDouble Const
@@ -87,8 +92,11 @@ double_  = CT CTDouble NoConst
 doublep_ :: Types
 doublep_ = CT CTDoubleStar NoConst
 
+cfloat_ :: Types
+cfloat_ = CT CTFloat NoConst
+
 float_ :: Types
-float_ = double_
+float_ = CT CTFloat NoConst
 
 bool_ :: Types
 bool_    = CT CTBool   NoConst
@@ -154,8 +162,11 @@ cchar var = (cchar_ , var)
 char :: String -> (Types,String)
 char var = (char_ , var)
 
+cshort :: String -> (Types,String)
+cshort var = (cshort_ , var)
+
 short :: String -> (Types,String)
-short = int
+short var = (short_ , var)
 
 cdouble :: String -> (Types,String)
 cdouble var = (cdouble_ , var)
@@ -166,8 +177,11 @@ double  var = (double_  , var)
 doublep :: String -> (Types,String)
 doublep var = (doublep_ , var)
 
+cfloat :: String -> (Types,String)
+cfloat var = (float_ , var)
+
 float :: String -> (Types,String)
-float = double
+float var = (float_ , var)
 
 bool :: String -> (Types,String)
 bool    var = (bool_    , var)
@@ -487,10 +501,12 @@ tmplMemFuncRetTypeToString _ (TemplateParamPointer _) = "Type##_p"
 convertC2HS :: CTypes -> Type ()
 convertC2HS CTString     = tycon "CString"
 convertC2HS CTChar       = tycon "CChar"
+convertC2HS CTShort      = tycon "CShort"
 convertC2HS CTInt        = tycon "CInt"
 convertC2HS CTUInt       = tycon "CUInt"
 convertC2HS CTLong       = tycon "CLong"
 convertC2HS CTULong      = tycon "CULong"
+convertC2HS CTFloat      = tycon "CFloat"
 convertC2HS CTDouble     = tycon "CDouble"
 convertC2HS CTDoubleStar = tyapp (tycon "Ptr") (tycon "CDouble")
 convertC2HS CTBool       = tycon "CInt"

--- a/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/lib/FFICXX/Generate/Code/Primitive.hs
@@ -63,6 +63,7 @@ ctypToStr ctyp isconst =
         CTUInt64 -> "uint64_t"
         CTString -> "char*"
         CTVoidStar -> "void*"
+        CEnum _ type_str -> type_str
         CPointer s -> ctypToStr s NoConst <> "*"
         CRef s -> ctypToStr s NoConst <> "*"
   in case isconst of
@@ -563,6 +564,7 @@ convertC2HS CTUInt32      = tycon "Word32"
 convertC2HS CTUInt64      = tycon "Word64"
 convertC2HS CTString    = tycon "CString"
 convertC2HS CTVoidStar   = tyapp (tycon "Ptr") unit_tycon
+convertC2HS (CEnum t _)  = convertC2HS t
 convertC2HS (CPointer t) = tyapp (tycon "Ptr") (convertC2HS t)
 convertC2HS (CRef t)     = tyapp (tycon "Ptr") (convertC2HS t)
 

--- a/fficxx/lib/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/lib/FFICXX/Generate/ContentMaker.hs
@@ -314,7 +314,11 @@ buildFFIHsc :: ClassModule -> Module ()
 buildFFIHsc m = mkModule (mname <.> "FFI") [lang ["ForeignFunctionInterface"]] ffiImports hscBody
   where mname = cmModule m
         headers = cmCIH m
-        ffiImports = [ mkImport "Foreign.C", mkImport "Foreign.Ptr", mkImport (mname <.> "RawType") ]
+        ffiImports = [ mkImport "Data.Word"
+                     , mkImport "Data.Int"
+                     , mkImport "Foreign.C"
+                     , mkImport "Foreign.Ptr"
+                     , mkImport (mname <.> "RawType") ]
                      <> genImportInFFI m
                      <> genExtraImport m
         hscBody = concatMap genHsFFI headers
@@ -344,6 +348,7 @@ buildInterfaceHs amap m = mkModule (cmModule m <.> "Interface")
                             ifaceImports ifaceBody
   where classes = cmClass m
         ifaceImports = [ mkImport "Data.Word"
+                       , mkImport "Data.Int"
                        , mkImport "Foreign.C"
                        , mkImport "Foreign.Ptr"
                        , mkImport "FFICXX.Runtime.Cast" ]
@@ -386,6 +391,7 @@ buildImplementationHs amap m = mkModule (cmModule m <.> "Implementation")
   where classes = cmClass m
         implImports = [ mkImport "Data.Monoid"                -- for template member
                       , mkImport "Data.Word"
+                      , mkImport "Data.Int"
                       , mkImport "Foreign.C"
                       , mkImport "Foreign.Ptr"
                       , mkImport "Language.Haskell.TH"        -- for template member

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -63,6 +63,7 @@ data CTypes = CTBool
             | CTUInt64
             | CTVoidStar
             | CTString
+            | CEnum CTypes String
             | CPointer CTypes
             | CRef CTypes
             deriving Show

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -25,10 +25,12 @@ import           FFICXX.Generate.Type.Cabal
 -- | C types
 data CTypes = CTString
             | CTChar
+            | CTShort
             | CTInt
             | CTUInt
             | CTLong
             | CTULong
+            | CTFloat
             | CTDouble
             | CTBool
             | CTDoubleStar

--- a/fficxx/lib/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/lib/FFICXX/Generate/Type/Class.hs
@@ -22,21 +22,47 @@ import           Data.Semigroup                    (Semigroup(..),(<>))
 --
 import           FFICXX.Generate.Type.Cabal
 
+
 -- | C types
-data CTypes = CTString
+data CTypes = CTBool
             | CTChar
-            | CTShort
-            | CTInt
-            | CTUInt
-            | CTLong
-            | CTULong
-            | CTFloat
+            | CTClock
             | CTDouble
-            | CTBool
-            | CTDoubleStar
+            | CTFile
+            | CTFloat
+            | CTFpos
+            | CTInt
+            | CTIntMax
+            | CTIntPtr
+            | CTJmpBuf
+            | CTLLong
+            | CTLong
+            | CTPtrdiff
+            | CTSChar
+            | CTSUSeconds
+            | CTShort
+            | CTSigAtomic
+            | CTSize
+            | CTTime
+            | CTUChar
+            | CTUInt
+            | CTUIntMax
+            | CTUIntPtr
+            | CTULLong
+            | CTULong
+            | CTUSeconds
+            | CTUShort
+            | CTWchar
+            | CTInt8
+            | CTInt16
+            | CTInt32
+            | CTInt64
+            | CTUInt8
+            | CTUInt16
+            | CTUInt32
+            | CTUInt64
             | CTVoidStar
-            | CTIntStar
-            | CTCharStarStar
+            | CTString
             | CPointer CTypes
             | CRef CTypes
             deriving Show


### PR DESCRIPTION
Hi,
This PR adds missing c-types of Foreign.C.Types(e.g. CFloat, CClock and so on) and enum-type.
