### PR TITLE
CDefinition. Unified newline treatment in Macro definition

### DIFF
--- a/fficxx-runtime/src/FFICXX/Runtime/CodeGen/C.hs
+++ b/fficxx-runtime/src/FFICXX/Runtime/CodeGen/C.hs
@@ -46,8 +46,10 @@ data CStatement =
     UsingNamespace Namespace -- ^ using namespace <namespace>;
   | TypeDef CType CName      -- ^ typedef origtype newname;
   | CDeclaration CDecl       -- ^ function declaration;
+  | CDefinition CDecl [CStatement] -- ^ function definition;
   | CMacroApp CName [CName]  -- ^ C Macro application at statement level (temporary)
   | Comment String           -- ^ comment
+  | CEmptyLine               -- ^ for convenience
   | CVerbatim String         -- ^ temporary verbatim
 
 data CMacro =
@@ -75,8 +77,11 @@ renderCStmt :: CStatement -> String
 renderCStmt (UsingNamespace (NS ns)) = "using namespace " <> ns <> ";"
 renderCStmt (TypeDef (CType typ) n)  = "typedef " <> typ <> " " <> renderCName n <> ";"
 renderCStmt (CDeclaration e)         = renderCDecl e <> ";"
+renderCStmt (CDefinition d body)     =
+  renderCDecl d <> " {\n" <> concatMap renderCStmt body <> "\n}\n"
 renderCStmt (CMacroApp n as)         = renderCName n <> "(" <> intercalate ", " (map renderCName as) <> ")" -- NOTE: no semicolon.
 renderCStmt (Comment str)            = "// " <> str <> "\n"
+renderCStmt CEmptyLine               = "\n"
 renderCStmt (CVerbatim str)          = str
 
 renderCMacro :: CMacro -> String

--- a/fficxx/src/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Cpp.hs
@@ -210,27 +210,38 @@ topLevelFunDecl TopLevelVariable {..} = R.FunDecl ret func []
     func = R.sname ("TopLevel_" <> maybe toplevelvar_name id toplevelvar_alias)
 
 
-genTopLevelFuncCppDefinition :: TopLevelFunction -> String
+
+   {-
+
+tmpl = "$decl { \n  $funcbody\n}"
+   subst tmpl (context [ ("decl"    , decl)
+                         , ("funcbody", funcDefStr)
+                         ]
+                )
+subst tmpl (context [ ("decl"    , decl)
+                         , ("funcbody", funcDefStr)
+                         ]
+                )
+
+
+   -}
+
+
+genTopLevelFuncCppDefinition :: TopLevelFunction -> R.CStatement
 genTopLevelFuncCppDefinition tf@TopLevelFunction {..} =
-  let tmpl = "$decl { \n  $funcbody\n}"
-      decl = R.renderCDecl $ topLevelFunDecl tf
+  let decl = topLevelFunDecl tf
       callstr = toplevelfunc_name <> "("
                 <> argsToCallString toplevelfunc_args
                 <> ")"
       funcDefStr = returnCpp False (toplevelfunc_ret) callstr
-  in subst tmpl (context [ ("decl"    , decl)
-                         , ("funcbody", funcDefStr)
-                         ]
-                )
+      body = [ R.CVerbatim funcDefStr ]
+  in R.CDefinition decl body
 genTopLevelFuncCppDefinition tv@TopLevelVariable {..} =
-  let tmpl = "$decl { \n  $funcbody\n}"
-      decl = R.renderCDecl $ topLevelFunDecl tv
+  let decl = topLevelFunDecl tv
       callstr = toplevelvar_name
       funcDefStr = returnCpp False (toplevelvar_ret) callstr
-  in subst tmpl (context [ ("decl"    , decl)
-                         , ("funcbody", funcDefStr)
-                         ]
-                )
+      body = [ R.CVerbatim funcDefStr ]
+  in R.CDefinition decl body
 
 
 genTmplFunCpp :: Bool -- ^ is for simple type?

--- a/fficxx/src/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Cpp.hs
@@ -64,7 +64,7 @@ genCppHeaderMacroType c =
 genCppHeaderMacroVirtual :: Class -> R.CMacro
 genCppHeaderMacroVirtual aclass =
   let funcDecls = map R.CDeclaration
-                . funcsToDecls aclass
+                . map (funcToDecl aclass)
                 . virtualFuncs
                 . class_funcs
                 $ aclass
@@ -75,7 +75,7 @@ genCppHeaderMacroVirtual aclass =
 genCppHeaderMacroNonVirtual :: Class -> R.CMacro
 genCppHeaderMacroNonVirtual c =
   let funcDecls = map R.CDeclaration
-                . funcsToDecls c
+                . map (funcToDecl c)
                 . filter (not.isVirtualFunc)
                 . class_funcs
                 $ c
@@ -332,9 +332,6 @@ funcToDecl c func
           R.CName [R.NamePart "Type", R.NamePart ("_" <> aliasedFuncName c func)]
         args  = argsToCTypVar (genericFuncArgs func)
     in R.FunDecl ret fname args
-
-funcsToDecls :: Class -> [Function] -> [R.CDecl]
-funcsToDecls c = map (funcToDecl c)
 
 funcToDef :: Class -> Function -> String
 funcToDef c func

--- a/fficxx/src/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Cpp.hs
@@ -22,7 +22,6 @@ import FFICXX.Generate.Code.Primitive        ( accessorCFunSig
                                              , tmplMemFuncArgToCTypVar
                                              , tmplMemFuncRetTypeToString
                                              , tmplAllArgsToCallString
-                                             -- , tmplAllArgsToString
                                              , tmplAllArgsToCTypVar
                                              , tmplRetTypeToString
                                              )
@@ -366,27 +365,6 @@ funcToDef c func
 
 funcsToDefs :: Class -> [Function] -> String
 funcsToDefs c = intercalateWith connBSlash (funcToDef c)
-
-
-{-  subst "$ret ${tname}_${fname}_ ## Type ( $args )"
-    (context [ ("tname", tclass_name)
-             , ("fname", ffiTmplFuncName f)
-             , ("args" , tmplAllArgsToString b Self t tfun_args)
-             , ("ret"  , tmplRetTypeToString b tfun_ret) ])
-  subst "$ret ${tname}_${fname}_ ## Type ( $args )"
-    (context [ ("tname", tclass_name)
-             , ("fname", ffiTmplFuncName f)
-             , ("args" , tmplAllArgsToString b NoSelf t tfun_new_args)
-             , ("ret"  , tmplRetTypeToString b (TemplateType t)) ])
-
-  subst "$ret ${tname}_delete_ ## Type ( $args )"
-    (context [ ("tname", tclass_name                     )
-             , ("args" , tmplAllArgsToString b Self t [] )
-             , ("ret"  , "void" ) ])
-
--}
-
-
 
 
 tmplFunToDecl :: Bool -> TemplateClass -> TemplateFunction -> R.CDecl

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -224,7 +224,9 @@ buildTopLevelCppDef tih =
                               in if n1 == n2
                                  then Nothing
                                  else Just ("typedef " <> n1 <> " " <> n2 <> ";")
-      declBodyStr    = intercalateWith connRet genTopLevelFuncCppDefinition (tihFuncs tih)
+      declBodyStr =
+        intercalate "\n" $
+          map (R.renderCStmt . genTopLevelFuncCppDefinition) (tihFuncs tih)
 
   in concatMap R.renderCMacro
        (   declHeaderStmts

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -254,10 +254,14 @@ buildTemplateHeader tcih =
   let t = tcihTClass tcih
       fs = tclass_funcs t
       headerStmts = map R.Include (tcihCxxHeaders tcih)
-      deffunc = intercalateWith connRet (genTmplFunCpp False t) fs
+      deffunc =    intercalate "\n"
+                     (map (R.renderCMacro . genTmplFunCpp False t) fs)
                 ++ "\n\n"
-                ++ intercalateWith connRet (genTmplFunCpp True t) fs
-      classlevel = genTmplClassCpp False t fs ++ "\n\n" ++ genTmplClassCpp True t fs
+                ++ intercalate "\n"
+                     (map (R.renderCMacro . genTmplFunCpp True t) fs)
+      classlevel =    R.renderCMacro (genTmplClassCpp False t fs)
+                   ++ "\n\n"
+                   ++ R.renderCMacro (genTmplClassCpp True t fs)
   in concatMap R.renderCMacro $
           [ R.Pragma R.Once
           , R.EmptyLine

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -41,7 +41,6 @@ import FFICXX.Generate.Type.PackageInterface  ( ClassName(..)
                                               , PackageInterface
                                               , PackageName(..)
                                               )
-import FFICXX.Generate.Util                   ( connRet, intercalateWith )
 import FFICXX.Generate.Util.HaskellSrcExts
 
 


### PR DESCRIPTION
Now every C++ codegen function uses AST although verbatim is still used.