### PR TITLE
Further towards intermediate reps for C++ code generation

### DIFF
--- a/fficxx-runtime/src/FFICXX/Runtime/CodeGen/C.hs
+++ b/fficxx-runtime/src/FFICXX/Runtime/CodeGen/C.hs
@@ -28,7 +28,10 @@ data CStatement =
     Include HeaderName       -- ^ #include "<header>"
   | UsingNamespace Namespace -- ^ using namespace <namespace>;
   | Pragma PragmaParam       -- ^ #pragma
+  | EmptyLine                -- ^ just for convenience
   | Verbatim String          -- ^ temporary verbatim
+
+data CBlock = ExternC [CStatement]
 
 renderPragmaParam :: PragmaParam -> String
 renderPragmaParam Once = "once"
@@ -37,4 +40,15 @@ render :: CStatement -> String
 render (Include (HdrName hdr))  = "#include \"" <> hdr <> "\"\n"
 render (UsingNamespace (NS ns)) = "using namespace " <> ns <> ";"
 render (Pragma param)           = "#pragma " <> renderPragmaParam param <> "\n"
-render (Verbatim str) = str
+render EmptyLine                = "\n"
+render (Verbatim str)           = str
+
+renderBlock :: CBlock -> String
+renderBlock (ExternC cstmts) =
+     "#ifdef __cplusplus\n\
+     \extern \"C\" {\n\
+     \#endif\n"
+  ++ concatMap render cstmts
+  ++ "#ifdef __cplusplus\n\
+     \}\n\
+     \#endif\n"

--- a/fficxx-runtime/src/FFICXX/Runtime/CodeGen/C.hs
+++ b/fficxx-runtime/src/FFICXX/Runtime/CodeGen/C.hs
@@ -22,12 +22,19 @@ newtype Namespace =
 instance IsString Namespace where
   fromString = NS
 
+data PragmaParam = Once
+
 data CStatement =
     Include HeaderName       -- ^ #include "<header>"
   | UsingNamespace Namespace -- ^ using namespace <namespace>;
+  | Pragma PragmaParam       -- ^ #pragma
   | Verbatim String          -- ^ temporary verbatim
 
+renderPragmaParam :: PragmaParam -> String
+renderPragmaParam Once = "once"
+
 render :: CStatement -> String
-render (Include (HdrName hdr)) = "#include \"" <> hdr <> "\"\n"
+render (Include (HdrName hdr))  = "#include \"" <> hdr <> "\"\n"
 render (UsingNamespace (NS ns)) = "using namespace " <> ns <> ";"
+render (Pragma param)           = "#pragma " <> renderPragmaParam param <> "\n"
 render (Verbatim str) = str

--- a/fficxx-runtime/src/FFICXX/Runtime/CodeGen/C.hs
+++ b/fficxx-runtime/src/FFICXX/Runtime/CodeGen/C.hs
@@ -37,18 +37,18 @@ renderPragmaParam :: PragmaParam -> String
 renderPragmaParam Once = "once"
 
 render :: CStatement -> String
-render (Include (HdrName hdr))  = "#include \"" <> hdr <> "\"\n"
+render (Include (HdrName hdr))  = "\n#include \"" <> hdr <> "\"\n"
 render (UsingNamespace (NS ns)) = "using namespace " <> ns <> ";"
-render (Pragma param)           = "#pragma " <> renderPragmaParam param <> "\n"
+render (Pragma param)           = "\n#pragma " <> renderPragmaParam param <> "\n"
 render EmptyLine                = "\n"
 render (Verbatim str)           = str
 
 renderBlock :: CBlock -> String
 renderBlock (ExternC cstmts) =
-     "#ifdef __cplusplus\n\
+     "\n#ifdef __cplusplus\n\
      \extern \"C\" {\n\
      \#endif\n"
   ++ concatMap render cstmts
-  ++ "#ifdef __cplusplus\n\
+  ++ "\n#ifdef __cplusplus\n\
      \}\n\
      \#endif\n"

--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -92,24 +92,24 @@ simpleBuilder cfg sbc = do
   buildJSONFile cabal topLevelMod pkgconfig extralibs (workingDir</>jsonFileName)
   --
   putStrLn "Generating Header file"
-  let -- typmacro = TypMcro ("__"  <> macrofy (unCabalName (cabal_pkgname cabal)) <> "__")
+  let
       gen :: FilePath -> String -> IO ()
       gen file str =
         let path = workingDir </> file in withFile path WriteMode (flip hPutStrLn str)
 
 
-  gen (unCabalName pkgname <> "Type.h") (buildTypeDeclHeader {- typmacro -} (map cihClass cihs))
+  gen (unCabalName pkgname <> "Type.h") (buildTypeDeclHeader (map cihClass cihs))
   for_ cihs $ \hdr -> gen
                         (unHdrName (cihSelfHeader hdr))
-                        (buildDeclHeader {- typmacro -} (unCabalName pkgname) hdr)
+                        (buildDeclHeader (unCabalName pkgname) hdr)
   gen
     (tihHeaderFileName tih <.> "h")
-    (buildTopLevelHeader {- typmacro -} (unCabalName pkgname) tih)
+    (buildTopLevelHeader (unCabalName pkgname) tih)
   for_ tcms $ \m ->
     let tcihs = tcmTCIH m
     in for_ tcihs $ \tcih ->
          let hdr = unHdrName (tcihSelfHeader tcih)
-         in gen hdr (buildTemplateHeader {- typmacro -} tcih)
+         in gen hdr (buildTemplateHeader tcih)
   --
   putStrLn "Generating Cpp file"
   for_ cihs (\hdr -> gen (cihSelfCpp hdr) (buildDefMain hdr))

--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -92,24 +92,24 @@ simpleBuilder cfg sbc = do
   buildJSONFile cabal topLevelMod pkgconfig extralibs (workingDir</>jsonFileName)
   --
   putStrLn "Generating Header file"
-  let typmacro = TypMcro ("__"  <> macrofy (unCabalName (cabal_pkgname cabal)) <> "__")
+  let -- typmacro = TypMcro ("__"  <> macrofy (unCabalName (cabal_pkgname cabal)) <> "__")
       gen :: FilePath -> String -> IO ()
       gen file str =
         let path = workingDir </> file in withFile path WriteMode (flip hPutStrLn str)
 
 
-  gen (unCabalName pkgname <> "Type.h") (buildTypeDeclHeader typmacro (map cihClass cihs))
+  gen (unCabalName pkgname <> "Type.h") (buildTypeDeclHeader {- typmacro -} (map cihClass cihs))
   for_ cihs $ \hdr -> gen
                         (unHdrName (cihSelfHeader hdr))
-                        (buildDeclHeader typmacro (unCabalName pkgname) hdr)
+                        (buildDeclHeader {- typmacro -} (unCabalName pkgname) hdr)
   gen
     (tihHeaderFileName tih <.> "h")
-    (buildTopLevelHeader typmacro (unCabalName pkgname) tih)
+    (buildTopLevelHeader {- typmacro -} (unCabalName pkgname) tih)
   for_ tcms $ \m ->
     let tcihs = tcmTCIH m
     in for_ tcihs $ \tcih ->
          let hdr = unHdrName (tcihSelfHeader tcih)
-         in gen hdr (buildTemplateHeader typmacro tcih)
+         in gen hdr (buildTemplateHeader {- typmacro -} tcih)
   --
   putStrLn "Generating Cpp file"
   for_ cihs (\hdr -> gen (cihSelfCpp hdr) (buildDefMain hdr))

--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -37,7 +37,6 @@ import           FFICXX.Generate.Type.Cabal              ( Cabal(..)
                                                          , AddCSrc(..)
                                                          )
 import           FFICXX.Generate.Type.Module
-import           FFICXX.Generate.Type.PackageInterface
 import           FFICXX.Generate.Util
 --
 

--- a/fficxx/src/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Cpp.hs
@@ -7,9 +7,7 @@ import Data.Char
 import Data.List                             (intercalate)
 import Data.Monoid                           ((<>))
 --
-import FFICXX.Runtime.CodeGen.C              ( CStatement(..)
-                                             , render
-                                             )
+import FFICXX.Runtime.CodeGen.C              ( CStatement(..) )
 --
 import FFICXX.Generate.Code.Primitive        (accessorCFunSig
                                              ,argsToCallString
@@ -182,15 +180,11 @@ genCppDefInstAccessor c =
 
 -----------------
 
-genAllCppHeaderInclude :: ClassImportHeader -> String
+genAllCppHeaderInclude :: ClassImportHeader -> [CStatement]
 genAllCppHeaderInclude header =
-    intercalate "\n" $
-      map (render . Include) $
-        (cihIncludedHPkgHeadersInCPP header <> cihIncludedCPkgHeaders header)
+  map Include (cihIncludedHPkgHeadersInCPP header <> cihIncludedCPkgHeaders header)
 
 ----
-
-
 
 -------------------------
 -- TOP LEVEL FUNCTIONS --

--- a/fficxx/src/FFICXX/Generate/Config.hs
+++ b/fficxx/src/FFICXX/Generate/Config.hs
@@ -1,9 +1,7 @@
 module FFICXX.Generate.Config where
 
-import FFICXX.Runtime.CodeGen.C    ( HeaderName )
---
 import FFICXX.Generate.Type.Cabal  ( Cabal )
-import FFICXX.Generate.Type.Class  ( Class, TemplateClass, TopLevelFunction )
+import FFICXX.Generate.Type.Class  ( Class, TopLevelFunction )
 import FFICXX.Generate.Type.Config ( ModuleUnitMap(..) )
 import FFICXX.Generate.Type.Module ( TemplateClassImportHeader )
 

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -46,7 +46,7 @@ import FFICXX.Generate.Type.PackageInterface  ( ClassName(..)
                                               , PackageInterface
                                               , PackageName(..)
                                               )
-import FFICXX.Generate.Util
+import FFICXX.Generate.Util                   ( connRet, connRet2, intercalateWith )
 import FFICXX.Generate.Util.HaskellSrcExts
 
 
@@ -149,23 +149,6 @@ buildDeclHeader cprefix header =
          , EmptyLine
          , Verbatim declBodyStr
          ]
-
-{-
-definitionTemplate :: Text
-definitionTemplate =
-  "$header\n\
-  \\n\
-  \$alias\n\
-  \\n\
-  \#define CHECKPROTECT(x,y) IS_PAREN(IS_ ## x ## _ ## y ## _PROTECTED)\n\
-  \\n\
-  \#define TYPECASTMETHOD(cname,mname,oname) \\\n\
-  \  IIF( CHECKPROTECT(cname,mname) ) ( \\\n\
-  \  (to_nonconst<oname,cname ## _t>), \\\n\
-  \  (to_nonconst<cname,cname ## _t>) )\n\
-  \\n\
-  \$cppbody\n"
--}
 
 -- |
 buildDefMain :: ClassImportHeader
@@ -284,13 +267,6 @@ buildTopLevelCppDef tih =
        , Verbatim declBodyStr
        ]
 
-
-{-
-   subst definitionTemplate (context [ ("header"   , declHeaderStr)
-                                       , ("alias"    , aliasStr     )
-                                       , ("cppbody"  , declBodyStr  ) ])
--}
-
 -- |
 buildTemplateHeader ::
      TemplateClassImportHeader
@@ -316,23 +292,6 @@ buildTemplateHeader tcih =
        , EmptyLine
        , Verbatim classlevel
        ]
-
-{-
-
-
-   subst
-       "$directive\n\
-       \\n\
-       \$headers\n\
-       \\n\
-       \$deffunc\n\
-       \$classlevel\n"
-       (context [ ("directive"  , directive    )
-                , ("headers"    , headerStr    )
-                , ("deffunc"    , deffunc      )
-                , ("classlevel" , classlevel   )
-                ])
--}
 
 -- |
 buildFFIHsc :: ClassModule -> Module ()

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -86,58 +86,18 @@ mkProtectedFunctionList c =
      . map (\x->"#define IS_" <> class_name c <> "_" <> x <> "_PROTECTED ()")
      . unProtected . class_protected) c
 
-
---        #ifdef __cplusplus\n\
---        \extern \"C\" { \n\
---       \#endif\n\
---        \\n\
-
 -- |
 buildTypeDeclHeader ::
      [Class]
   -> String
 buildTypeDeclHeader classes =
   let typeDeclBodyStr = intercalateWith connRet2 (genCppHeaderMacroType) classes
-      -- directive = render (Pragma Once)
   in renderBlock $
        ExternC
          [ Pragma Once
          , EmptyLine
          , Verbatim typeDeclBodyStr
          ]
-{-     subst
-       \$directive\n\
-       \\n\
-       \$typeDeclBody\n\
-       \\n\
-       \#ifdef __cplusplus\n\
-       \}\n\
-       \#endif\n"
-       (context
-         [ ("typeDeclBody", typeDeclBodyStr )
-         , ("directive", directive)
-         ]
-       )
--}
-
-
-  -- #ifdef __cplusplus\n\
-  --  \extern \"C\" { \n\
-  -- \#endif\n\
-  -- \\n\
-  -- \$directive\n\
-  -- \\n\
-
-  -- \#ifdef __cplusplus\n\
-  -- \}\n\
-  -- \#endif\n"
-
-declarationTemplate :: Text
-declarationTemplate =
-  "$declarationheader\n\
-  \ // \n\
-  \$declarationbody\n\
-  \\n"
 
 -- |
 buildDeclHeader ::
@@ -186,13 +146,9 @@ buildDeclHeader cprefix header =
        ExternC
          [ Pragma Once
          , EmptyLine
-         , Verbatim $
-             subst declarationTemplate
-              (context
-                [ ("declarationheader", declHeaderStr )
-                , ("declarationbody"  , declBodyStr   )
-                ]
-              )
+         , Verbatim declHeaderStr
+         , EmptyLine
+         , Verbatim declBodyStr
          ]
 
 definitionTemplate :: Text
@@ -255,9 +211,7 @@ buildTopLevelHeader ::
   -> TopLevelImportHeader
   -> String
 buildTopLevelHeader cprefix tih =
-  let
-      -- directive = render $ Pragma Once
-      declHeaderStr =
+  let declHeaderStr =
         render (Include (HdrName (cprefix ++ "Type.h")))
         `connRet2`
         intercalate "\n"
@@ -267,13 +221,9 @@ buildTopLevelHeader cprefix tih =
        ExternC
          [ Pragma Once
          , EmptyLine
-         , Verbatim $
-             subst declarationTemplate
-              (context
-                [ ("declarationheader", declHeaderStr )
-                , ("declarationbody"  , declBodyStr   )
-                ]
-              )
+         , Verbatim declHeaderStr
+         , EmptyLine
+         , Verbatim declBodyStr
          ]
 
 -- |

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -3,18 +3,15 @@
 
 module FFICXX.Generate.ContentMaker where
 
-import Control.Lens                           ((&),(.~),at)
+import Control.Lens                           ( (&), (.~), at )
 import Control.Monad.Trans.Reader
-import Data.Char                              (toUpper)
-import Data.Either                            (rights)
-import Data.Function                          (on)
+import Data.Either                            ( rights )
 import qualified Data.Map as M
-import Data.Maybe                             (mapMaybe,maybeToList)
-import Data.Monoid                            ((<>))
-import Data.List                              (find,intercalate,nub,nubBy)
+import Data.Maybe                             ( mapMaybe, maybeToList )
+import Data.Monoid                            ( (<>) )
+import Data.List                              ( find, intercalate, nub )
 import Data.List.Split                        ( splitOn )
 import Data.Text                              ( Text )
-import qualified Data.Text as T               ( pack )
 import Language.Haskell.Exts.Syntax           ( Module(..)
                                               , Decl(..)
                                               )
@@ -22,7 +19,6 @@ import System.FilePath
 --
 import FFICXX.Runtime.CodeGen.C               ( CStatement(..)
                                               , HeaderName(..)
-                                              , Namespace(..)
                                               , PragmaParam(..)
                                               , render
                                               )
@@ -48,7 +44,6 @@ import FFICXX.Generate.Type.Module
 import FFICXX.Generate.Type.PackageInterface  ( ClassName(..)
                                               , PackageInterface
                                               , PackageName(..)
-                                              , TypeMacro(..)
                                               )
 import FFICXX.Generate.Util
 import FFICXX.Generate.Util.HaskellSrcExts

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -89,18 +89,11 @@ mkProtectedFunctionList c =
      . map (\x->"#define IS_" <> class_name c <> "_" <> x <> "_PROTECTED ()")
      . unProtected . class_protected) c
 
-
-    -- \#ifndef $typemacro\n\
-    --    \#define $typemacro\n\
-    --    \#endif // $typemacro\n\
-
-
 -- |
 buildTypeDeclHeader ::
-     -- TypeMacro -- ^ typemacro
      [Class]
   -> String
-buildTypeDeclHeader {- (TypMcro typemacro) -} classes =
+buildTypeDeclHeader classes =
   let typeDeclBodyStr = intercalateWith connRet2 (genCppHeaderMacroType) classes
       directive = render (Pragma Once)
   in subst
@@ -118,14 +111,8 @@ buildTypeDeclHeader {- (TypMcro typemacro) -} classes =
        (context
          [ ("typeDeclBody", typeDeclBodyStr )
          , ("directive", directive)
-                -- , ("typemacro"   , typemacro       )
          ]
        )
-
---   \#ifndef $typemacro\n\
---   \#define $typemacro\n\
---   \#endif // $typemacro\n\
---   \\n\
 
 declarationTemplate :: Text
 declarationTemplate =
@@ -145,14 +132,12 @@ declarationTemplate =
 
 -- |
 buildDeclHeader ::
-     -- TypeMacro  -- ^ typemacro prefix
      String     -- ^ C prefix
   -> ClassImportHeader
   -> String
-buildDeclHeader {- (TypMcro typemacroprefix) -} cprefix header =
+buildDeclHeader cprefix header =
   let classes = [cihClass header]
       aclass = cihClass header
-      -- typemacrostr = typemacroprefix <> ffiClassName aclass <> "__"
       directive = render $ Pragma Once
       declHeaderStr =
         render (Include (HdrName (cprefix ++ "Type.h")))
@@ -191,8 +176,7 @@ buildDeclHeader {- (TypMcro typemacroprefix) -} cprefix header =
                       classDeclsStr
   in subst declarationTemplate
        (context
-         [ -- ("typemacro"        , typemacrostr  )
-           ("directive"        , directive)
+         [ ("directive"        , directive)
          , ("declarationheader", declHeaderStr )
          , ("declarationbody"  , declBodyStr   )
          ]
@@ -255,12 +239,11 @@ buildDefMain cih =
 
 -- |
 buildTopLevelHeader ::
-   --  TypeMacro  -- ^ typemacro prefix
      String     -- ^ C prefix
   -> TopLevelImportHeader
   -> String
-buildTopLevelHeader {- (TypMcro typemacroprefix) -} cprefix tih =
-  let -- typemacrostr = typemacroprefix <> "TOPLEVEL" <> "__"
+buildTopLevelHeader cprefix tih =
+  let
       directive = render $ Pragma Once
       declHeaderStr =
         render (Include (HdrName (cprefix ++ "Type.h")))
@@ -271,8 +254,7 @@ buildTopLevelHeader {- (TypMcro typemacroprefix) -} cprefix tih =
   in subst
        declarationTemplate
        (context
-         [ -- ("typemacro"        , typemacrostr  )
-           ("directive"        , directive)
+         [ ("directive"        , directive)
          , ("declarationheader", declHeaderStr )
          , ("declarationbody"  , declBodyStr   )
          ]
@@ -316,21 +298,15 @@ buildTopLevelCppDef tih =
                                        , ("alias"    , aliasStr     )
                                        , ("cppbody"  , declBodyStr  ) ])
 
--- #ifndef $typemacro\n\
---       \#define $typemacro\n\
---       \#endif\n
-
 
 -- |
 buildTemplateHeader ::
-    -- TypeMacro  -- ^ typemacro prefix
      TemplateClassImportHeader
   -> String
-buildTemplateHeader {- (TypMcro typemacroprefix) -} tcih =
+buildTemplateHeader tcih =
   let
       t = tcihTClass tcih
       directive = render $ Pragma Once
-      -- typemacrostr = typemacroprefix <> "TEMPLATE__" <> map toUpper (tclass_name t) <> "__"
       fs = tclass_funcs t
 
       headerStr = concatMap (render . Include) (tcihCxxHeaders tcih)
@@ -346,8 +322,7 @@ buildTemplateHeader {- (TypMcro typemacroprefix) -} tcih =
        \\n\
        \$deffunc\n\
        \$classlevel\n"
-       (context [ -- ("typemacro"  , typemacrostr )
-                  ("directive"  , directive    )
+       (context [ ("directive"  , directive    )
                 , ("headers"    , headerStr    )
                 , ("deffunc"    , deffunc      )
                 , ("classlevel" , classlevel   )

--- a/fficxx/src/FFICXX/Generate/Type/PackageInterface.hs
+++ b/fficxx/src/FFICXX/Generate/Type/PackageInterface.hs
@@ -11,9 +11,4 @@ import FFICXX.Runtime.CodeGen.C ( HeaderName(..) )
 newtype PackageName = PkgName String  deriving (Hashable, Show, Eq, Ord)
 newtype ClassName = ClsName String deriving (Hashable, Show, Eq, Ord)
 
-
-
 type PackageInterface = HM.HashMap (PackageName, ClassName) HeaderName 
-
-newtype TypeMacro = TypMcro { unTypMcro :: String } 
-                  deriving (Show,Eq,Ord)


### PR DESCRIPTION
`#pragma once`, `extern "C" { }` and all `#include` are now replaced by intermediate AST.