### PR TITLE
Support Static Files in simpleBuild

### DIFF
--- a/fficxx/lib/FFICXX/Generate/Builder.hs
+++ b/fficxx/lib/FFICXX/Generate/Builder.hs
@@ -46,12 +46,8 @@ import           FFICXX.Generate.Type.PackageInterface
 import           FFICXX.Generate.Util
 --
 
-
 macrofy :: String -> String
 macrofy = map ((\x->if x=='-' then '_' else x) . toUpper)
-
-
-
 
 simpleBuilder :: FFICXXConfig -> SimpleBuilderConfig -> IO ()
 simpleBuilder cfg sbc = do

--- a/fficxx/lib/FFICXX/Generate/Builder.hs
+++ b/fficxx/lib/FFICXX/Generate/Builder.hs
@@ -49,6 +49,7 @@ import           FFICXX.Generate.Util
 macrofy :: String -> String
 macrofy = map ((\x->if x=='-' then '_' else x) . toUpper)
 
+
 simpleBuilder :: FFICXXConfig -> SimpleBuilderConfig -> IO ()
 simpleBuilder cfg sbc = do
   putStrLn "----------------------------------------------------"
@@ -63,11 +64,13 @@ simpleBuilder cfg sbc = do
         templates
         extralibs
         extramods
+        staticFiles
         = sbc
       pkgname = cabal_pkgname cabal
   putStrLn ("Generating " <> unCabalName pkgname)
   let workingDir = fficxxconfig_workingDir cfg
       installDir = fficxxconfig_installBaseDir cfg
+      staticDir  = fficxxconfig_staticFileDir cfg
 
       pkgconfig@(PkgConfig mods cihs tih tcms _tcihs _ _) =
         mkPackageConfig
@@ -83,6 +86,9 @@ simpleBuilder cfg sbc = do
   createDirectoryIfMissing True installDir
   createDirectoryIfMissing True (installDir </> "src")
   createDirectoryIfMissing True (installDir </> "csrc")
+  --
+  putStrLn "Copying static files"
+  mapM_ (\x->copyFileWithMD5Check (staticDir </> x) (installDir </> x)) staticFiles
   --
   putStrLn "Generating Cabal file"
   buildCabalFile cabal topLevelMod pkgconfig extralibs (workingDir</>cabalFileName)

--- a/fficxx/lib/FFICXX/Generate/Config.hs
+++ b/fficxx/lib/FFICXX/Generate/Config.hs
@@ -20,18 +20,20 @@ import FFICXX.Generate.Type.PackageInterface ( HeaderName )
 
 
 data FFICXXConfig = FFICXXConfig {
-    fficxxconfig_workingDir :: FilePath
+    fficxxconfig_workingDir     :: FilePath
   , fficxxconfig_installBaseDir :: FilePath
+  , fficxxconfig_staticFileDir  :: FilePath
   } deriving Show
 
 data SimpleBuilderConfig =
   SimpleBuilderConfig {
-    sbcTopModule  :: String
-  , sbcModUnitMap :: ModuleUnitMap
-  , sbcCabal      :: Cabal
-  , sbcClasses    :: [Class]
-  , sbcTopLevels  :: [TopLevelFunction]
-  , sbcTemplates  :: [(TemplateClass,HeaderName)]
-  , sbcExtraLibs  :: [String]
-  , sbcExtraDeps  :: [(String,[String])]
+    sbcTopModule     :: String
+  , sbcModUnitMap    :: ModuleUnitMap
+  , sbcCabal         :: Cabal
+  , sbcClasses       :: [Class]
+  , sbcTopLevels     :: [TopLevelFunction]
+  , sbcTemplates     :: [(TemplateClass,HeaderName)]
+  , sbcExtraLibs     :: [String]
+  , sbcExtraDeps     :: [(String,[String])]
+  , sbcStaticFiles   :: [String]
   }

--- a/fficxx/lib/FFICXX/Generate/Config.hs
+++ b/fficxx/lib/FFICXX/Generate/Config.hs
@@ -19,11 +19,10 @@ import FFICXX.Generate.Type.Config           ( ModuleUnitMap(..) )
 import FFICXX.Generate.Type.PackageInterface ( HeaderName )
 
 
-data FFICXXConfig = FFICXXConfig { 
-  fficxxconfig_scriptBaseDir :: FilePath, 
-  fficxxconfig_workingDir :: FilePath, 
-  fficxxconfig_installBaseDir :: FilePath
-} deriving Show
+data FFICXXConfig = FFICXXConfig {
+    fficxxconfig_workingDir :: FilePath
+  , fficxxconfig_installBaseDir :: FilePath
+  } deriving Show
 
 data SimpleBuilderConfig =
   SimpleBuilderConfig {
@@ -36,4 +35,3 @@ data SimpleBuilderConfig =
   , sbcExtraLibs  :: [String]
   , sbcExtraDeps  :: [(String,[String])]
   }
-

--- a/sample/mysample-generator/MySampleGen.hs
+++ b/sample/mysample-generator/MySampleGen.hs
@@ -53,8 +53,7 @@ main :: IO ()
 main =
   cwd <- getCurrentDirectory
   let cfg = FFICXXConfig {
-              fficxxconfig_scriptBaseDir = cwd
-            , fficxxconfig_workingDir = cwd </> "working"
+              fficxxconfig_workingDir = cwd </> "working"
             , fficxxconfig_installBaseDir = cwd </> "MySample"
             }
       sbc = SimpleBuilderConfig {

--- a/sample/mysample-generator/MySampleGen.hs
+++ b/sample/mysample-generator/MySampleGen.hs
@@ -55,6 +55,7 @@ main =
   let cfg = FFICXXConfig {
               fficxxconfig_workingDir = cwd </> "working"
             , fficxxconfig_installBaseDir = cwd </> "MySample"
+            , fficxxconfig_staticDir = ""
             }
       sbc = SimpleBuilderConfig {
               sbcTopModule  = "MySample"
@@ -65,5 +66,6 @@ main =
             , sbcTemplates  = []
             , sbcExtraLibs  = []
             , sbcExtraDeps  = []
+            , sbcStaticFiles = []
             }
   simpleBuilder cfg sbc

--- a/sample/snappy-generator/SnappyGen.hs
+++ b/sample/snappy-generator/SnappyGen.hs
@@ -89,8 +89,7 @@ main :: IO ()
 main = do
   cwd <- getCurrentDirectory
   let cfg = FFICXXConfig {
-              fficxxconfig_scriptBaseDir = cwd
-            , fficxxconfig_workingDir = cwd </> "working"
+              fficxxconfig_workingDir = cwd </> "working"
             , fficxxconfig_installBaseDir = cwd </> "Snappy"
             }
       sbc = SimpleBuilderConfig {

--- a/sample/snappy-generator/SnappyGen.hs
+++ b/sample/snappy-generator/SnappyGen.hs
@@ -91,6 +91,7 @@ main = do
   let cfg = FFICXXConfig {
               fficxxconfig_workingDir = cwd </> "working"
             , fficxxconfig_installBaseDir = cwd </> "Snappy"
+            , fficxxconfig_staticDir = ""
             }
       sbc = SimpleBuilderConfig {
               sbcTopModule  = "Snappy"
@@ -101,5 +102,6 @@ main = do
             , sbcTemplates  = []
             , sbcExtraLibs  = ["snappy"]
             , sbcExtraDeps  = []
+            , sbcStaticFiles = []
             }
   simpleBuilder cfg sbc

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -114,6 +114,7 @@ main = do
   let cfg = FFICXXConfig {
               fficxxconfig_workingDir = cwd </> "working"
             , fficxxconfig_installBaseDir = cwd </> "stdcxx"
+            , fficxxconfig_staticDir = ""
             }
       sbc = SimpleBuilderConfig
               sbcTopModule  = "STD"
@@ -124,5 +125,6 @@ main = do
             , sbcTemplates  = templates
             , sbcExtraLibs  = []
             , sbcExtraDeps  = extraDep
+            , sbcStaticFiles = []
             }
   simpleBuilder cfg sbc

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -112,8 +112,7 @@ main :: IO ()
 main = do
   cwd <- getCurrentDirectory
   let cfg = FFICXXConfig {
-              fficxxconfig_scriptBaseDir = cwd
-            , fficxxconfig_workingDir = cwd </> "working"
+              fficxxconfig_workingDir = cwd </> "working"
             , fficxxconfig_installBaseDir = cwd </> "stdcxx"
             }
       sbc = SimpleBuilderConfig


### PR DESCRIPTION
Files like LICENSE, CHANGES, Setup.hs need to be separately configured as static files. 
This was needed for HROOT which uses `root-config` for extra include/libraries config. 