### PR TITLE
C++ multi-parameter template interfaced via fficxx!

### DIFF
--- a/examples/map/build.sh
+++ b/examples/map/build.sh
@@ -1,0 +1,2 @@
+g++ -c maptest.cpp
+g++ -o maptest maptest.o

--- a/examples/map/maptest.cpp
+++ b/examples/map/maptest.cpp
@@ -1,0 +1,31 @@
+#include <iostream>
+#include <map>
+#include <utility>
+
+int main( int argc, char** argv ) {
+
+  std::map<int, double> mymap ;
+
+  mymap.insert (std::pair <int, double> (1,2.3)) ;
+  mymap.insert (std::pair <int, double> (4,5.6));
+
+  std::cout << "mymap.size() = " << mymap.size() << std::endl;
+  std::cout << "mymap.at(1)  = " << mymap.at(1) << std::endl;
+
+  auto it = mymap.find(2);
+  if (it == mymap.end() ) {
+    std::cout << "not found element at key = 2" << std::endl;
+  }
+
+  auto it2 = mymap.find(4);
+  if (it2 == mymap.end() ) {
+    std::cout << "not found element at key = 4" << std::endl;
+  }
+  else {
+    std::cout << "it->second = " << it2->second << std::endl;
+  }
+
+  std::cout << "mymap.at(2)  = " << mymap.at(2) << std::endl;
+
+  return 0;
+}

--- a/examples/map/test.hs
+++ b/examples/map/test.hs
@@ -29,52 +29,13 @@ TH.genMapInstanceFor
           , tpinfoCxxNamespaces = []
           , tpinfoSuffix        = "int"
           }
-
-
-TH.genVectorInstanceFor
-  NonCPrim
-  [t|CppString|]
-  (TPInfo { tpinfoCxxType       = "std::string"
-          , tpinfoCxxHeaders    = [ HdrName "string", HdrName "stdcxxType.h"]
-          , tpinfoCxxNamespaces = [ NS "std" ]
-          , tpinfoSuffix        = "string"
-          }
   )
 
 test1 :: IO ()
 test1 = do
-  v :: Vector CInt <- newVector
-  n <- size v
-  print =<< size v
-
-  push_back v 1
-  print =<< size v
-  mapM_ (push_back v) [1..100]
-  print =<< size v
-  pop_back v
-  print =<< size v
-
-  print =<< at v 5
-  deleteVector v
-
-
-test2 = do
-  withCString "hello" $ \cstr -> do
-    v :: Vector CppString <- newVector
-    cppstr <- newCppString cstr
-    push_back v cppstr
-    print =<< size v
-    cppstr' <- at v 0
-    cstr' <- cppString_c_str cppstr'
-    bstr <- B.packCString cstr'
-    print bstr
-    print =<< size v
-    pop_back v
-    print =<< size v
-    deleteVector v
-
+  m :: Map CInt CInt <- newMap
+  pure ()
 
 main :: IO ()
 main = do
   test1
-  test2

--- a/examples/map/test.hs
+++ b/examples/map/test.hs
@@ -11,11 +11,11 @@ import Foreign.C.String
 import FFICXX.Runtime.CodeGen.Cxx ( HeaderName(..), Namespace(..) )
 import FFICXX.Runtime.TH          ( IsCPrimitive(..), TemplateParamInfo(..) )
 import STD.CppString
-import STD.Vector.Template
-import qualified STD.Vector.TH as TH
+import STD.Map.Template
+import qualified STD.Map.TH as TH
 
 
-TH.genVectorInstanceFor
+TH.genMapInstanceFor
   CPrim
   [t|CInt|]
   (TPInfo { tpinfoCxxType       = "int"
@@ -24,6 +24,12 @@ TH.genVectorInstanceFor
           , tpinfoSuffix        = "int"
           }
   )
+  (TPInfo { tpinfoCxxType       = "int"
+          , tpinfoCxxHeaders    = []
+          , tpinfoCxxNamespaces = []
+          , tpinfoSuffix        = "int"
+          }
+
 
 TH.genVectorInstanceFor
   NonCPrim

--- a/examples/map/test.hs
+++ b/examples/map/test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -18,22 +19,25 @@ import qualified STD.Map.TH as TH
 TH.genMapInstanceFor
   CPrim
   [t|CInt|]
+  [t|CDouble|]
   (TPInfo { tpinfoCxxType       = "int"
           , tpinfoCxxHeaders    = []
           , tpinfoCxxNamespaces = []
           , tpinfoSuffix        = "int"
           }
   )
-  (TPInfo { tpinfoCxxType       = "int"
+{-
+  (TPInfo { tpinfoCxxType       = "double"
           , tpinfoCxxHeaders    = []
           , tpinfoCxxNamespaces = []
-          , tpinfoSuffix        = "int"
+          , tpinfoSuffix        = "double"
           }
   )
+-}
 
 test1 :: IO ()
 test1 = do
-  m :: Map CInt CInt <- newMap
+  m :: Map CInt CDouble <- newMap
   pure ()
 
 main :: IO ()

--- a/examples/map/test.hs
+++ b/examples/map/test.hs
@@ -18,22 +18,19 @@ import qualified STD.Map.TH as TH
 
 TH.genMapInstanceFor
   CPrim
-  [t|CInt|]
-  [t|CDouble|]
-  (TPInfo { tpinfoCxxType       = "int"
-          , tpinfoCxxHeaders    = []
-          , tpinfoCxxNamespaces = []
-          , tpinfoSuffix        = "int"
-          }
+  ( [t|CInt|], TPInfo { tpinfoCxxType       = "int"
+                      , tpinfoCxxHeaders    = []
+                      , tpinfoCxxNamespaces = []
+                      , tpinfoSuffix        = "int"
+                      }
   )
-{-
-  (TPInfo { tpinfoCxxType       = "double"
-          , tpinfoCxxHeaders    = []
-          , tpinfoCxxNamespaces = []
-          , tpinfoSuffix        = "double"
-          }
+  ( [t|CDouble|], TPInfo { tpinfoCxxType       = "double"
+                         , tpinfoCxxHeaders    = []
+                         , tpinfoCxxNamespaces = []
+                         , tpinfoSuffix        = "double"
+                         }
   )
--}
+
 
 test1 :: IO ()
 test1 = do

--- a/examples/map/test.hs
+++ b/examples/map/test.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+import qualified Data.ByteString.Char8 as B
+
+import Foreign.C.Types
+import Foreign.Ptr
+import Foreign.C.String
+
+import FFICXX.Runtime.CodeGen.Cxx ( HeaderName(..), Namespace(..) )
+import FFICXX.Runtime.TH          ( IsCPrimitive(..), TemplateParamInfo(..) )
+import STD.CppString
+import STD.Vector.Template
+import qualified STD.Vector.TH as TH
+
+
+TH.genVectorInstanceFor
+  CPrim
+  [t|CInt|]
+  (TPInfo { tpinfoCxxType       = "int"
+          , tpinfoCxxHeaders    = []
+          , tpinfoCxxNamespaces = []
+          , tpinfoSuffix        = "int"
+          }
+  )
+
+TH.genVectorInstanceFor
+  NonCPrim
+  [t|CppString|]
+  (TPInfo { tpinfoCxxType       = "std::string"
+          , tpinfoCxxHeaders    = [ HdrName "string", HdrName "stdcxxType.h"]
+          , tpinfoCxxNamespaces = [ NS "std" ]
+          , tpinfoSuffix        = "string"
+          }
+  )
+
+test1 :: IO ()
+test1 = do
+  v :: Vector CInt <- newVector
+  n <- size v
+  print =<< size v
+
+  push_back v 1
+  print =<< size v
+  mapM_ (push_back v) [1..100]
+  print =<< size v
+  pop_back v
+  print =<< size v
+
+  print =<< at v 5
+  deleteVector v
+
+
+test2 = do
+  withCString "hello" $ \cstr -> do
+    v :: Vector CppString <- newVector
+    cppstr <- newCppString cstr
+    push_back v cppstr
+    print =<< size v
+    cppstr' <- at v 0
+    cstr' <- cppString_c_str cppstr'
+    bstr <- B.packCString cstr'
+    print bstr
+    print =<< size v
+    pop_back v
+    print =<< size v
+    deleteVector v
+
+
+main :: IO ()
+main = do
+  test1
+  test2

--- a/examples/proxy/Gen.hs
+++ b/examples/proxy/Gen.hs
@@ -107,7 +107,7 @@ string =
     False
 
 t_vector :: TemplateClass
-t_vector = TmplCls stdcxx_cabal "Vector" "std::vector" "t"
+t_vector = TmplCls stdcxx_cabal "Vector" "std::vector" ["t"]
              [ TFunNew [] Nothing
              , TFun void_ "push_back" "push_back" [Arg (TemplateParam "t") "x"] Nothing
              , TFun void_ "pop_back"  "pop_back"  []                        Nothing
@@ -117,7 +117,7 @@ t_vector = TmplCls stdcxx_cabal "Vector" "std::vector" "t"
              ]
 
 t_unique_ptr :: TemplateClass
-t_unique_ptr = TmplCls stdcxx_cabal "UniquePtr" "std::unique_ptr" "t"
+t_unique_ptr = TmplCls stdcxx_cabal "UniquePtr" "std::unique_ptr" ["t"]
              [ TFunNew [] (Just "newUniquePtr0")
              , TFunNew [Arg (TemplateParamPointer "t") "p"] Nothing
              , TFun (TemplateParamPointer "t") "get" "get" [] Nothing

--- a/examples/proxy/Gen.hs
+++ b/examples/proxy/Gen.hs
@@ -107,21 +107,21 @@ string =
     False
 
 t_vector :: TemplateClass
-t_vector = TmplCls stdcxx_cabal "Vector" "std::vector" ["t"]
+t_vector = TmplCls stdcxx_cabal "Vector" "std::vector" ["tp1"]
              [ TFunNew [] Nothing
-             , TFun void_ "push_back" "push_back" [Arg (TemplateParam "t") "x"] Nothing
-             , TFun void_ "pop_back"  "pop_back"  []                        Nothing
-             , TFun (TemplateParam "t") "at" "at" [int "n"]                 Nothing
-             , TFun int_  "size"      "size"      []                        Nothing
+             , TFun void_ "push_back" "push_back"   [Arg (TemplateParam "tp1") "x"] Nothing
+             , TFun void_ "pop_back"  "pop_back"    []                        Nothing
+             , TFun (TemplateParam "tp1") "at" "at" [int "n"]                 Nothing
+             , TFun int_  "size"      "size"        []                        Nothing
              , TFunDelete
              ]
 
 t_unique_ptr :: TemplateClass
-t_unique_ptr = TmplCls stdcxx_cabal "UniquePtr" "std::unique_ptr" ["t"]
+t_unique_ptr = TmplCls stdcxx_cabal "UniquePtr" "std::unique_ptr" ["tp1"]
              [ TFunNew [] (Just "newUniquePtr0")
-             , TFunNew [Arg (TemplateParamPointer "t") "p"] Nothing
-             , TFun (TemplateParamPointer "t") "get" "get" [] Nothing
-             , TFun (TemplateParamPointer "t") "release" "release" [] Nothing
+             , TFunNew [Arg (TemplateParamPointer "tp1") "p"] Nothing
+             , TFun (TemplateParamPointer "tp1") "get" "get" [] Nothing
+             , TFun (TemplateParamPointer "tp1") "release" "release" [] Nothing
              , TFun void_ "reset" "reset" [] Nothing
              , TFunDelete
              ]

--- a/examples/shared_ptr/test.hs
+++ b/examples/shared_ptr/test.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings        #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE TemplateHaskell          #-}
 
 module Main where
 
@@ -19,12 +20,11 @@ import qualified STD.SharedPtr.TH as TH
 
 TH.genSharedPtrInstanceFor
   NonCPrim
-  [t|CppString|]
-  (TPInfo { tpinfoCxxType       = "std::string"
-          , tpinfoCxxHeaders    = [ HdrName "string", HdrName "stdcxxType.h" ]
-          , tpinfoCxxNamespaces = [ NS "std" ]
-          , tpinfoSuffix        = "string"
-          }
+  ( [t|CppString|], TPInfo { tpinfoCxxType       = "std::string"
+                           , tpinfoCxxHeaders    = [ "string", "stdcxxType.h" ]
+                           , tpinfoCxxNamespaces = [ "std" ]
+                           , tpinfoSuffix        = "string"
+                           }
   )
 
 

--- a/examples/template-member/Gen.hs
+++ b/examples/template-member/Gen.hs
@@ -107,7 +107,7 @@ string =
     False
 
 t_vector :: TemplateClass
-t_vector = TmplCls stdcxx_cabal "Vector" "std::vector" "t"
+t_vector = TmplCls stdcxx_cabal "Vector" "std::vector" ["t"]
              [ TFunNew [] Nothing
              , TFun void_ "push_back" "push_back" [Arg (TemplateParam "t") "x"] Nothing
              , TFun void_ "pop_back"  "pop_back"  []                        Nothing
@@ -117,7 +117,7 @@ t_vector = TmplCls stdcxx_cabal "Vector" "std::vector" "t"
              ]
 
 t_unique_ptr :: TemplateClass
-t_unique_ptr = TmplCls stdcxx_cabal "UniquePtr" "std::unique_ptr" "t"
+t_unique_ptr = TmplCls stdcxx_cabal "UniquePtr" "std::unique_ptr" ["t"]
              [ TFunNew [] (Just "newUniquePtr0")
              , TFunNew [Arg (TemplateParamPointer "t") "p"] Nothing
              , TFun (TemplateParamPointer "t") "get" "get" [] Nothing

--- a/examples/template-member/Gen.hs
+++ b/examples/template-member/Gen.hs
@@ -107,21 +107,21 @@ string =
     False
 
 t_vector :: TemplateClass
-t_vector = TmplCls stdcxx_cabal "Vector" "std::vector" ["t"]
+t_vector = TmplCls stdcxx_cabal "Vector" "std::vector" ["tp1"]
              [ TFunNew [] Nothing
-             , TFun void_ "push_back" "push_back" [Arg (TemplateParam "t") "x"] Nothing
-             , TFun void_ "pop_back"  "pop_back"  []                        Nothing
-             , TFun (TemplateParam "t") "at" "at" [int "n"]                 Nothing
-             , TFun int_  "size"      "size"      []                        Nothing
+             , TFun void_ "push_back" "push_back"   [Arg (TemplateParam "tp1") "x"] Nothing
+             , TFun void_ "pop_back"  "pop_back"    []                        Nothing
+             , TFun (TemplateParam "tp1") "at" "at" [int "n"]                 Nothing
+             , TFun int_  "size"      "size"        []                        Nothing
              , TFunDelete
              ]
 
 t_unique_ptr :: TemplateClass
-t_unique_ptr = TmplCls stdcxx_cabal "UniquePtr" "std::unique_ptr" ["t"]
+t_unique_ptr = TmplCls stdcxx_cabal "UniquePtr" "std::unique_ptr" ["tp1"]
              [ TFunNew [] (Just "newUniquePtr0")
-             , TFunNew [Arg (TemplateParamPointer "t") "p"] Nothing
-             , TFun (TemplateParamPointer "t") "get" "get" [] Nothing
-             , TFun (TemplateParamPointer "t") "release" "release" [] Nothing
+             , TFunNew [Arg (TemplateParamPointer "tp1") "p"] Nothing
+             , TFun (TemplateParamPointer "tp1") "get" "get" [] Nothing
+             , TFun (TemplateParamPointer "tp1") "release" "release" [] Nothing
              , TFun void_ "reset" "reset" [] Nothing
              , TFunDelete
              ]

--- a/examples/template-member/app.hs
+++ b/examples/template-member/app.hs
@@ -14,45 +14,39 @@ import TMFTest.T2
 
 genUniquePtrInstanceFor
   NonCPrim
-  [t|T1|]
-  TPInfo {
-    tpinfoCxxType       = "T1"
-  , tpinfoCxxHeaders    = [ "TMFTestT1.h"
-                          , "test.h"
-                          ]
-  , tpinfoCxxNamespaces = []
-  , tpinfoSuffix        = "T1"
-  }
+  ( [t|T1|], TPInfo { tpinfoCxxType       = "T1"
+                    , tpinfoCxxHeaders    = [ "TMFTestT1.h", "test.h" ]
+                    , tpinfoCxxNamespaces = []
+                    , tpinfoSuffix        = "T1"
+                    }
+  )
 
 genInstanceFor_a_method
   NonCPrim
-  [t|T1|]
-  TPInfo {
-    tpinfoCxxType       = "T1"
-  , tpinfoCxxHeaders    = [ "TMFTestT1.h" ]
-  , tpinfoCxxNamespaces = []
-  , tpinfoSuffix        = "T1"
-  }
+  ( [t|T1|], TPInfo { tpinfoCxxType       = "T1"
+                    , tpinfoCxxHeaders    = [ "TMFTestT1.h" ]
+                    , tpinfoCxxNamespaces = []
+                    , tpinfoSuffix        = "T1"
+                    }
+  )
 
 genInstanceFor_a_method
   NonCPrim
-  [t|T2|]
-  TPInfo {
-    tpinfoCxxType       = "T2"
-  , tpinfoCxxHeaders    = [ "TMFTestT2.h" ]
-  , tpinfoCxxNamespaces = []
-  , tpinfoSuffix        = "T2"
-  }
+  ( [t|T2|], TPInfo { tpinfoCxxType       = "T2"
+                    , tpinfoCxxHeaders    = [ "TMFTestT2.h" ]
+                    , tpinfoCxxNamespaces = []
+                    , tpinfoSuffix        = "T2"
+                    }
+  )
 
 genInstanceFor_a_method2
   NonCPrim
-  [t|T1|]
-  TPInfo {
-    tpinfoCxxType       = "T1"
-  , tpinfoCxxHeaders    = [ "TMFTestT1.h" ]
-  , tpinfoCxxNamespaces = []
-  , tpinfoSuffix        = "T1"
-  }
+  ( [t|T1|], TPInfo { tpinfoCxxType       = "T1"
+                    , tpinfoCxxHeaders    = [ "TMFTestT1.h" ]
+                    , tpinfoCxxNamespaces = []
+                    , tpinfoSuffix        = "T1"
+                    }
+  )
 
 main :: IO ()
 main = do

--- a/examples/unique_ptr/test.hs
+++ b/examples/unique_ptr/test.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings        #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE TemplateHaskell          #-}
 
 import qualified Data.ByteString.Char8 as B
 
@@ -16,12 +17,11 @@ import qualified STD.UniquePtr.TH as TH
 
 TH.genUniquePtrInstanceFor
   NonCPrim
-  [t|CppString|]
-  (TPInfo { tpinfoCxxType       = "std::string"
-          , tpinfoCxxHeaders    = [ HdrName "string", HdrName "stdcxxType.h" ]
-          , tpinfoCxxNamespaces = [ NS "std" ]
-          , tpinfoSuffix        = "string"
-          }
+  ( [t|CppString|], TPInfo { tpinfoCxxType       = "std::string"
+                           , tpinfoCxxHeaders    = [ HdrName "string", HdrName "stdcxxType.h" ]
+                           , tpinfoCxxNamespaces = [ NS "std" ]
+                           , tpinfoSuffix        = "string"
+                           }
   )
 
 main :: IO ()

--- a/examples/vector/test.hs
+++ b/examples/vector/test.hs
@@ -17,22 +17,20 @@ import qualified STD.Vector.TH as TH
 
 TH.genVectorInstanceFor
   CPrim
-  [t|CInt|]
-  (TPInfo { tpinfoCxxType       = "int"
-          , tpinfoCxxHeaders    = []
-          , tpinfoCxxNamespaces = []
-          , tpinfoSuffix        = "int"
-          }
+  ( [t|CInt|], TPInfo { tpinfoCxxType       = "int"
+                      , tpinfoCxxHeaders    = []
+                      , tpinfoCxxNamespaces = []
+                      , tpinfoSuffix        = "int"
+                      }
   )
 
 TH.genVectorInstanceFor
   NonCPrim
-  [t|CppString|]
-  (TPInfo { tpinfoCxxType       = "std::string"
-          , tpinfoCxxHeaders    = [ HdrName "string", HdrName "stdcxxType.h"]
-          , tpinfoCxxNamespaces = [ NS "std" ]
-          , tpinfoSuffix        = "string"
-          }
+  ( [t|CppString|], TPInfo { tpinfoCxxType       = "std::string"
+                           , tpinfoCxxHeaders    = [ HdrName "string", HdrName "stdcxxType.h"]
+                           , tpinfoCxxNamespaces = [ NS "std" ]
+                           , tpinfoSuffix        = "string"
+                           }
   )
 
 test1 :: IO ()

--- a/fficxx-runtime/src/FFICXX/Runtime/Cast.hs
+++ b/fficxx-runtime/src/FFICXX/Runtime/Cast.hs
@@ -10,41 +10,35 @@
 
 module FFICXX.Runtime.Cast where
 
-import Control.Monad         ((>=>))
 import Data.ByteString.Char8 (ByteString,packCString, useAsCString)
-import Data.String
 import Data.Word
 import Data.Int
 import Foreign.C
-import Foreign.C.String
-import Foreign.ForeignPtr
 import Foreign.Marshal.Array
 import Foreign.Ptr
-import Foreign.Storable
--- import System.IO.Unsafe
 
 
-class IsRawType a 
+class IsRawType a
 
 class Castable a b where
-  cast   :: a -> (b -> IO r) -> IO r 
-  uncast :: b -> (a -> IO r) -> IO r 
+  cast   :: a -> (b -> IO r) -> IO r
+  uncast :: b -> (a -> IO r) -> IO r
 
 class FPtr a where
   type Raw a :: *
-  get_fptr :: a -> Ptr (Raw a) 
+  get_fptr :: a -> Ptr (Raw a)
   cast_fptr_to_obj :: Ptr (Raw a) -> a
 
 
 class FunPtrWrappable a where
   type FunPtrHsType a :: *
   type FunPtrType a :: *
-  data FunPtrWrapped a :: *  
-  fptrWrap :: FunPtrWrapped a -> IO (FunPtr (FunPtrType a)) 
-  wrap :: FunPtrHsType a -> FunPtrWrapped a 
+  data FunPtrWrapped a :: *
+  fptrWrap :: FunPtrWrapped a -> IO (FunPtr (FunPtrType a))
+  wrap :: FunPtrHsType a -> FunPtrWrapped a
 
 
-class IsCType a where 
+class IsCType a where
 
 instance IsCType CBool
 instance IsCType CChar
@@ -238,33 +232,33 @@ instance Castable Word64 Word64 where
   cast x f = f x
   uncast x f = f x
 
-instance Castable (Ptr CInt) (Ptr CInt) where 
+instance Castable (Ptr CInt) (Ptr CInt) where
   cast x f = f x
-  uncast x f = f x 
+  uncast x f = f x
 
-instance Castable (Ptr CChar) (Ptr CChar) where 
-  cast x f = f x 
-  uncast x f = f x 
+instance Castable (Ptr CChar) (Ptr CChar) where
+  cast x f = f x
+  uncast x f = f x
 
-instance Castable (Ptr CUInt) (Ptr CUInt) where 
-  cast x f = f x 
-  uncast x f = f x 
+instance Castable (Ptr CUInt) (Ptr CUInt) where
+  cast x f = f x
+  uncast x f = f x
 
-instance Castable (Ptr CULong) (Ptr CULong) where 
-  cast x f = f x 
-  uncast x f = f x 
+instance Castable (Ptr CULong) (Ptr CULong) where
+  cast x f = f x
+  uncast x f = f x
 
-instance Castable (Ptr CLong) (Ptr CLong) where 
-  cast x f = f x 
-  uncast x f = f x 
+instance Castable (Ptr CLong) (Ptr CLong) where
+  cast x f = f x
+  uncast x f = f x
 
-instance Castable (Ptr CDouble) (Ptr CDouble) where 
-  cast x f = f x 
-  uncast x f = f x 
+instance Castable (Ptr CDouble) (Ptr CDouble) where
+  cast x f = f x
+  uncast x f = f x
 
-instance Castable (Ptr CString) (Ptr CString) where 
-  cast x f = f x 
-  uncast x f = f x 
+instance Castable (Ptr CString) (Ptr CString) where
+  cast x f = f x
+  uncast x f = f x
 
 instance Castable (Ptr ()) (Ptr ()) where
   cast x f = f x
@@ -290,81 +284,83 @@ instance Castable Word CUInt where
 instance Castable Word8 CChar where
   cast x f = f (fromIntegral x)
   uncast x f = f (fromIntegral x)
-  
+
 instance Castable Double CDouble where
   cast x f = f (realToFrac x)
   uncast x f = f (realToFrac x)
 
+-- TODO: remove this
 instance Castable [Double] (Ptr CDouble) where
-  cast xs f = newArray (map realToFrac xs) >>= f 
-  uncast xs f = undefined 
+  cast xs f = newArray (map realToFrac xs) >>= f
+  uncast _ _ = undefined
 
+-- TODO: remove this
 instance Castable [Int] (Ptr CInt) where
   cast xs f = newArray (map fromIntegral xs) >>= f
-  uncast xs f = undefined 
+  uncast _ _ = undefined
 
 instance Castable ByteString CString where
   cast x f = useAsCString x f
-  uncast x f = packCString x >>= f 
+  uncast x f = packCString x >>= f
 
-
+-- TODO: remove this
 instance Castable [ByteString] (Ptr CString) where
   cast xs f = do ys <- mapM (\x -> useAsCString x return) xs
                  withArray ys $ \cptr -> f cptr
-  uncast xs f = undefined 
+  uncast _ _ = undefined
 
-{- 
+{-
 instance Castable String CString where
   cast x = unsafePerformIO (newCString x)
-  uncast x = unsafePerformIO (peekCString x) 
+  uncast x = unsafePerformIO (peekCString x)
 
 
 instance (Castable a a', Castable b b') => Castable (a->b) (a'->b') where
   cast f = cast . f . uncast
-  uncast f = uncast . f . cast 
+  uncast f = uncast . f . cast
 -}
 
 xformnull :: (Castable a ca) => (IO ca) -> IO a
 xformnull f = f >>= \ca -> uncast ca return
 
-xform0 :: (Castable a ca, Castable y cy) 
+xform0 :: (Castable a ca, Castable y cy)
        => (ca -> IO cy) -> a -> IO y
 xform0 f a = cast a $ \ca -> f ca >>= \cy -> uncast cy return
 
-xform1 :: (Castable a ca, Castable x1 cx1, Castable y cy) 
+xform1 :: (Castable a ca, Castable x1 cx1, Castable y cy)
        => (ca -> cx1 -> IO cy) -> a -> x1 -> IO y
 xform1 f a x1 = cast a $ \ca ->
                   cast x1 $ \cx1 ->
-                    f ca cx1 >>= \cy -> uncast cy return 
+                    f ca cx1 >>= \cy -> uncast cy return
 
-xform2 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable y cy) 
+xform2 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable y cy)
        => (ca -> cx1 -> cx2 -> IO cy) -> a -> x1 -> x2-> IO y
 xform2 f a x1 x2 = cast a $ \ca ->
                      cast x1 $ \cx1 ->
                        cast x2 $ \cx2 ->
                          f ca cx1 cx2 >>= \cy -> uncast cy return
 
-xform3 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable y cy) 
+xform3 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable y cy)
        => (ca -> cx1 -> cx2 -> cx3 -> IO cy) -> a -> x1 -> x2 -> x3 -> IO y
 xform3 f a x1 x2 x3 = cast a $ \ca ->
                         cast x1 $ \cx1 ->
                           cast x2 $ \cx2 ->
                             cast x3 $ \cx3 ->
-                              f ca cx1 cx2 cx3 >>= \cy -> uncast cy return 
+                              f ca cx1 cx2 cx3 >>= \cy -> uncast cy return
 
-xform4 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4, Castable y cy) 
+xform4 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4, Castable y cy)
        => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> IO cy) -> a -> x1 -> x2 -> x3 -> x4 -> IO y
 xform4 f a x1 x2 x3 x4 =
   cast a $ \ca ->
     cast x1 $ \cx1 ->
       cast x2 $ \cx2 ->
         cast x3 $ \cx3 ->
-          cast x4 $ \cx4 -> 
-            f ca cx1 cx2 cx3 cx4 >>= \cy -> uncast cy return 
+          cast x4 $ \cx4 ->
+            f ca cx1 cx2 cx3 cx4 >>= \cy -> uncast cy return
 
 
 xform5 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
-           Castable x5 cx5, Castable y cy) 
+           Castable x5 cx5, Castable y cy)
        => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> IO cy) -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> IO y
 xform5 f a x1 x2 x3 x4 x5 =
   cast a $ \ca ->
@@ -372,28 +368,14 @@ xform5 f a x1 x2 x3 x4 x5 =
       cast x2 $ \cx2 ->
         cast x3 $ \cx3 ->
           cast x4 $ \cx4 ->
-            cast x5 $ \cx5 -> 
-              f ca cx1 cx2 cx3 cx4 cx5 >>= \cy -> uncast cy return 
+            cast x5 $ \cx5 ->
+              f ca cx1 cx2 cx3 cx4 cx5 >>= \cy -> uncast cy return
 
 xform6 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
-           Castable x5 cx5, Castable x6 cx6, Castable y cy) 
-       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> IO cy) 
+           Castable x5 cx5, Castable x6 cx6, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> IO cy)
           -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> IO y
-xform6 f a x1 x2 x3 x4 x5 x6 = 
-  cast a $ \ca ->
-    cast x1 $ \cx1 ->
-      cast x2 $ \cx2 ->
-        cast x3 $ \cx3 ->
-          cast x4 $ \cx4 ->
-            cast x5 $ \cx5 ->
-              cast x6 $ \cx6 -> 
-                f ca cx1 cx2 cx3 cx4 cx5 cx6 >>= \cy -> uncast cy return 
-  
-xform7 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
-           Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable y cy) 
-       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> IO cy) 
-          -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> IO y
-xform7 f a x1 x2 x3 x4 x5 x6 x7 = 
+xform6 f a x1 x2 x3 x4 x5 x6 =
   cast a $ \ca ->
     cast x1 $ \cx1 ->
       cast x2 $ \cx2 ->
@@ -401,13 +383,27 @@ xform7 f a x1 x2 x3 x4 x5 x6 x7 =
           cast x4 $ \cx4 ->
             cast x5 $ \cx5 ->
               cast x6 $ \cx6 ->
-                cast x7 $ \cx7 ->  
-                  f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 >>= \cy -> uncast cy return 
+                f ca cx1 cx2 cx3 cx4 cx5 cx6 >>= \cy -> uncast cy return
+
+xform7 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
+           Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> IO cy)
+          -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> IO y
+xform7 f a x1 x2 x3 x4 x5 x6 x7 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            cast x5 $ \cx5 ->
+              cast x6 $ \cx6 ->
+                cast x7 $ \cx7 ->
+                  f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 >>= \cy -> uncast cy return
 
 
 xform8 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
-           Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable y cy) 
-       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> IO cy) 
+           Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> IO cy)
           -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> x8 -> IO y
 xform8 f a x1 x2 x3 x4 x5 x6 x7 x8 =
   cast a $ \ca ->
@@ -418,33 +414,15 @@ xform8 f a x1 x2 x3 x4 x5 x6 x7 x8 =
             cast x5 $ \cx5 ->
               cast x6 $ \cx6 ->
                 cast x7 $ \cx7 ->
-                  cast x8 $ \cx8 ->  
-                    f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 >>= \cy -> uncast cy return 
+                  cast x8 $ \cx8 ->
+                    f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 >>= \cy -> uncast cy return
 
 xform9 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
-           Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9, 
-           Castable y cy) 
-       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> cx9 -> IO cy) 
+           Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
+           Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> cx9 -> IO cy)
           -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> x8 -> x9 -> IO y
-xform9 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 = 
-  cast a $ \ca ->
-    cast x1 $ \cx1 ->
-      cast x2 $ \cx2 ->
-        cast x3 $ \cx3 ->
-          cast x4 $ \cx4 ->
-            cast x5 $ \cx5 ->
-              cast x6 $ \cx6 ->
-                cast x7 $ \cx7 ->
-                  cast x8 $ \cx8 ->
-                    cast x9 $ \cx9 ->  
-                      f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 >>= \cy -> uncast cy return 
-
-xform10 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
-            Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,  
-            Castable x10 cx10, Castable y cy) 
-       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> cx9 -> cx10 -> IO cy) 
-          -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> x8 -> x9 -> x10 -> IO y
-xform10 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 = 
+xform9 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 =
   cast a $ \ca ->
     cast x1 $ \cx1 ->
       cast x2 $ \cx2 ->
@@ -455,13 +433,31 @@ xform10 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 =
                 cast x7 $ \cx7 ->
                   cast x8 $ \cx8 ->
                     cast x9 $ \cx9 ->
-                      cast x10 $ \cx10 ->  
-                        f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 >>= \cy -> uncast cy return 
+                      f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 >>= \cy -> uncast cy return
+
+xform10 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
+            Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
+            Castable x10 cx10, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> cx9 -> cx10 -> IO cy)
+          -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> x8 -> x9 -> x10 -> IO y
+xform10 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            cast x5 $ \cx5 ->
+              cast x6 $ \cx6 ->
+                cast x7 $ \cx7 ->
+                  cast x8 $ \cx8 ->
+                    cast x9 $ \cx9 ->
+                      cast x10 $ \cx10 ->
+                        f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 >>= \cy -> uncast cy return
 
 xform11 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
-            Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,  
-            Castable x10 cx10, Castable x11 cx11, Castable y cy) 
-       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> cx9 -> cx10 -> cx11 -> IO cy) 
+            Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
+            Castable x10 cx10, Castable x11 cx11, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> cx9 -> cx10 -> cx11 -> IO cy)
           -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> x8 -> x9 -> x10 -> x11 -> IO y
 xform11 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 =
   cast a $ \ca ->
@@ -475,6 +471,5 @@ xform11 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 =
                   cast x8 $ \cx8 ->
                     cast x9 $ \cx9 ->
                       cast x10 $ \cx10 ->
-                        cast x11 $ \cx11 ->  
-                         f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 >>= \cy -> uncast cy return 
-
+                        cast x11 $ \cx11 ->
+                         f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 >>= \cy -> uncast cy return

--- a/fficxx-runtime/src/FFICXX/Runtime/CodeGen/Cxx.hs
+++ b/fficxx-runtime/src/FFICXX/Runtime/CodeGen/Cxx.hs
@@ -90,14 +90,14 @@ renderCOp CArrow  = "->"
 renderCOp CAssign = "="
 
 data CExp (f :: * -> *) =
-    CVar (CName f)                      -- ^ variable
-  | CApp (CExp f) [CExp f]              -- ^ C function app:  f(a1,a2,..)
-  | CTApp (CName f ) [CType f] [CExp f] -- ^ template app  :  f<T1,T2,..>(a1,a2,..)
+    CVar  (CName f)                     -- ^ variable
+  | CApp  (CExp  f) [CExp f]            -- ^ C function app:  f(a1,a2,..)
+  | CTApp (CName f) [CType f] [CExp f]  -- ^ template app  :  f<T1,T2,..>(a1,a2,..)
   | CBinOp COp (CExp f) (CExp f)        -- ^ binary operator: x `op` y
   | CCast (CType f) (CExp f)            -- ^ (type)exp
   | CAddr (CExp f)                      -- ^ &(exp)
   | CStar (CExp f)                      -- ^ *(exp)
-  | CNew (CName f) [CExp f]             -- ^ new operator: new Cstr(a1,a2,...)
+  | CNew (CName f)  [CExp f]            -- ^ new operator: new Cstr(a1,a2,...)
   | CTNew (CName f) [CType f] [CExp f]  -- ^ new operator for template class: new Cstr<T1,T2,..>(a1,a2,..)
   | CEMacroApp (CName f) [CName f]      -- ^ macro function at expression level
   | CEVerbatim String                   -- ^ verbatim

--- a/fficxx-runtime/src/FFICXX/Runtime/CodeGen/Cxx.hs
+++ b/fficxx-runtime/src/FFICXX/Runtime/CodeGen/Cxx.hs
@@ -25,38 +25,6 @@ newtype Namespace =
 instance IsString Namespace where
   fromString = NS
 
--- | Dummy ~ Identity. For testing now.
-data Dummy a = Dummy { unDummy :: a }
-
--- data Op = Add | Mul
-
--- | embedded DSL for C++ code generation via interpretation
-data HExp =
-    Val Int
-  | Add HExp HExp
-  | Lam (HExp -> HExp)
-  | App HExp HExp
---   deriving Show
-
--- data HEval =
---     EVal Int
---   | ELam String HEval
-
--- data Evaluated =
---     EValue   Int                  -- ^ fully evaluated
---   | EClosure (HExp -> Evaluated)  -- ^ closure
-
--- pprint :: Evaluated -> String
--- pprint (EValue n) = show n
--- pprint (EClosure f) = "closure"
-
-eval :: HExp -> Int
-eval (Val v)   = v
-eval (Add x y) = eval x + eval y
-eval (Lam _)   = error "lambda"
-eval (App (Lam f) x) = eval (f x)
-
-
 data PragmaParam = Once
 
 -- | parts for interpolation

--- a/fficxx-runtime/src/FFICXX/Runtime/Function/TH.hs
+++ b/fficxx-runtime/src/FFICXX/Runtime/Function/TH.hs
@@ -64,22 +64,26 @@ genFunctionInstanceFor qtyp param
        wrap <- mkWrapper (typ,suffix)
        addModFinalizer
          (addForeignSource LangCxx
-            ("\n#include \"functional\"\n\n\n#include \"Function.h\"\n\n"
-             ++ let headers = fpinfoCxxHeaders param
+           ("\n#include \"functional\"\n\n\n#include \"Function.h\"\n\n"
+            ++ (let headers = fpinfoCxxHeaders param
                     f x = renderCMacro (Include x)
                 in concatMap f headers
-             ++ let nss = fpinfoCxxNamespaces param
+               )
+            ++ (let nss = fpinfoCxxNamespaces param
                     f x = renderCStmt (UsingNamespace x)
                 in concatMap f nss
-             ++ let retstr = fromMaybe "void" (fpinfoCxxRetType param)
+               )
+            ++ (let retstr = fromMaybe "void" (fpinfoCxxRetType param)
                     argstr = let args = fpinfoCxxArgTypes param
                                  vs = case args of
                                         [] -> "(,)"
                                         _ -> intercalate "," $
                                                map (\(t,x) -> "(" ++ t ++ "," ++ x ++ ")") args
                              in "(" ++ vs ++ ")"
-                in "Function(" ++ suffix ++ "," ++ retstr ++ "," ++ argstr ++ ")\n"))
-
+                in "Function(" ++ suffix ++ "," ++ retstr ++ "," ++ argstr ++ ")\n"
+               )
+           )
+         )
        let lst = [f1,f2,f3]
        return [ mkInstance [] (AppT (con "IFunction") typ) lst
               , mkInstance [] (AppT (con "FunPtrWrapper") typ) [wrap]

--- a/fficxx-runtime/src/FFICXX/Runtime/TH.hs
+++ b/fficxx-runtime/src/FFICXX/Runtime/TH.hs
@@ -12,27 +12,31 @@ import Language.Haskell.TH.Syntax ( Body(NormalB), Callconv(CCall)
 import FFICXX.Runtime.CodeGen.Cxx ( HeaderName, Namespace)
 
 
--- |
+-- | Primitive C type like int, double should be treated differently than
+--   Non-primitive type. The primitive type detection is not yet automatic.
+--   So we manually mark template instantiation with this boolean parameter.
+data IsCPrimitive =
+    CPrim
+  | NonCPrim
+  deriving Show
+
+
+-- | template parameter: A,B,.. in T<A,B..>
 data TemplateParamInfo =
   TPInfo {
     tpinfoCxxType       :: String
+  -- , tpinfoIsCPrimitive  :: IsCPrimitive  -- ^ whether the parameter is C-primitive type
   , tpinfoCxxHeaders    :: [HeaderName]
   , tpinfoCxxNamespaces :: [Namespace]
   , tpinfoSuffix        :: String
   }
   deriving Show
 
--- | Primitive C type like int, double should be treated differently than
---   Non-primitive type. The primitive type detection is not yet automatic.
---   So we manually mark template instantiation with this boolean parameter.
-data IsCPrimitive = CPrim | NonCPrim
-
-
--- | function pointer parameter for std::function
+-- | function pointer parameter A(B,C,..) in std::function<A(B,C,..)>
 data FunctionParamInfo =
   FPInfo {
     fpinfoCxxArgTypes   :: [(String,String)]
-  , fpinfoCxxRetType    :: Maybe String -- Nothing = void
+  , fpinfoCxxRetType    :: Maybe String
   , fpinfoCxxHeaders    :: [HeaderName]
   , fpinfoCxxNamespaces :: [Namespace]
   , fpinfoSuffix        :: String

--- a/fficxx-runtime/src/FFICXX/Runtime/TH.hs
+++ b/fficxx-runtime/src/FFICXX/Runtime/TH.hs
@@ -48,17 +48,17 @@ mkInstance :: Cxt -> Type -> [Dec] -> Dec
 mkInstance = InstanceD Nothing
 
 
-mkTFunc :: (Type, String, String -> String, Type -> Q Type) -> Q Exp
-mkTFunc (typ, suffix, nf, tyf)
+mkTFunc :: (types, String, String -> String, types -> Q Type) -> Q Exp
+mkTFunc (typs, suffix, nf, tyf)
   = do let fn = nf suffix
        let fn' = "c_" <> fn
        n <- newName fn'
-       d <- forImpD CCall safe fn n (tyf typ)
+       d <- forImpD CCall safe fn n (tyf typs)
        addTopDecls [d]
        [| $( varE n ) |]
 
 
-mkMember :: String -> (Type -> String -> Q Exp) -> Type -> String -> Q Dec
+mkMember :: String -> (types -> String -> Q Exp) -> types -> String -> Q Dec
 mkMember fname f typ suffix = do
   let x = mkNameS "x"
   e <- f typ suffix
@@ -66,7 +66,7 @@ mkMember fname f typ suffix = do
     FunD (mkNameS fname) [ Clause [VarP x] (NormalB (AppE e (VarE x))) [] ]
 
 
-mkNew :: String -> (Type -> String -> Q Exp) -> Type -> String -> Q Dec
+mkNew :: String -> (types -> String -> Q Exp) -> types -> String -> Q Dec
 mkNew fname f typ suffix = do
   e <- f typ suffix
   pure $
@@ -74,5 +74,5 @@ mkNew fname f typ suffix = do
       [ Clause [] (NormalB e) [] ]
 
 
-mkDelete :: String -> (Type -> String -> Q Exp) -> Type -> String -> Q Dec
+mkDelete :: String -> (types -> String -> Q Exp) -> types -> String -> Q Dec
 mkDelete = mkMember

--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -40,7 +40,6 @@ import           FFICXX.Generate.Type.Class              ( hasProxy )
 import           FFICXX.Generate.Type.Module             ( ClassImportHeader(..)
                                                          , ClassModule(..)
                                                          , PackageConfig(..)
-                                                         , TemplateClassImportHeader(..)
                                                          , TemplateClassModule(..)
                                                          , TopLevelImportHeader(..)
                                                          )
@@ -111,11 +110,7 @@ simpleBuilder cfg sbc = do
   gen
     (tihHeaderFileName tih <.> "h")
     (buildTopLevelHeader (unCabalName pkgname) tih)
-  for_ tcms $ \m ->
-    let tcih = tcmTCIH m
-        hdr = unHdrName (tcihSelfHeader tcih)
-    in gen hdr (buildTemplateHeader tcih)
-  --
+
   putStrLn "Generating Cpp file"
   for_ cihs (\hdr -> gen (cihSelfCpp hdr) (buildDefMain hdr))
   gen (tihHeaderFileName tih <.> "cpp") (buildTopLevelCppDef tih)
@@ -213,7 +208,7 @@ copyFileWithMD5Check src tgt = do
 
 
 copyCppFiles :: FilePath -> FilePath -> String -> PackageConfig -> IO ()
-copyCppFiles wdir ddir cprefix (PkgConfig _ cihs tih _ tcihs acincs acsrcs) = do
+copyCppFiles wdir ddir cprefix (PkgConfig _ cihs tih _ _tcihs acincs acsrcs) = do
   let thfile = cprefix <> "Type.h"
       tlhfile = tihHeaderFileName tih <.> "h"
       tlcppfile = tihHeaderFileName tih <.> "cpp"
@@ -227,10 +222,6 @@ copyCppFiles wdir ddir cprefix (PkgConfig _ cihs tih _ tcihs acincs acsrcs) = do
         cppfile = cihSelfCpp header
     copyFileWithMD5Check (wdir </> hfile) (ddir </> hfile)
     copyFileWithMD5Check (wdir </> cppfile) (ddir </> cppfile)
-
-  for_ tcihs $ \header-> do
-    let hfile = unHdrName (tcihSelfHeader header)
-    copyFileWithMD5Check (wdir </> hfile) (ddir </> hfile)
 
   for_ acincs $ \(AddCInc header _) ->
     copyFileWithMD5Check (wdir </> header) (ddir </> header)

--- a/fficxx/src/FFICXX/Generate/Code/Cabal.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Cabal.hs
@@ -70,7 +70,7 @@ genIncludeFiles :: String        -- ^ package name
                 -> [AddCInc]
                 -> [String]
 genIncludeFiles pkgname (cih,tcih) acincs =
-  let selfheaders = map cihSelfHeader cih <> map tcihSelfHeader tcih
+  let selfheaders = map cihSelfHeader cih --  <> map tcihSelfHeader tcih
       includeFileStrs = map unHdrName (selfheaders ++ map (\(AddCInc hdr _) -> HdrName hdr) acincs)
   in (pkgname<>"Type.h") : includeFileStrs
 

--- a/fficxx/src/FFICXX/Generate/Code/Cabal.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Cabal.hs
@@ -41,8 +41,7 @@ genCsrcFiles :: (TopLevelImportHeader,[ClassModule])
              -> [AddCSrc]
              -> [String]
 genCsrcFiles (tih,cmods) acincs acsrcs =
-  let -- indent = cabalIndentation
-      selfheaders' = do
+  let selfheaders' = do
         x <- cmods
         let y = cmCIH x
         return (cihSelfHeader y)
@@ -69,12 +68,10 @@ genIncludeFiles :: String        -- ^ package name
                 -> ([ClassImportHeader],[TemplateClassImportHeader])
                 -> [AddCInc]
                 -> [String]
-genIncludeFiles pkgname (cih,tcih) acincs =
-  let selfheaders = map cihSelfHeader cih --  <> map tcihSelfHeader tcih
+genIncludeFiles pkgname (cih,_tcih) acincs =
+  let selfheaders = map cihSelfHeader cih
       includeFileStrs = map unHdrName (selfheaders ++ map (\(AddCInc hdr _) -> HdrName hdr) acincs)
   in (pkgname<>"Type.h") : includeFileStrs
-
-
 
 -- for library
 genCppFiles :: (TopLevelImportHeader,[ClassModule])

--- a/fficxx/src/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Cpp.hs
@@ -281,14 +281,15 @@ genTmplClassCpp ::
   -> [TemplateFunction]
   -> R.CMacro Identity
 genTmplClassCpp b TmplCls {..} fs =
-    R.Define (R.sname macroname) [R.sname "Type"] (map macro1 fs)
+    R.Define (R.sname macroname) params (map macro1 fs)
  where
+  params = map R.sname tclass_params
   suffix = case b of { CPrim -> "_s"; NonCPrim -> "" }
   tname = tclass_name
   macroname = tname <> "_instance" <> suffix
-  macro1 f@TFun {..}    = R.CMacroApp (R.sname (tname <> "_" <> ffiTmplFuncName f <> suffix)) [R.sname "Type"]
-  macro1 f@TFunNew {..} = R.CMacroApp (R.sname (tname <> "_" <> ffiTmplFuncName f))           [R.sname "Type"]
-  macro1 TFunDelete     = R.CMacroApp (R.sname (tname <> "_delete"))                          [R.sname "Type"]
+  macro1 f@TFun {..}    = R.CMacroApp (R.sname (tname <> "_" <> ffiTmplFuncName f <> suffix)) params
+  macro1 f@TFunNew {..} = R.CMacroApp (R.sname (tname <> "_" <> ffiTmplFuncName f))           params
+  macro1 TFunDelete     = R.CMacroApp (R.sname (tname <> "_delete"))                          params
 
 returnCpp ::
      IsCPrimitive

--- a/fficxx/src/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Cpp.hs
@@ -21,7 +21,6 @@ import FFICXX.Generate.Code.Primitive
                                     , CFunSig(..)
                                     , genericFuncArgs
                                     , genericFuncRet
-                                    -- , mkTmplTypeParams
                                     , returnCType
                                     , tmplMemFuncArgToCTypVar
                                     , tmplMemFuncRetTypeToString

--- a/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
@@ -2,13 +2,13 @@
 
 module FFICXX.Generate.Code.HsProxy where
 
-import Language.Haskell.Exts.Build    ( app, doE, qualStmt, strE )
+import Language.Haskell.Exts.Build    ( app, doE, listE, qualStmt, strE )
 import qualified Data.List as L       ( foldr1 )
 import Language.Haskell.Exts.Syntax   ( Decl(..) )
 --
 import qualified FFICXX.Runtime.CodeGen.Cxx as R
 import FFICXX.Generate.Util.HaskellSrcExts
-                                      ( con, inapp, list, mkFun, mkPVar, mkVar
+                                      ( con, inapp, mkFun, mkPVar, mkVar
                                       , op, qualifier
                                       , tyapp, tycon, tylist
                                       )
@@ -35,5 +35,4 @@ genProxyInstance =
             includeStatic =
               strE $ concatMap (<> "\n")
                 [ R.renderCMacro (R.Include "MacroPatternMatch.h") ]
-        retstmt = v "pure"
-                  `app` list []
+        retstmt = v "pure" `app` listE []

--- a/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
@@ -8,7 +8,7 @@ import Language.Haskell.Exts.Syntax   ( Decl(..) )
 --
 import qualified FFICXX.Runtime.CodeGen.Cxx as R
 import FFICXX.Generate.Util.HaskellSrcExts
-                                      ( con, inapp, mkFun, mkPVar, mkVar
+                                      ( con, inapp, mkFun, mkVar
                                       , op, qualifier
                                       , tyapp, tycon, tylist
                                       )
@@ -18,7 +18,6 @@ genProxyInstance :: [Decl ()]
 genProxyInstance =
     mkFun fname sig [] rhs Nothing
   where fname = "genImplProxy"
-        p = mkPVar
         v = mkVar
         sig = tycon "Q" `tyapp` tylist (tycon "Dec")
         rhs = doE [foreignSrcStmt, qualStmt retstmt]

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -278,21 +278,21 @@ genTmplInstance tcih =
           where
             -- temporary
 
-            deffunc = let
-                        t = tcihTClass tcih
-                        fs = tclass_funcs t
-                      in    map (R.renderCMacro . genTmplFunCpp NonCPrim t) fs
-                         ++ map (R.renderCMacro . genTmplFunCpp CPrim    t) fs
-                         ++ [ R.renderCMacro (genTmplClassCpp NonCPrim t fs)
-                            , R.renderCMacro (genTmplClassCpp CPrim    t fs)
-                            ]
+            body = let
+                     t = tcihTClass tcih
+                     fs = tclass_funcs t
+                   in map R.renderCMacro $
+                           map R.Include (tcihCxxHeaders tcih)
+                        ++ map (genTmplFunCpp NonCPrim t) fs
+                        ++ map (genTmplFunCpp CPrim    t) fs
+                        ++ [ genTmplClassCpp NonCPrim t fs
+                           , genTmplClassCpp CPrim    t fs
+                           ]
 
             includeStatic =
               strE $ concatMap (<> "\n")
-                       (   [ R.renderCMacro (R.Include (HdrName "MacroPatternMatch.h"))
-                           , R.renderCMacro (R.Include (tcihSelfHeader tcih))
-                           ]
-                        ++ deffunc
+                       (   [ R.renderCMacro (R.Include (HdrName "MacroPatternMatch.h")) ]
+                        ++ body
                        )
             includeDynamic =
               letE

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -156,10 +156,10 @@ genTmplInterface t =
   , mkInstance cxEmpty "Castable" [ hightype, tyapp tyPtr rawtype ] castBody
   ]
  where (hname,rname) = hsTemplateClassName t
-       tp = tclass_param t
+       tps = tclass_params t
        fs = tclass_funcs t
-       rawtype = tyapp (tycon rname) (mkTVar tp)
-       hightype = tyapp (tycon hname) (mkTVar tp)
+       rawtype  = foldl1 tyapp (tycon rname : map mkTVar tps)
+       hightype = foldl1 tyapp (tycon hname : map mkTVar tps)
        sigdecl f = mkFunSig (hsTmplFuncName t f) (functionSignatureT t f)
        methods = map (clsDecl . sigdecl) fs
        fptrbody = [ insType (tyapp (tycon "Raw") hightype) rawtype
@@ -177,7 +177,7 @@ genTmplImplementation t = concatMap gen (tclass_funcs t)
             sig = tycon "Type" `tyfun` (tycon "String" `tyfun` (tyapp (tycon "Q") (tycon "Exp")))
             v = mkVar
             p = mkPVar
-            tp = tclass_param t
+            tps = tclass_params t
             prefix = tclass_name t
             lit' = strE (prefix<>"_"<>nc<>"_")
             lam = lambda [p "n"] ( lit' `app` v "<>" `app` v "n")

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -3,7 +3,7 @@
 module FFICXX.Generate.Code.HsTemplate where
 
 import Data.Monoid                    ( (<>) )
-import qualified Data.List as L       ( foldr1, intercalate )
+import qualified Data.List as L       ( foldr1 )
 import Language.Haskell.Exts.Build    ( app, binds, caseE, doE
                                       , lamE, letE, letStmt, listE, name
                                       , pApp, paren, pTuple
@@ -191,7 +191,7 @@ genTmplImplementation t = concatMap gen (tclass_funcs t)
             sig = foldr1 tyfun [tparams , tycon "String", tyapp (tycon "Q") (tycon "Exp") ]
             tvars_p = if nparams == 1 then map p tvars else [pTuple (map p tvars)]
             prefix = tclass_name t
-            lit' = strE (prefix<>"_"<>nc) -- <>"_")
+            lit' = strE (prefix<>"_"<>nc)
             lam = lamE [p "n"] ( lit' `app` v "<>" `app` v "n")
             rhs = app (v "mkTFunc") $
                     let typs = if nparams == 1 then map v tvars else [tuple (map v tvars)]
@@ -299,17 +299,13 @@ genTmplInstance tcih =
                   )
           where
             -- temporary
-            body = let
-                     t = tcihTClass tcih
-                     fs = tclass_funcs t
-                   in map R.renderCMacro $
-                           map R.Include (tcihCxxHeaders tcih)
-                        ++ map (genTmplFunCpp NonCPrim t) fs
-                        ++ map (genTmplFunCpp CPrim    t) fs
-                        ++ [ genTmplClassCpp NonCPrim t fs
-                           , genTmplClassCpp CPrim    t fs
-                           ]
-
+            body = map R.renderCMacro $
+                        map R.Include (tcihCxxHeaders tcih)
+                     ++ map (genTmplFunCpp NonCPrim t) fs
+                     ++ map (genTmplFunCpp CPrim    t) fs
+                     ++ [ genTmplClassCpp NonCPrim t fs
+                        , genTmplClassCpp CPrim    t fs
+                        ]
             includeStatic =
               strE $ concatMap (<> "\n")
                        (   [ R.renderCMacro (R.Include (HdrName "MacroPatternMatch.h")) ]
@@ -331,7 +327,6 @@ genTmplInstance tcih =
                     (v "renderCStmt" `app` (con "UsingNamespace" `app` v "x"))
                 ]
                 (v "concatMap" `app` v "f" `app` v "nss")
-
 
         retstmt = v "pure"
                   `app` listE [ v "mkInstance"

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -473,6 +473,7 @@ buildTHHs m =
   mkModule (tcmModule m <.> "TH")
     [ lang  ["TemplateHaskell"] ]
     (   [ mkImport "Data.Char"
+        , mkImport "Data.List"
         , mkImport "Data.Monoid"
         , mkImport "Foreign.C.Types"
         , mkImport "Foreign.Ptr"

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -307,11 +307,11 @@ buildTemplateHeader tcih =
   let t = tcihTClass tcih
       fs = tclass_funcs t
       headerStmts = map R.Include (tcihCxxHeaders tcih)
-      deffunc =    intercalate "\n"
-                     (map (R.renderCMacro . genTmplFunCpp NonCPrim t) fs)
-                ++ "\n\n"
-                ++ intercalate "\n"
-                     (map (R.renderCMacro . genTmplFunCpp CPrim    t) fs)
+      -- deffunc =    intercalate "\n"
+      --                (map (R.renderCMacro . genTmplFunCpp NonCPrim t) fs)
+      --          ++ "\n\n"
+      --          ++ intercalate "\n"
+      --               (map (R.renderCMacro . genTmplFunCpp CPrim    t) fs)
       classlevel =    R.renderCMacro (genTmplClassCpp NonCPrim t fs)
                    ++ "\n\n"
                    ++ R.renderCMacro (genTmplClassCpp CPrim    t fs)
@@ -320,11 +320,11 @@ buildTemplateHeader tcih =
           , R.EmptyLine
           ]
        <> headerStmts
-       <> [ R.EmptyLine
-          , R.Verbatim deffunc
-          , R.EmptyLine
-          , R.Verbatim classlevel
-          ]
+       -- <> [ R.EmptyLine
+       --   -- , R.Verbatim deffunc
+       --   -- , R.EmptyLine
+       --   , R.Verbatim classlevel
+       --   ]
 
 -- |
 buildFFIHsc :: ClassModule -> Module ()

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -300,33 +300,6 @@ buildTopLevelCppDef tih =
        )
 
 -- |
-buildTemplateHeader ::
-     TemplateClassImportHeader
-  -> String
-buildTemplateHeader tcih =
-  let t = tcihTClass tcih
-      fs = tclass_funcs t
-      headerStmts = map R.Include (tcihCxxHeaders tcih)
-      -- deffunc =    intercalate "\n"
-      --                (map (R.renderCMacro . genTmplFunCpp NonCPrim t) fs)
-      --          ++ "\n\n"
-      --          ++ intercalate "\n"
-      --               (map (R.renderCMacro . genTmplFunCpp CPrim    t) fs)
-      classlevel =    R.renderCMacro (genTmplClassCpp NonCPrim t fs)
-                   ++ "\n\n"
-                   ++ R.renderCMacro (genTmplClassCpp CPrim    t fs)
-  in concatMap R.renderCMacro $
-          [ R.Pragma R.Once
-          , R.EmptyLine
-          ]
-       <> headerStmts
-       -- <> [ R.EmptyLine
-       --   -- , R.Verbatim deffunc
-       --   -- , R.EmptyLine
-       --   , R.Verbatim classlevel
-       --   ]
-
--- |
 buildFFIHsc :: ClassModule -> Module ()
 buildFFIHsc m = mkModule (mname <.> "FFI") [lang ["ForeignFunctionInterface"]] ffiImports hscBody
   where mname = cmModule m

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -19,7 +19,6 @@ import System.FilePath                        ( (<.>), (</>) )
 --
 import FFICXX.Runtime.CodeGen.Cxx             ( HeaderName(..) )
 import qualified FFICXX.Runtime.CodeGen.Cxx as R
-import FFICXX.Runtime.TH                      ( IsCPrimitive(CPrim,NonCPrim) )
 --
 import FFICXX.Generate.Code.Cpp               ( genAllCppHeaderInclude
                                               , genCppDefMacroAccessor
@@ -36,8 +35,6 @@ import FFICXX.Generate.Code.Cpp               ( genAllCppHeaderInclude
                                               , genCppHeaderMacroType
                                               , genCppHeaderMacroVirtual
                                               , genCppHeaderMacroNonVirtual
-                                              , genTmplClassCpp
-                                              , genTmplFunCpp
                                               , genTopLevelFuncCppDefinition
                                               , topLevelFunDecl
                                               )
@@ -81,7 +78,6 @@ import FFICXX.Generate.Type.Class             ( Class(..)
                                               , ClassGlobal(..)
                                               , DaughterMap
                                               , ProtectedMethod(..)
-                                              , TemplateClass(..)
                                               , isAbstractClass
                                               )
 import FFICXX.Generate.Type.Module            ( ClassImportHeader(..)

--- a/fficxx/src/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Class.hs
@@ -270,16 +270,16 @@ data TemplateFunction =
 
 data TemplateClass =
   TmplCls {
-    tclass_cabal :: Cabal
-  , tclass_name  :: String
-  , tclass_oname :: String
-  , tclass_param :: String
-  , tclass_funcs :: [TemplateFunction]
+    tclass_cabal  :: Cabal
+  , tclass_name   :: String
+  , tclass_oname  :: String
+  , tclass_params :: [String]
+  , tclass_funcs  :: [TemplateFunction]
   }
 
 -- TODO: we had better not override standard definitions
 instance Show TemplateClass where
-  show x = show (tclass_name x <> " " <> tclass_param x) -- intercalate " " (tclass_params x))
+  show x = show (tclass_name x <> " " <> intercalate " " (tclass_params x))
 
 -- TODO: we had better not override standard definitions
 instance Eq TemplateClass where

--- a/fficxx/src/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Class.hs
@@ -5,11 +5,12 @@
 
 module FFICXX.Generate.Type.Class where
 
+import           Data.List                         ( intercalate )
 import qualified Data.Map                     as M
-import           Data.Monoid                       (Monoid(..))
-import           Data.Semigroup                    (Semigroup(..),(<>))
+import           Data.Monoid                       ( Monoid(..) )
+import           Data.Semigroup                    ( Semigroup(..), (<>) )
 --
-import           FFICXX.Generate.Type.Cabal
+import           FFICXX.Generate.Type.Cabal        ( Cabal )
 
 
 -- | C types
@@ -252,27 +253,33 @@ instance Ord Class where
   compare x y = compare (class_name x) (class_name y)
 
 
-data TemplateFunction = TFun { tfun_ret :: Types
-                             , tfun_name :: String
-                             , tfun_oname :: String
-                             , tfun_args :: [Arg]
-                             , tfun_alias :: Maybe String }
-                      | TFunNew { tfun_new_args :: [Arg]
-                                , tfun_new_alias :: Maybe String
-                                }
-                      | TFunDelete
+data TemplateFunction =
+    TFun {
+      tfun_ret :: Types
+    , tfun_name :: String
+    , tfun_oname :: String
+    , tfun_args :: [Arg]
+    , tfun_alias :: Maybe String
+    }
+  | TFunNew {
+      tfun_new_args :: [Arg]
+    , tfun_new_alias :: Maybe String
+    }
+  | TFunDelete
 
 
-data TemplateClass = TmplCls { tclass_cabal :: Cabal
-                             , tclass_name :: String
-                             , tclass_oname :: String
-                             , tclass_param :: String
-                             , tclass_funcs :: [TemplateFunction]
-                             }
+data TemplateClass =
+  TmplCls {
+    tclass_cabal :: Cabal
+  , tclass_name  :: String
+  , tclass_oname :: String
+  , tclass_param :: String
+  , tclass_funcs :: [TemplateFunction]
+  }
 
 -- TODO: we had better not override standard definitions
 instance Show TemplateClass where
-  show x = show (tclass_name x <> " " <> tclass_param x)
+  show x = show (tclass_name x <> " " <> tclass_param x) -- intercalate " " (tclass_params x))
 
 -- TODO: we had better not override standard definitions
 instance Eq TemplateClass where

--- a/fficxx/src/FFICXX/Generate/Type/Module.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Module.hs
@@ -52,7 +52,7 @@ data TemplateClassModule =
 data TemplateClassImportHeader =
   TCIH {
     tcihTClass :: TemplateClass
-  , tcihSelfHeader :: HeaderName   -- ^ fficxx-side main header
+  -- , tcihSelfHeader :: HeaderName   -- ^ fficxx-side main header
   , tcihCxxHeaders :: [HeaderName] -- ^ C++-side headers
   } deriving (Show)
 

--- a/fficxx/src/FFICXX/Generate/Util/HaskellSrcExts.hs
+++ b/fficxx/src/FFICXX/Generate/Util/HaskellSrcExts.hs
@@ -194,10 +194,8 @@ emodule nm = EModuleContents () (ModuleName () nm)
 
 nonamespace = NoNamespace ()
 
-list = List ()
-lambda = Lambda ()
-
 insType = InsType ()
+
 insDecl = InsDecl ()
 
 generator = Generator ()

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -97,6 +97,14 @@ classes = [ deletable
 toplevelfunctions :: [TopLevelFunction]
 toplevelfunctions = [ ]
 
+t_map :: TemplateClass
+t_map =
+  TmplCls cabal "Map" "std::map" ["k","v"]
+    [ TFunNew [] Nothing
+    , TFun int_  "size" "size" [] Nothing
+    , TFunDelete
+    ]
+
 t_vector :: TemplateClass
 t_vector =
   TmplCls cabal "Vector" "std::vector" ["t"]
@@ -132,9 +140,10 @@ t_shared_ptr =
 
 templates :: [TemplateClassImportHeader]
 templates =
-  [ TCIH t_vector     (HdrName "Vector.h")    [HdrName "vector"]
-  , TCIH t_unique_ptr (HdrName "UniquePtr.h") [HdrName "memory"]
-  , TCIH t_shared_ptr (HdrName "SharedPtr.h") [HdrName "memory"]
+  [ TCIH t_map        "Map.h"       ["map"]
+  , TCIH t_vector     "Vector.h"    ["vector"]
+  , TCIH t_unique_ptr "UniquePtr.h" ["memory"]
+  , TCIH t_shared_ptr "SharedPtr.h" ["memory"]
   ]
 
 headers :: [ (ModuleUnit, ModuleUnitImports) ]

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -99,7 +99,7 @@ toplevelfunctions = [ ]
 
 t_map :: TemplateClass
 t_map =
-  TmplCls cabal "Map" "std::map" ["k","v"]
+  TmplCls cabal "Map" "std::map" ["tpk","tpv"]
     [ TFunNew [] Nothing
     , TFun int_  "size" "size" [] Nothing
     , TFunDelete
@@ -107,32 +107,32 @@ t_map =
 
 t_vector :: TemplateClass
 t_vector =
-  TmplCls cabal "Vector" "std::vector" ["t"]
+  TmplCls cabal "Vector" "std::vector"      ["tp1"]
     [ TFunNew [] Nothing
-    , TFun void_ "push_back" "push_back" [Arg (TemplateParam "t") "x"] Nothing
-    , TFun void_ "pop_back"  "pop_back"  []                        Nothing
-    , TFun (TemplateParam "t") "at" "at" [int "n"]                 Nothing
-    , TFun int_  "size"      "size"      []                        Nothing
+    , TFun void_ "push_back" "push_back"    [Arg (TemplateParam "tp1") "x"] Nothing
+    , TFun void_ "pop_back"  "pop_back"     []                        Nothing
+    , TFun (TemplateParam "tp1") "at" "at" [int "n"]                 Nothing
+    , TFun int_  "size"      "size"         []                        Nothing
     , TFunDelete
     ]
 
 t_unique_ptr :: TemplateClass
 t_unique_ptr =
-  TmplCls cabal "UniquePtr" "std::unique_ptr" ["t"]
+  TmplCls cabal "UniquePtr" "std::unique_ptr" ["tp1"]
     [ TFunNew [] (Just "newUniquePtr0")
-    , TFunNew [Arg (TemplateParamPointer "t") "p"] Nothing
-    , TFun (TemplateParamPointer "t") "get" "get" [] Nothing
-    , TFun (TemplateParamPointer "t") "release" "release" [] Nothing
+    , TFunNew [Arg (TemplateParamPointer "tp1") "p"] Nothing
+    , TFun (TemplateParamPointer "tp1") "get" "get" [] Nothing
+    , TFun (TemplateParamPointer "tp1") "release" "release" [] Nothing
     , TFun void_ "reset" "reset" [] Nothing
     , TFunDelete
     ]
 
 t_shared_ptr :: TemplateClass
 t_shared_ptr =
-  TmplCls cabal "SharedPtr" "std::shared_ptr" ["t"]
+  TmplCls cabal "SharedPtr" "std::shared_ptr" ["tp1"]
     [ TFunNew [] (Just "newSharedPtr0")
-    , TFunNew [Arg (TemplateParamPointer "t") "p"] Nothing
-    , TFun (TemplateParamPointer "t") "get" "get" [] Nothing
+    , TFunNew [Arg (TemplateParamPointer "tp1") "p"] Nothing
+    , TFun (TemplateParamPointer "tp1") "get" "get" [] Nothing
     , TFun void_ "reset" "reset" [] Nothing
     , TFun int_ "use_count" "use_count" [] Nothing
     , TFunDelete

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -99,7 +99,7 @@ toplevelfunctions = [ ]
 
 t_vector :: TemplateClass
 t_vector =
-  TmplCls cabal "Vector" "std::vector" "t"
+  TmplCls cabal "Vector" "std::vector" ["t"]
     [ TFunNew [] Nothing
     , TFun void_ "push_back" "push_back" [Arg (TemplateParam "t") "x"] Nothing
     , TFun void_ "pop_back"  "pop_back"  []                        Nothing
@@ -110,7 +110,7 @@ t_vector =
 
 t_unique_ptr :: TemplateClass
 t_unique_ptr =
-  TmplCls cabal "UniquePtr" "std::unique_ptr" "t"
+  TmplCls cabal "UniquePtr" "std::unique_ptr" ["t"]
     [ TFunNew [] (Just "newUniquePtr0")
     , TFunNew [Arg (TemplateParamPointer "t") "p"] Nothing
     , TFun (TemplateParamPointer "t") "get" "get" [] Nothing
@@ -121,7 +121,7 @@ t_unique_ptr =
 
 t_shared_ptr :: TemplateClass
 t_shared_ptr =
-  TmplCls cabal "SharedPtr" "std::shared_ptr" "t"
+  TmplCls cabal "SharedPtr" "std::shared_ptr" ["t"]
     [ TFunNew [] (Just "newSharedPtr0")
     , TFunNew [Arg (TemplateParamPointer "t") "p"] Nothing
     , TFun (TemplateParamPointer "t") "get" "get" [] Nothing

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -140,10 +140,10 @@ t_shared_ptr =
 
 templates :: [TemplateClassImportHeader]
 templates =
-  [ TCIH t_map        "Map.h"       ["map"]
-  , TCIH t_vector     "Vector.h"    ["vector"]
-  , TCIH t_unique_ptr "UniquePtr.h" ["memory"]
-  , TCIH t_shared_ptr "SharedPtr.h" ["memory"]
+  [ TCIH t_map        ["map"]
+  , TCIH t_vector     ["vector"]
+  , TCIH t_unique_ptr ["memory"]
+  , TCIH t_shared_ptr ["memory"]
   ]
 
 headers :: [ (ModuleUnit, ModuleUnitImports) ]

--- a/workspace/build.sh
+++ b/workspace/build.sh
@@ -39,3 +39,8 @@ cabal new-exec -- runhaskell -- -fobject-code -O0 template-member/app.hs
 runhaskell ./proxy/Gen.hs ./proxy/template
 cabal new-build proxy-test
 cabal new-exec -- runhaskell -- -iproxy -fobject-code -O0 proxy/app.hs
+
+# map
+rm map/test.o map/test
+cabal new-exec -- ghc map/test.hs
+./map/test

--- a/workspace/build.sh
+++ b/workspace/build.sh
@@ -41,6 +41,6 @@ cabal new-build proxy-test
 cabal new-exec -- runhaskell -- -iproxy -fobject-code -O0 proxy/app.hs
 
 # map
-rm map/test.o map/test
-cabal new-exec -- ghc map/test.hs
-./map/test
+#rm map/test.o map/test
+#cabal new-exec -- ghc map/test.hs
+#./map/test

--- a/workspace/build_short2.sh
+++ b/workspace/build_short2.sh
@@ -1,0 +1,14 @@
+rm -rf dist-newstyle
+rm -rf stdcxx
+rm -rf tmf-test
+rm -rf proxy-test
+rm -rf working
+cabal new-build fficxx
+sleep 1s
+cabal new-exec runhaskell ../stdcxx-gen/Gen.hs
+cabal new-build stdcxx
+
+# map
+rm map/test.o map/test
+cabal new-exec -- ghc map/test.hs
+./map/test

--- a/workspace/map
+++ b/workspace/map
@@ -1,0 +1,1 @@
+../examples/map


### PR DESCRIPTION
Now I generalized single-parameter template support to multi-parameter C++ template. Now C++ template like `std::map<k,v>` can be interfaced.
