### PR TITLE
Inline C++ code generation for template member function

### DIFF
--- a/fficxx/src/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Cpp.hs
@@ -448,7 +448,7 @@ tmplMemberFunToDecl :: Class -> TemplateMemberFunction -> R.CFunDecl
 tmplMemberFunToDecl c f =
   let ret = R.CTVerbatim $ tmplMemFuncRetTypeToString c (tmf_ret f)
       fname =
-        R.CName [ R.NamePart (hsTemplateMemberFunctionName c f)
+        R.CName [ R.NamePart (hsTemplateMemberFunctionName c f <> "_")
                 , R.NamePart "Type"
                 ]
       args = map (tmplMemFuncArgToCTypVar c) ((Arg SelfType "p"):tmf_args f)

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -114,12 +114,6 @@ genTMFInstance cih f = mkFun fname sig [p "isCprim", p "qtyp", p "param"] rhs No
                         , includeDynamic
                         , namespaceStr
                         , strE (hsTemplateMemberFunctionName c f)
-                        -- , paren $
-                        --     caseE
-                        --       (v "isCprim")
-                        --       [ match (p "CPrim")    (strE "_s")
-                        --       , match (p "NonCPrim") (strE "")
-                        --      ]
                         , strE "("
                         , v "suffix"
                         , strE ")\n"

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -30,7 +30,9 @@ import FFICXX.Generate.Type.Class     ( Class(..)
                                       , TemplateFunction(..)
                                       , TemplateMemberFunction(..)
                                       )
-import FFICXX.Generate.Type.Module    ( TemplateClassImportHeader(..) )
+import FFICXX.Generate.Type.Module    ( ClassImportHeader(..)
+                                      , TemplateClassImportHeader(..)
+                                      )
 import FFICXX.Generate.Util.HaskellSrcExts
                                       ( bracketExp
                                       , con, conDecl, cxEmpty, clsDecl
@@ -51,51 +53,99 @@ import FFICXX.Generate.Util.HaskellSrcExts
 -- Template member function --
 ------------------------------
 
-genTemplateMemberFunctions :: Class -> [Decl ()]
-genTemplateMemberFunctions c =
-  concatMap (\f -> genTMFExp c f <> genTMFInstance c f) (class_tmpl_funcs c)
+genTemplateMemberFunctions :: ClassImportHeader -> [Decl ()]
+genTemplateMemberFunctions cih =
+  let c = cihClass cih 
+  in concatMap (\f -> genTMFExp c f <> genTMFInstance cih f) (class_tmpl_funcs c)
 
 
 genTMFExp :: Class -> TemplateMemberFunction -> [Decl ()]
 genTMFExp c f = mkFun nh sig [p "typ", p "suffix"] rhs (Just bstmts)
-      where nh = hsTemplateMemberFunctionNameTH c f
-            sig = tycon "Type" `tyfun` (tycon "String" `tyfun` (tyapp (tycon "Q") (tycon "Exp")))
-            v = mkVar
-            p = mkPVar
-            tp = tmf_param f
-            lit' = strE (hsTemplateMemberFunctionName c f <> "_")
-            lam = lambda [p "n"] ( lit' `app` v "<>" `app` v "n")
-            rhs = app (v "mkTFunc") (tuple [v "typ", v "suffix", lam, v "tyf"])
-            sig' = functionSignatureTMF c f
-            bstmts = binds [ mkBind1 "tyf" [mkPVar "n"]
-                               (letE [ pbind_ (p tp) (v "pure" `app` (v "typ")) ]
-                                  (bracketExp (typeBracket sig')))
-                               Nothing
-                           ]
+  where
+    nh = hsTemplateMemberFunctionNameTH c f
+    sig = tycon "Type" `tyfun` (tycon "String" `tyfun` (tyapp (tycon "Q") (tycon "Exp")))
+    v = mkVar
+    p = mkPVar
+    tp = tmf_param f
+    lit' = strE (hsTemplateMemberFunctionName c f <> "_")
+    lam = lambda [p "n"] ( lit' `app` v "<>" `app` v "n")
+    rhs = app (v "mkTFunc") (tuple [v "typ", v "suffix", lam, v "tyf"])
+    sig' = functionSignatureTMF c f
+    bstmts = binds [ mkBind1 "tyf" [mkPVar "n"]
+                       (letE [ pbind_ (p tp) (v "pure" `app` (v "typ")) ]
+                          (bracketExp (typeBracket sig')))
+                       Nothing
+                   ]
 
-
-genTMFInstance :: Class -> TemplateMemberFunction -> [Decl ()]
-genTMFInstance c f = mkFun fname sig [p "qtyp", p "suffix"] rhs Nothing
-  where fname = "genInstanceFor_" <> hsTemplateMemberFunctionName c f
-        p = mkPVar
-        v = mkVar
-        sig = (tyapp (tycon "Q") (tycon "Type")) `tyfun`
-                (tycon "String" `tyfun`
-                  (tyapp (tycon "Q") (tylist (tycon "Dec"))))
-        rhs = doE [qtypstmt, genstmt, letStmt lststmt, qualStmt retstmt]
-        qtypstmt = generator (p "typ") (v "qtyp")
-        genstmt = generator
-                    (p "f1")
-                    (v "mkMember" `app` (     strE (hsTemplateMemberFunctionName c f <> "_")
-                                        `app` v "<>"
-                                        `app` v "suffix"
-                                        )
-                                  `app` v (hsTemplateMemberFunctionNameTH c f)
-                                  `app` v "typ"
-                                  `app` v "suffix"
-                    )
-        lststmt = [ pbind_ (p "lst") (list ([v "f1"])) ]
-        retstmt = v "pure" `app` v "lst"
+genTMFInstance :: ClassImportHeader -> TemplateMemberFunction -> [Decl ()]
+genTMFInstance cih f = mkFun fname sig [p "isCprim", p "qtyp", p "param"] rhs Nothing
+  where
+    c = cihClass cih
+    fname = "genInstanceFor_" <> hsTemplateMemberFunctionName c f
+    p = mkPVar
+    v = mkVar
+    sig =         tycon "IsCPrimitive"
+          `tyfun` (tycon "Q" `tyapp` tycon "Type")
+          `tyfun` tycon "TemplateParamInfo"
+          `tyfun` (tycon "Q" `tyapp` tylist (tycon "Dec"))
+    rhs = doE [suffixstmt, qtypstmt, genstmt, foreignSrcStmt, letStmt lststmt, qualStmt retstmt]
+    suffixstmt = letStmt [ pbind_ (p "suffix") (v "tpinfoSuffix" `app` v "param" ) ]
+    qtypstmt = generator (p "typ") (v "qtyp")
+    genstmt = generator
+                (p "f1")
+                (v "mkMember" `app` (     strE (hsTemplateMemberFunctionName c f <> "_")
+                                    `app` v "<>"
+                                    `app` v "suffix"
+                                    )
+                              `app` v (hsTemplateMemberFunctionNameTH c f)
+                              `app` v "typ"
+                              `app` v "suffix"
+                )
+    lststmt = [ pbind_ (p "lst") (list ([v "f1"])) ]
+    retstmt = v "pure" `app` v "lst"
+    -- TODO: refactor out the following code.
+    foreignSrcStmt =
+      qualifier $
+              (v "addModFinalizer")
+        `app` (      v "addForeignSource"
+               `app` con "LangCxx"
+               `app` (L.foldr1 (\x y -> inapp x (op "++") y)
+                        [ includeStatic
+                        , includeDynamic
+                        , namespaceStr
+                        , strE (hsTemplateMemberFunctionName c f)
+                        -- , paren $
+                        --     caseE
+                        --       (v "isCprim")
+                        --       [ match (p "CPrim")    (strE "_s")
+                        --       , match (p "NonCPrim") (strE "")
+                        --      ]
+                        , strE "("
+                        , v "suffix"
+                        , strE ")\n"
+                        ]
+                     )
+              )
+      where
+        includeStatic =
+          strE $ concatMap (<> "\n")
+            [ R.renderCMacro (R.Include (HdrName "MacroPatternMatch.h"))
+            , R.renderCMacro (R.Include (cihSelfHeader cih)) -- (tcihSelfHeader tcih))
+            ]
+        includeDynamic =
+          letE
+            [ pbind_ (p "headers") (v "tpinfoCxxHeaders" `app` v "param" )
+            , pbind_ (pApp (name "f") [p "x"])
+                (v "renderCMacro" `app` (con "Include" `app` v "x"))
+            ]
+            (v "concatMap" `app` v "f" `app` v "headers")
+        namespaceStr =
+          letE
+            [ pbind_ (p "nss") (v "tpinfoCxxNamespaces" `app` v "param" )
+            , pbind_ (pApp (name "f") [p "x"])
+                (v "renderCStmt" `app` (con "UsingNamespace" `app` v "x"))
+            ]
+            (v "concatMap" `app` v "f" `app` v "nss")
 
 --------------------
 -- Template Class --
@@ -161,12 +211,10 @@ genTmplInstance t tcih fs =
               `tyfun` tycon "TemplateParamInfo"
               `tyfun` (tycon "Q" `tyapp` tylist (tycon "Dec"))
         nfs = zip ([1..] :: [Int]) fs
-        rhs = doE (  [ suffixstmt
-                     , qtypstmt
-                     ]
-                  <> map genstmt nfs
-                  <> [foreignSrcStmt]
-                  <> [letStmt (lststmt nfs), qualStmt retstmt])
+        rhs = doE (   [ suffixstmt, qtypstmt ]
+                   <> map genstmt nfs
+                   <> [foreignSrcStmt, letStmt (lststmt nfs), qualStmt retstmt]
+                  )
         suffixstmt = letStmt [ pbind_ (p "suffix") (v "tpinfoSuffix" `app` v "param" ) ]
         qtypstmt = generator (p "typ") (v "qtyp")
         genstmt (n,f@TFun    {..}) = generator
@@ -191,7 +239,7 @@ genTmplInstance t tcih fs =
                                                      `app` v    "suffix"
                                        )
         lststmt xs = [ pbind_ (p "lst") (list (map (v . (\n->"f"<>show n) . fst) xs)) ]
-
+        -- TODO: refactor out the following code.
         foreignSrcStmt =
           qualifier $
                   (v "addModFinalizer")

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -128,10 +128,10 @@ genTMFInstance cih f = mkFun fname sig [p "isCprim", p "qtyp", p "param"] rhs No
               )
       where
         includeStatic =
-          strE $ concatMap (<> "\n")
-            [ R.renderCMacro (R.Include (HdrName "MacroPatternMatch.h"))
-            , R.renderCMacro (R.Include (cihSelfHeader cih)) -- (tcihSelfHeader tcih))
-            ]
+          strE $ concatMap ((<>"\n") . R.renderCMacro . R.Include) $
+               [ HdrName "MacroPatternMatch.h", cihSelfHeader cih ]
+            <> cihIncludedHPkgHeadersInCPP cih
+            <> cihIncludedCPkgHeaders cih
         includeDynamic =
           letE
             [ pbind_ (p "headers") (v "tpinfoCxxHeaders" `app` v "param" )

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -375,7 +375,8 @@ buildImplementationHs amap m = mkModule (cmModule m <.> "Implementation")
                                         , "TypeSynonymInstances"
                                         ] ]
                                  implImports implBody
-  where classes = cmClass m
+  where -- TODO: classes should come from ClassImportHeader, not from module, directly.
+        classes = cmClass m
         implImports = [ mkImport "Data.Monoid"                -- for template member
                       , mkImport "Data.Word"
                       , mkImport "Data.Int"

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -131,8 +131,9 @@ buildDeclHeader cprefix header =
          <> map R.CRegular classDeclStmts
 
 -- |
-buildDefMain :: ClassImportHeader
-          -> String
+buildDefMain ::
+     ClassImportHeader
+  -> String
 buildDefMain cih =
   let classes = [cihClass cih]
       headerStmts =

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -384,6 +384,7 @@ buildImplementationHs amap m = mkModule (cmModule m <.> "Implementation")
                       , mkImport "Language.Haskell.TH.Syntax" -- for template member
                       , mkImport "System.IO.Unsafe"
                       , mkImport "FFICXX.Runtime.Cast"
+                      , mkImport "FFICXX.Runtime.CodeGen.C"   -- for template member
                       , mkImport "FFICXX.Runtime.TH"          -- for template member
                       ]
                       <> genImportInImplementation m
@@ -396,7 +397,7 @@ buildImplementationHs amap m = mkModule (cmModule m <.> "Implementation")
                    <> concatMap genHsFrontInstNonVirtual classes
                    <> concatMap genHsFrontInstStatic classes
                    <> concatMap genHsFrontInstVariables classes
-                   <> concatMap genTemplateMemberFunctions classes
+                   <> concatMap genTemplateMemberFunctions (cmCIH m)
 
 buildTemplateHs :: TemplateClassModule -> Module ()
 buildTemplateHs m =

--- a/fficxx/src/FFICXX/Generate/Type/Module.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Module.hs
@@ -23,7 +23,7 @@ data ClassImportHeader = ClassImportHeader
 -- | Haskell side
 data ClassModule = ClassModule
                    { cmModule :: String
-                   , cmClass :: [Class]
+                   , cmClass :: [Class]   -- TODO: this should be merged into CIH.
                    , cmCIH :: [ClassImportHeader]
                    , cmImportedModulesHighNonSource :: [Either TemplateClass Class]  -- ^ imported modules that do not need source
                                                                          -- NOTE: source means the same cabal package.


### PR DESCRIPTION
For template member function like `A::member<T>` in the folllowing:  
```
class A {
  template <typename T> int member(T& x ) 
};
```
C++ code is generated in an inline way. No more stub.cc finally!!!