### PR TITLE
multi-parameter template for function arguments and template member functions

### DIFF
--- a/examples/template-member/Gen.hs
+++ b/examples/template-member/Gen.hs
@@ -165,14 +165,14 @@ classA cabal =
   , class_vars  = [ ]
   , class_tmpl_funcs =
       [ TemplateMemberFunction {
-          tmf_param = "tp1"
+          tmf_params = ["tp1"]
         , tmf_ret = void_
         , tmf_name = "method"
         , tmf_args = [ Arg (TemplateParamPointer "tp1") "x" ]
         , tmf_alias = Nothing
         }
       , TemplateMemberFunction {
-          tmf_param = "tp1"
+          tmf_params = ["tp1"]
         , tmf_ret = void_
         , tmf_name = "method2"
         , tmf_args = [ Arg

--- a/examples/template-member/Gen.hs
+++ b/examples/template-member/Gen.hs
@@ -165,22 +165,22 @@ classA cabal =
   , class_vars  = [ ]
   , class_tmpl_funcs =
       [ TemplateMemberFunction {
-          tmf_param = "t"
+          tmf_param = "tp1"
         , tmf_ret = void_
         , tmf_name = "method"
-        , tmf_args = [ Arg (TemplateParamPointer "t") "x" ]
+        , tmf_args = [ Arg (TemplateParamPointer "tp1") "x" ]
         , tmf_alias = Nothing
         }
       , TemplateMemberFunction {
-          tmf_param = "t"
+          tmf_param = "tp1"
         , tmf_ret = void_
         , tmf_name = "method2"
         , tmf_args = [ Arg
                          (TemplateAppMove
                            TemplateAppInfo {
                              tapp_tclass = t_unique_ptr
-                           , tapp_tparam = TArg_TypeParam "t"
-                           , tapp_CppTypeForParam = "std::unique_ptr<Type>"
+                           , tapp_tparams = [ TArg_TypeParam "tp1" ]
+                           , tapp_CppTypeForParam = "std::unique_ptr<tp1>"
                            }
                          )
                          "x"

--- a/fficxx/src/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Cpp.hs
@@ -184,18 +184,22 @@ genCppDefMacroTemplateMemberFunction ::
   -> TemplateMemberFunction
   -> R.CMacro Identity
 genCppDefMacroTemplateMemberFunction c f =
-   R.Define (R.sname macroname) [R.sname "Type"]
+   R.Define (R.sname macroname) (map R.sname [tmf_param f]) -- [R.sname "Type"]
      [ R.CExtern [R.CDeclaration decl]
      , tmplMemberFunToDef c f
      , autoinst
      ]
   where
+    nsuffix = intersperse (R.NamePart "_") $ map R.NamePart [tmf_param f]
     macroname = hsTemplateMemberFunctionName c f
     decl = tmplMemberFunToDecl c f
     autoinst =
       R.CInit
-        (R.CVarDecl R.CTAuto (R.CName [R.NamePart ("a_" <> macroname <> "_"), R.NamePart "Type"]))
-        (R.CVar (R.CName [R.NamePart (macroname <> "_"), R.NamePart "Type"]))
+        (R.CVarDecl
+          R.CTAuto
+          (R.CName (R.NamePart ("a_" <> macroname <> "_") : nsuffix))
+        )
+        (R.CVar (R.CName (R.NamePart (macroname <> "_") : nsuffix)))
 
 
 ---- Invoke Macro to define Virtual/NonVirtual method for a class
@@ -270,8 +274,8 @@ genTmplFunCpp b t@TmplCls {..} f =
   autoinst =
     R.CInit
       (R.CVarDecl
-         R.CTAuto
-         (R.CName (R.NamePart ("a_" <> tclass_name <> "_" <> ffiTmplFuncName f <> "_") : nsuffix ))
+        R.CTAuto
+        (R.CName (R.NamePart ("a_" <> tclass_name <> "_" <> ffiTmplFuncName f <> "_") : nsuffix ))
       )
       (R.CVar (R.CName (R.NamePart (tclass_name <> "_" <> ffiTmplFuncName f <> "_") : nsuffix )))
 
@@ -572,11 +576,10 @@ accessorToDef v a =
 -- TODO: Handle simple type
 tmplMemberFunToDecl :: Class -> TemplateMemberFunction -> R.CFunDecl Identity
 tmplMemberFunToDecl c f =
-  let ret = R.CTVerbatim $ tmplMemFuncRetTypeToString c (tmf_ret f)
+  let nsuffix = intersperse (R.NamePart "_") $ map R.NamePart [tmf_param f]
+      ret = R.CTVerbatim $ tmplMemFuncRetTypeToString c (tmf_ret f)
       fname =
-        R.CName [ R.NamePart (hsTemplateMemberFunctionName c f <> "_")
-                , R.NamePart "Type"
-                ]
+        R.CName (R.NamePart (hsTemplateMemberFunctionName c f <> "_") : nsuffix)
       args = map (tmplMemFuncArgToCTypVar c) ((Arg SelfType "p"):tmf_args f)
   in R.CFunDecl ret fname args
 
@@ -585,6 +588,7 @@ tmplMemberFunToDef :: Class -> TemplateMemberFunction -> R.CStatement Identity
 tmplMemberFunToDef c f =
     R.CDefinition (Just R.Inline) (tmplMemberFunToDecl c f) body
   where
+    tparams = map (R.CTSimple . R.sname) [tmf_param f]
     body = returnCpp NonCPrim (tmf_ret f) $
              R.CBinOp
                R.CArrow
@@ -595,6 +599,6 @@ tmplMemberFunToDef c f =
                )
                (R.CTApp
                  (R.sname (tmf_name f))
-                 [ R.CTSimple (R.sname "Type") ]
+                 tparams
                  (map (tmplArgToCallCExp NonCPrim) (tmf_args f))
                )

--- a/fficxx/src/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Cpp.hs
@@ -184,13 +184,13 @@ genCppDefMacroTemplateMemberFunction ::
   -> TemplateMemberFunction
   -> R.CMacro Identity
 genCppDefMacroTemplateMemberFunction c f =
-   R.Define (R.sname macroname) (map R.sname [tmf_param f]) -- [R.sname "Type"]
+   R.Define (R.sname macroname) (map R.sname (tmf_params f))
      [ R.CExtern [R.CDeclaration decl]
      , tmplMemberFunToDef c f
      , autoinst
      ]
   where
-    nsuffix = intersperse (R.NamePart "_") $ map R.NamePart [tmf_param f]
+    nsuffix = intersperse (R.NamePart "_") $ map R.NamePart (tmf_params f)
     macroname = hsTemplateMemberFunctionName c f
     decl = tmplMemberFunToDecl c f
     autoinst =
@@ -576,7 +576,7 @@ accessorToDef v a =
 -- TODO: Handle simple type
 tmplMemberFunToDecl :: Class -> TemplateMemberFunction -> R.CFunDecl Identity
 tmplMemberFunToDecl c f =
-  let nsuffix = intersperse (R.NamePart "_") $ map R.NamePart [tmf_param f]
+  let nsuffix = intersperse (R.NamePart "_") $ map R.NamePart (tmf_params f)
       ret = tmplMemFuncReturnCType c (tmf_ret f)
       fname =
         R.CName (R.NamePart (hsTemplateMemberFunctionName c f <> "_") : nsuffix)
@@ -588,7 +588,7 @@ tmplMemberFunToDef :: Class -> TemplateMemberFunction -> R.CStatement Identity
 tmplMemberFunToDef c f =
     R.CDefinition (Just R.Inline) (tmplMemberFunToDecl c f) body
   where
-    tparams = map (R.CTSimple . R.sname) [tmf_param f]
+    tparams = map (R.CTSimple . R.sname) (tmf_params f)
     body = returnCpp NonCPrim (tmf_ret f) $
              R.CBinOp
                R.CArrow

--- a/fficxx/src/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Cpp.hs
@@ -23,7 +23,7 @@ import FFICXX.Generate.Code.Primitive
                                     , genericFuncRet
                                     , returnCType
                                     , tmplMemFuncArgToCTypVar
-                                    , tmplMemFuncRetTypeToString
+                                    , tmplMemFuncReturnCType
                                     , tmplAllArgsToCTypVar
                                     , tmplArgToCallCExp
                                     , tmplReturnCType
@@ -577,7 +577,7 @@ accessorToDef v a =
 tmplMemberFunToDecl :: Class -> TemplateMemberFunction -> R.CFunDecl Identity
 tmplMemberFunToDecl c f =
   let nsuffix = intersperse (R.NamePart "_") $ map R.NamePart [tmf_param f]
-      ret = R.CTVerbatim $ tmplMemFuncRetTypeToString c (tmf_ret f)
+      ret = tmplMemFuncReturnCType c (tmf_ret f)
       fname =
         R.CName (R.NamePart (hsTemplateMemberFunctionName c f <> "_") : nsuffix)
       args = map (tmplMemFuncArgToCTypVar c) ((Arg SelfType "p"):tmf_args f)

--- a/fficxx/src/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Primitive.hs
@@ -624,21 +624,20 @@ tmplMemFuncArgToCTypVar _ _ = error "tmplMemFuncArgToString: undefined"
 
 
 -- |
-tmplMemFuncRetTypeToString :: Class -> Types -> String
-tmplMemFuncRetTypeToString _ (CT ctyp isconst)        = R.renderCType $ ctypToCType ctyp isconst
-tmplMemFuncRetTypeToString _ Void                     = "void"
-tmplMemFuncRetTypeToString c SelfType                 = ffiClassName c <> "_p"
-tmplMemFuncRetTypeToString _ (CPT (CPTClass c) _)     = ffiClassName c <> "_p"
-tmplMemFuncRetTypeToString _ (CPT (CPTClassRef c) _)  = ffiClassName c <> "_p"
-tmplMemFuncRetTypeToString _ (CPT (CPTClassCopy c) _) = ffiClassName c <> "_p"
-tmplMemFuncRetTypeToString _ (CPT (CPTClassMove c) _) = ffiClassName c <> "_p"
-tmplMemFuncRetTypeToString _ (TemplateApp     _)      = "void*"
-tmplMemFuncRetTypeToString _ (TemplateAppRef  _)      = "void*"
-tmplMemFuncRetTypeToString _ (TemplateAppMove _)      = "void*"
-tmplMemFuncRetTypeToString _ (TemplateType _)         = "void*"
-tmplMemFuncRetTypeToString _ (TemplateParam _)        = "Type##_p"
-tmplMemFuncRetTypeToString _ (TemplateParamPointer _) = "Type##_p"
-
+tmplMemFuncReturnCType :: Class -> Types -> R.CType Identity
+tmplMemFuncReturnCType _ (CT ctyp isconst)        = ctypToCType ctyp isconst
+tmplMemFuncReturnCType _ Void                     = R.CTVoid
+tmplMemFuncReturnCType c SelfType                 = R.CTSimple (R.sname (ffiClassName c <> "_p"))
+tmplMemFuncReturnCType _ (CPT (CPTClass c) _)     = R.CTSimple (R.sname (ffiClassName c <> "_p"))
+tmplMemFuncReturnCType _ (CPT (CPTClassRef c) _)  = R.CTSimple (R.sname (ffiClassName c <> "_p"))
+tmplMemFuncReturnCType _ (CPT (CPTClassCopy c) _) = R.CTSimple (R.sname (ffiClassName c <> "_p"))
+tmplMemFuncReturnCType _ (CPT (CPTClassMove c) _) = R.CTSimple (R.sname (ffiClassName c <> "_p"))
+tmplMemFuncReturnCType _ (TemplateApp     _)      = R.CTStar R.CTVoid
+tmplMemFuncReturnCType _ (TemplateAppRef  _)      = R.CTStar R.CTVoid
+tmplMemFuncReturnCType _ (TemplateAppMove _)      = R.CTStar R.CTVoid
+tmplMemFuncReturnCType _ (TemplateType _)         = R.CTStar R.CTVoid
+tmplMemFuncReturnCType _ (TemplateParam t)        = R.CTSimple $ R.CName [ R.NamePart t, R.NamePart "_p" ]
+tmplMemFuncReturnCType _ (TemplateParamPointer t) = R.CTSimple $ R.CName [ R.NamePart t, R.NamePart "_p" ]
 
 -- |
 convertC2HS :: CTypes -> Type ()

--- a/fficxx/src/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Primitive.hs
@@ -596,6 +596,7 @@ tmplReturnCType b (TemplateParamPointer t) = case b of
 -- Template Member Function --
 -- ---------------------------
 
+-- |
 tmplMemFuncArgToCTypVar :: Class -> Arg -> (R.CType Identity, R.CName Identity)
 tmplMemFuncArgToCTypVar _ (Arg (CT ctyp isconst) varname) =
   (ctypToCType ctyp isconst, R.sname varname)
@@ -613,16 +614,16 @@ tmplMemFuncArgToCTypVar _ (Arg (CPT (CPTClassMove c) isconst) varname) =
   case isconst of
     Const   -> (R.CTSimple (R.sname ("const_" <> ffiClassName c <> "_p")), R.sname varname)
     NoConst -> (R.CTSimple (R.sname (ffiClassName c <> "_p")), R.sname varname)
-tmplMemFuncArgToCTypVar _ (Arg (TemplateApp     _) v) = (R.CTStar R.CTVoid, R.sname v)
-tmplMemFuncArgToCTypVar _ (Arg (TemplateAppRef  _) v) = (R.CTStar R.CTVoid, R.sname v)
-tmplMemFuncArgToCTypVar _ (Arg (TemplateAppMove _) v) = (R.CTStar R.CTVoid, R.sname v)
-tmplMemFuncArgToCTypVar _ (Arg (TemplateType   _)  v) = (R.CTStar R.CTVoid, R.sname v)
-tmplMemFuncArgToCTypVar _ (Arg (TemplateParam _) v) = (R.CTSimple (R.CName [ R.NamePart "Type", R.NamePart "_p" ]), R.sname v)
-tmplMemFuncArgToCTypVar _ (Arg (TemplateParamPointer _) v) = (R.CTSimple (R.CName [ R.NamePart "Type", R.NamePart "_p" ]), R.sname v)
+tmplMemFuncArgToCTypVar _ (Arg (TemplateApp     _) v)      = (R.CTStar R.CTVoid, R.sname v)
+tmplMemFuncArgToCTypVar _ (Arg (TemplateAppRef  _) v)      = (R.CTStar R.CTVoid, R.sname v)
+tmplMemFuncArgToCTypVar _ (Arg (TemplateAppMove _) v)      = (R.CTStar R.CTVoid, R.sname v)
+tmplMemFuncArgToCTypVar _ (Arg (TemplateType   _)  v)      = (R.CTStar R.CTVoid, R.sname v)
+tmplMemFuncArgToCTypVar _ (Arg (TemplateParam t) v)        = (R.CTSimple (R.CName [ R.NamePart t, R.NamePart "_p" ]), R.sname v)
+tmplMemFuncArgToCTypVar _ (Arg (TemplateParamPointer t) v) = (R.CTSimple (R.CName [ R.NamePart t, R.NamePart "_p" ]), R.sname v)
 tmplMemFuncArgToCTypVar _ _ = error "tmplMemFuncArgToString: undefined"
 
 
-
+-- |
 tmplMemFuncRetTypeToString :: Class -> Types -> String
 tmplMemFuncRetTypeToString _ (CT ctyp isconst)        = R.renderCType $ ctypToCType ctyp isconst
 tmplMemFuncRetTypeToString _ Void                     = "void"
@@ -637,7 +638,6 @@ tmplMemFuncRetTypeToString _ (TemplateAppMove _)      = "void*"
 tmplMemFuncRetTypeToString _ (TemplateType _)         = "void*"
 tmplMemFuncRetTypeToString _ (TemplateParam _)        = "Type##_p"
 tmplMemFuncRetTypeToString _ (TemplateParamPointer _) = "Type##_p"
-
 
 
 -- |

--- a/fficxx/src/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Primitive.hs
@@ -864,10 +864,10 @@ functionSignatureTT t f = foldr1 tyfun (lst <> [tyapp (tycon "IO") ctyp])
 functionSignatureTMF :: Class -> TemplateMemberFunction -> Type ()
 functionSignatureTMF c f = foldr1 tyfun (lst <> [tyapp (tycon "IO") ctyp])
   where
-    ctyp = convertCpp2HS4Tmpl e Nothing [spl] (tmf_ret f)                      -- TODO: update with multiple template parameters
+    spls = map (tySplice . parenSplice . mkVar) (tmf_params f)
+    ctyp = convertCpp2HS4Tmpl e Nothing spls (tmf_ret f)
     e = tycon (fst (hsClassName c))
-    spl = tySplice (parenSplice (mkVar (tmf_param f)))                         -- TODO: update with multiple template parameters
-    lst = e : map (convertCpp2HS4Tmpl e Nothing [spl] . arg_type) (tmf_args f) -- TODO: update with multiple template parameters
+    lst = e : map (convertCpp2HS4Tmpl e Nothing spls . arg_type) (tmf_args f)
 
 
 accessorCFunSig :: Types -> Accessor -> CFunSig

--- a/fficxx/src/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Primitive.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE RecordWildCards #-}
+
 module FFICXX.Generate.Code.Primitive where
 
 import Control.Monad.Trans.State    ( runState, put, get )
@@ -536,37 +538,32 @@ tmplArgToCallCExp _ (Arg (CPT (CPTClassMove c) _) varname) =
 tmplArgToCallCExp _ (Arg (CT (CRef _) _) varname) =
   R.CStar $ R.CVar $ R.sname varname
 tmplArgToCallCExp _ (Arg (TemplateApp x) varname) =
-  case tapp_tparam x of
-    -- TODO: need to use param
-    TArg_TypeParam _p ->
-      R.CTApp
-        (R.sname "static_cast")
-        [ R.CTStar $ R.CTTApp (R.sname (tclass_oname (tapp_tclass x))) [ R.CTSimple (R.sname "Type") ] ]
-        [ R.CVar $ R.sname varname ]
-    _ -> error "tmplArgToCallCExp: TemplateApp"
+  let targs = map (R.CTSimple . R.sname . hsClassNameForTArg) (tapp_tparams x)
+  in R.CTApp
+       (R.sname "static_cast")
+       [ R.CTStar $ R.CTTApp (R.sname (tclass_oname (tapp_tclass x))) targs ]
+       [ R.CVar $ R.sname varname ]
+  -- case tapp_tparam x of
+  --   -- TODO: need to use param
+  --   TArg_TypeParam _p ->
+  --   _ -> error "tmplArgToCallCExp: TemplateApp"
 tmplArgToCallCExp _ (Arg (TemplateAppRef x) varname) =
-  case tapp_tparam x of
-    -- TODO: need to use param
-    TArg_TypeParam _p ->
-      R.CStar $
-        R.CTApp
-          (R.sname "static_cast")
-          [ R.CTStar $ R.CTTApp (R.sname (tclass_oname (tapp_tclass x))) [ R.CTSimple (R.sname "Type") ] ]
-          [ R.CVar $ R.sname varname ]
-    _ -> error "tmplArgToCallCExp: TemplateAppRef"
+  let targs = map (R.CTSimple . R.sname . hsClassNameForTArg) (tapp_tparams x)
+  in R.CStar $
+       R.CTApp
+         (R.sname "static_cast")
+         [ R.CTStar $ R.CTTApp (R.sname (tclass_oname (tapp_tclass x))) targs ]
+         [ R.CVar $ R.sname varname ]
 tmplArgToCallCExp _ (Arg (TemplateAppMove x) varname) =
-  case tapp_tparam x of
-    -- TODO: need to use param
-    TArg_TypeParam _p ->
-      R.CApp
-        (R.CVar (R.sname "std::move"))
-        [ R.CStar $
-            R.CTApp
-              (R.sname "static_cast")
-              [ R.CTStar $ R.CTTApp (R.sname (tclass_oname (tapp_tclass x))) [ R.CTSimple (R.sname "Type") ] ]
-              [ R.CVar $ R.sname varname ]
-        ]
-    _ -> error "tmplArgToCallCExp: TemplateAppMove"
+  let targs = map (R.CTSimple . R.sname . hsClassNameForTArg) (tapp_tparams x)
+  in R.CApp
+       (R.CVar (R.sname "std::move"))
+       [ R.CStar $
+           R.CTApp
+             (R.sname "static_cast")
+             [ R.CTStar $ R.CTTApp (R.sname (tclass_oname (tapp_tclass x))) targs ]
+             [ R.CVar $ R.sname varname ]
+       ]
 tmplArgToCallCExp b (Arg (TemplateParam typ) varname) =
   case b of
     CPrim    -> R.CVar $ R.sname varname
@@ -656,48 +653,48 @@ tmplMemFuncRetTypeToString _ (TemplateParamPointer _) = "Type##_p"
 
 -- |
 convertC2HS :: CTypes -> Type ()
-convertC2HS CTBool      = tycon "CBool"
-convertC2HS CTChar      = tycon "CChar"
-convertC2HS CTClock     = tycon "CClock"
-convertC2HS CTDouble    = tycon "CDouble"
-convertC2HS CTFile      = tycon "CFile"
-convertC2HS CTFloat     = tycon "CFloat"
-convertC2HS CTFpos      = tycon "CFpos"
-convertC2HS CTInt       = tycon "CInt"
-convertC2HS CTIntMax    = tycon "CIntMax"
-convertC2HS CTIntPtr    = tycon "CIntPtr"
-convertC2HS CTJmpBuf    = tycon "CJmpBuf"
-convertC2HS CTLLong     = tycon "CLLong"
-convertC2HS CTLong      = tycon "CLong"
-convertC2HS CTPtrdiff   = tycon "CPtrdiff"
-convertC2HS CTSChar     = tycon "CSChar"
-convertC2HS CTSUSeconds = tycon "CSUSeconds"
-convertC2HS CTShort     = tycon "CShort"
-convertC2HS CTSigAtomic = tycon "CSigAtomic"
-convertC2HS CTSize      = tycon "CSize"
-convertC2HS CTTime      = tycon "CTime"
-convertC2HS CTUChar     = tycon "CUChar"
-convertC2HS CTUInt      = tycon "CUInt"
-convertC2HS CTUIntMax   = tycon "CUIntMax"
-convertC2HS CTUIntPtr   = tycon "CUIntPtr"
-convertC2HS CTULLong    = tycon "CULLong"
-convertC2HS CTULong     = tycon "CULong"
-convertC2HS CTUSeconds  = tycon "CUSeconds"
-convertC2HS CTUShort    = tycon "CUShort"
-convertC2HS CTWchar     = tycon "CWchar"
-convertC2HS CTInt8      = tycon "Int8"
-convertC2HS CTInt16      = tycon "Int16"
-convertC2HS CTInt32      = tycon "Int32"
-convertC2HS CTInt64      = tycon "Int64"
-convertC2HS CTUInt8      = tycon "Word8"
+convertC2HS CTBool        = tycon "CBool"
+convertC2HS CTChar        = tycon "CChar"
+convertC2HS CTClock       = tycon "CClock"
+convertC2HS CTDouble      = tycon "CDouble"
+convertC2HS CTFile        = tycon "CFile"
+convertC2HS CTFloat       = tycon "CFloat"
+convertC2HS CTFpos        = tycon "CFpos"
+convertC2HS CTInt         = tycon "CInt"
+convertC2HS CTIntMax      = tycon "CIntMax"
+convertC2HS CTIntPtr      = tycon "CIntPtr"
+convertC2HS CTJmpBuf      = tycon "CJmpBuf"
+convertC2HS CTLLong       = tycon "CLLong"
+convertC2HS CTLong        = tycon "CLong"
+convertC2HS CTPtrdiff     = tycon "CPtrdiff"
+convertC2HS CTSChar       = tycon "CSChar"
+convertC2HS CTSUSeconds   = tycon "CSUSeconds"
+convertC2HS CTShort       = tycon "CShort"
+convertC2HS CTSigAtomic   = tycon "CSigAtomic"
+convertC2HS CTSize        = tycon "CSize"
+convertC2HS CTTime        = tycon "CTime"
+convertC2HS CTUChar       = tycon "CUChar"
+convertC2HS CTUInt        = tycon "CUInt"
+convertC2HS CTUIntMax     = tycon "CUIntMax"
+convertC2HS CTUIntPtr     = tycon "CUIntPtr"
+convertC2HS CTULLong      = tycon "CULLong"
+convertC2HS CTULong       = tycon "CULong"
+convertC2HS CTUSeconds    = tycon "CUSeconds"
+convertC2HS CTUShort      = tycon "CUShort"
+convertC2HS CTWchar       = tycon "CWchar"
+convertC2HS CTInt8        = tycon "Int8"
+convertC2HS CTInt16       = tycon "Int16"
+convertC2HS CTInt32       = tycon "Int32"
+convertC2HS CTInt64       = tycon "Int64"
+convertC2HS CTUInt8       = tycon "Word8"
 convertC2HS CTUInt16      = tycon "Word16"
 convertC2HS CTUInt32      = tycon "Word32"
 convertC2HS CTUInt64      = tycon "Word64"
-convertC2HS CTString    = tycon "CString"
-convertC2HS CTVoidStar   = tyapp (tycon "Ptr") unit_tycon
-convertC2HS (CEnum t _)  = convertC2HS t
-convertC2HS (CPointer t) = tyapp (tycon "Ptr") (convertC2HS t)
-convertC2HS (CRef t)     = tyapp (tycon "Ptr") (convertC2HS t)
+convertC2HS CTString      = tycon "CString"
+convertC2HS CTVoidStar    = tyapp (tycon "Ptr") unit_tycon
+convertC2HS (CEnum t _)   = convertC2HS t
+convertC2HS (CPointer t)  = tyapp (tycon "Ptr") (convertC2HS t)
+convertC2HS (CRef t)      = tyapp (tycon "Ptr") (convertC2HS t)
 
 -- |
 convertCpp2HS :: Maybe Class -> Types -> Type ()
@@ -709,16 +706,18 @@ convertCpp2HS _c (CPT (CPTClass c') _)     = (tycon . fst . hsClassName) c'
 convertCpp2HS _c (CPT (CPTClassRef c') _)  = (tycon . fst . hsClassName) c'
 convertCpp2HS _c (CPT (CPTClassCopy c') _) = (tycon . fst . hsClassName) c'
 convertCpp2HS _c (CPT (CPTClassMove c') _) = (tycon . fst . hsClassName) c'
-convertCpp2HS _c (TemplateApp x)           = tyapp
-                                               (tycon (tclass_name (tapp_tclass x)))
-                                               (tycon (hsClassNameForTArg (tapp_tparam x)))
-convertCpp2HS _c (TemplateAppRef x)        = tyapp
-                                               (tycon (tclass_name (tapp_tclass x)))
-                                               (tycon (hsClassNameForTArg (tapp_tparam x)))
-convertCpp2HS _c (TemplateAppMove x)       = tyapp
-                                               (tycon (tclass_name (tapp_tclass x)))
-                                               (tycon (hsClassNameForTArg (tapp_tparam x)))
-convertCpp2HS _c (TemplateType t)          = foldl1 tyapp (tycon (tclass_name t) : map mkTVar (tclass_params t))
+convertCpp2HS _c (TemplateApp x) =
+  foldl1 tyapp $ map tycon $
+    tclass_name (tapp_tclass x) : map hsClassNameForTArg (tapp_tparams x)
+convertCpp2HS _c (TemplateAppRef x) =
+  foldl1 tyapp $ map tycon $
+    tclass_name (tapp_tclass x) : map hsClassNameForTArg (tapp_tparams x)
+convertCpp2HS _c (TemplateAppMove x) =
+  foldl1 tyapp $ map tycon $
+    tclass_name (tapp_tclass x) : map hsClassNameForTArg (tapp_tparams x)
+convertCpp2HS _c (TemplateType t) =
+  foldl1 tyapp $
+    tycon (tclass_name t) : map mkTVar (tclass_params t)
 convertCpp2HS _c (TemplateParam p)         = mkTVar p
 convertCpp2HS _c (TemplateParamPointer p)  = mkTVar p
 
@@ -729,32 +728,43 @@ convertCpp2HS4Tmpl
   -> [Type ()]    -- ^ type paramemter splice
   -> Types
   -> Type ()
-convertCpp2HS4Tmpl _ _c _ Void                  = unit_tycon
-convertCpp2HS4Tmpl _ (Just c) _ SelfType        = tycon ((fst.hsClassName) c)
-convertCpp2HS4Tmpl _ Nothing _ SelfType         = error "convertCpp2HS4Tmpl : SelfType but no class "
-convertCpp2HS4Tmpl _ _c _ (CT t _)              = convertC2HS t
-convertCpp2HS4Tmpl _ _c _ (CPT (CPTClass c') _)     = (tycon . fst . hsClassName) c'
-convertCpp2HS4Tmpl _ _c _ (CPT (CPTClassRef c') _)  = (tycon . fst . hsClassName) c'
-convertCpp2HS4Tmpl _ _c _ (CPT (CPTClassCopy c') _) = (tycon . fst . hsClassName) c'
-convertCpp2HS4Tmpl _ _c _ (CPT (CPTClassMove c') _) = (tycon . fst . hsClassName) c'
-convertCpp2HS4Tmpl _e c ss x@(TemplateApp p) =
-  case tapp_tparam p of
-    TArg_TypeParam _ -> let t = tapp_tclass p
-                            (hname,_) = hsTemplateClassName t
-                        in foldl1 tyapp (tycon hname : ss)
-    _ -> convertCpp2HS c x
-convertCpp2HS4Tmpl _e c ss x@(TemplateAppRef p) =
-  case tapp_tparam p of
-    TArg_TypeParam _ -> let t = tapp_tclass p
-                            (hname,_) = hsTemplateClassName t
-                        in foldl1 tyapp (tycon hname : ss)
-    _ -> convertCpp2HS c x
-convertCpp2HS4Tmpl _e c ss x@(TemplateAppMove p) =
-  case tapp_tparam p of
-    TArg_TypeParam _ -> let t = tapp_tclass p
-                            (hname,_) = hsTemplateClassName t
-                        in foldl1 tyapp (tycon hname : ss)
-    _ -> convertCpp2HS c x
+convertCpp2HS4Tmpl _ c _ Void                  = convertCpp2HS c Void
+convertCpp2HS4Tmpl _ (Just c) _ SelfType       = convertCpp2HS (Just c) SelfType
+convertCpp2HS4Tmpl _ Nothing _ SelfType        = convertCpp2HS Nothing SelfType
+convertCpp2HS4Tmpl _ c _ x@(CT t _)            = convertCpp2HS c x
+convertCpp2HS4Tmpl _ c _ x@(CPT (CPTClass c') _) = convertCpp2HS c x
+convertCpp2HS4Tmpl _ c _ x@(CPT (CPTClassRef c') _)  = convertCpp2HS c x
+convertCpp2HS4Tmpl _ c _ x@(CPT (CPTClassCopy c') _) = convertCpp2HS c x
+convertCpp2HS4Tmpl _ c _ x@(CPT (CPTClassMove c') _) = convertCpp2HS c x
+convertCpp2HS4Tmpl _e c ss (TemplateApp info) =
+  let pss = zip (tapp_tparams info) ss
+  in foldl1 tyapp $
+       tycon (tclass_name (tapp_tclass info)) : map (\case (TArg_TypeParam _,s) -> s; (p,_) -> tycon (hsClassNameForTArg p)) pss
+  -- case tapp_tparam p of
+  --  TArg_TypeParam _ -> let t = tapp_tclass p
+  --                          (hname,_) = hsTemplateClassName t
+  --                      in foldl1 tyapp (tycon hname : ss)
+  --  _ -> convertCpp2HS c x
+convertCpp2HS4Tmpl _e c ss (TemplateAppRef info) =
+  let pss = zip (tapp_tparams info) ss
+  in foldl1 tyapp $
+       tycon (tclass_name (tapp_tclass info)) : map (\case (TArg_TypeParam _,s) -> s; (p,_) -> tycon (hsClassNameForTArg p)) pss
+
+  --case tapp_tparam p of
+  --  TArg_TypeParam _ -> let t = tapp_tclass p
+  --                          (hname,_) = hsTemplateClassName t
+  --                      in foldl1 tyapp (tycon hname : ss)
+  --  _ -> convertCpp2HS c x
+convertCpp2HS4Tmpl _e c ss (TemplateAppMove info) =
+  let pss = zip (tapp_tparams info) ss
+  in foldl1 tyapp $
+       tycon (tclass_name (tapp_tclass info)) : map (\case (TArg_TypeParam _,s) -> s; (p,_) -> tycon (hsClassNameForTArg p)) pss
+
+  --case tapp_tparam p of
+  --  TArg_TypeParam _ -> let t = tapp_tclass p
+  --                          (hname,_) = hsTemplateClassName t
+  --                      in foldl1 tyapp (tycon hname : ss)
+  --  _ -> convertCpp2HS c x
 convertCpp2HS4Tmpl e _c _ (TemplateType _)          = e
 convertCpp2HS4Tmpl _ _c (s:_) (TemplateParam _)         = s  -- TODO: need to be fixed
 convertCpp2HS4Tmpl _ _c (s:_) (TemplateParamPointer _)  = s  -- TODO: need to be fixed
@@ -823,17 +833,20 @@ extractArgRetTypes mc isvirtual (CFunSig args ret) =
            CPT (CPTClassMove c') _ -> addclass c'
            -- it is not clear whether the following is okay or not.
            (TemplateApp x)    -> pure $
-                                   tyapp
-                                     (tycon (tclass_name (tapp_tclass x)))
-                                     (tycon (hsClassNameForTArg (tapp_tparam x)))
+                                   convertCpp2HS Nothing (TemplateApp x)
+                                   -- tyapp
+                                   --   (tycon (tclass_name (tapp_tclass x)))
+                                   --   (tycon (hsClassNameForTArg (tapp_tparams x)))
            (TemplateAppRef x) -> pure $
-                                   tyapp
-                                     (tycon (tclass_name (tapp_tclass x)))
-                                     (tycon (hsClassNameForTArg (tapp_tparam x)))
+                                   convertCpp2HS Nothing (TemplateAppRef x)
+                                   -- tyapp
+                                   --   (tycon (tclass_name (tapp_tclass x)))
+                                   --   (tycon (hsClassNameForTArg (tapp_tparams x)))
            (TemplateAppMove x)-> pure $
-                                   tyapp
-                                     (tycon (tclass_name (tapp_tclass x)))
-                                     (tycon (hsClassNameForTArg (tapp_tparam x)))
+                                   convertCpp2HS Nothing (TemplateAppMove x)
+                                   -- tyapp
+                                   --   (tycon (tclass_name (tapp_tclass x)))
+                                   --   (tycon (hsClassNameForTArg (tapp_tparams x)))
            (TemplateType t)   -> pure $
                                    foldl1 tyapp (tycon (tclass_name t) : map mkTVar (tclass_params t))
            (TemplateParam p)      -> return (mkTVar p)
@@ -867,8 +880,6 @@ functionSignatureT t TFunNew {..} =
 functionSignatureT t TFunDelete =
   let ctyp = convertCpp2HS Nothing (TemplateType t)
   in ctyp `tyfun` (tyapp (tycon "IO") unit_tycon)
-
-
 
 -- TODO: rename this and combine this with functionSignatureTMF
 functionSignatureTT :: TemplateClass -> TemplateFunction -> Type ()
@@ -935,23 +946,20 @@ hsFFIFuncTyp msc (CFunSig args ret) =
           where rawname = snd (hsClassName d)
         hsargtype (CPT (CPTClassCopy d) _)    = tyapp tyPtr (tycon rawname)
           where rawname = snd (hsClassName d)
-        hsargtype (TemplateApp x)   = tyapp
-                                        tyPtr
-                                        (tyapp
-                                           (tycon rawname)
-                                           (tycon (hsClassNameForTArg (tapp_tparam x))))
+        hsargtype (TemplateApp x)    = tyapp tyPtr $
+                                         foldl1 tyapp $
+                                           map tycon $
+                                            rawname : map hsClassNameForTArg (tapp_tparams x)
           where rawname = snd (hsTemplateClassName (tapp_tclass x))
-        hsargtype (TemplateAppRef x) = tyapp
-                                         tyPtr
-                                         (tyapp
-                                            (tycon rawname)
-                                            (tycon (hsClassNameForTArg (tapp_tparam x))))
+        hsargtype (TemplateAppRef x) = tyapp tyPtr $
+                                         foldl1 tyapp $
+                                           map tycon $
+                                             rawname : map hsClassNameForTArg (tapp_tparams x)
           where rawname = snd (hsTemplateClassName (tapp_tclass x))
-        hsargtype (TemplateAppMove x)= tyapp
-                                         tyPtr
-                                         (tyapp
-                                            (tycon rawname)
-                                            (tycon (hsClassNameForTArg (tapp_tparam x))))
+        hsargtype (TemplateAppMove x)= tyapp tyPtr $
+                                         foldl1 tyapp $
+                                           map tycon $
+                                             rawname : map hsClassNameForTArg (tapp_tparams x)
           where rawname = snd (hsTemplateClassName (tapp_tclass x))
         hsargtype (TemplateType t)           = tyapp tyPtr $ foldl1 tyapp (tycon rawname : map mkTVar (tclass_params t))
           where rawname = snd (hsTemplateClassName t)
@@ -970,26 +978,23 @@ hsFFIFuncTyp msc (CFunSig args ret) =
           where rawname = snd (hsClassName d)
         hsrettype (CPT (CPTClassMove d) _)   = tyapp tyPtr (tycon rawname)
           where rawname = snd (hsClassName d)
-        hsrettype (TemplateApp x)    = tyapp
-                                         tyPtr
-                                         (tyapp
-                                            (tycon rawname)
-                                            (tycon (hsClassNameForTArg (tapp_tparam x))))
+        hsrettype (TemplateApp x)    = tyapp tyPtr $
+                                         foldl1 tyapp $
+                                           map tycon $
+                                            rawname : map hsClassNameForTArg (tapp_tparams x)
           where rawname = snd (hsTemplateClassName (tapp_tclass x))
-        hsrettype (TemplateAppRef x) = tyapp
-                                         tyPtr
-                                         (tyapp
-                                            (tycon rawname)
-                                            (tycon (hsClassNameForTArg (tapp_tparam x))))
+        hsrettype (TemplateAppRef x) = tyapp tyPtr $
+                                         foldl1 tyapp $
+                                           map tycon $
+                                            rawname : map hsClassNameForTArg (tapp_tparams x)
           where rawname = snd (hsTemplateClassName (tapp_tclass x))
-        hsrettype (TemplateAppMove x)= tyapp
-                                         tyPtr
-                                         (tyapp
-                                            (tycon rawname)
-                                            (tycon (hsClassNameForTArg (tapp_tparam x))))
+        hsrettype (TemplateAppMove x)= tyapp tyPtr $
+                                         foldl1 tyapp $
+                                           map tycon $
+                                            rawname : map hsClassNameForTArg (tapp_tparams x)
           where rawname = snd (hsTemplateClassName (tapp_tclass x))
-        hsrettype (TemplateType t)           = tyapp tyPtr $
-                                                 foldl1 tyapp (tycon rawname : map mkTVar (tclass_params t))
+        hsrettype (TemplateType t)   = tyapp tyPtr $
+                                         foldl1 tyapp (tycon rawname : map mkTVar (tclass_params t))
           where rawname = snd (hsTemplateClassName t)
         hsrettype (TemplateParam p)          = mkTVar p
         hsrettype (TemplateParamPointer p)   = mkTVar p

--- a/fficxx/src/FFICXX/Generate/Dependency.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency.hs
@@ -88,20 +88,10 @@ extractClassFromType (CPT (CPTClassCopy c) _) = [Right c]
 extractClassFromType (CPT (CPTClassMove c) _) = [Right c]
 extractClassFromType (TemplateApp (TemplateAppInfo t ps _)) =
   Left t : (map Right $ mapMaybe (\case TArg_Class c -> Just c; _ -> Nothing) ps)
---              TArg_Class c -> [Right c]
---              _            -> []
 extractClassFromType (TemplateAppRef (TemplateAppInfo t ps _))   =
   Left t : (map Right $ mapMaybe (\case TArg_Class c -> Just c; _ -> Nothing) ps)
-
-
---  case p of
---              TArg_Class c -> [Right c]
---              _            -> []
 extractClassFromType (TemplateAppMove (TemplateAppInfo t ps _))   =
   Left t : (map Right $ mapMaybe (\case TArg_Class c -> Just c; _ -> Nothing) ps)
--- (Left t): case p of
---              TArg_Class c -> [Right c]
---              _            -> []
 extractClassFromType (TemplateType t)         = [Left t]
 extractClassFromType (TemplateParam _)        = []
 extractClassFromType (TemplateParamPointer _) = []

--- a/fficxx/src/FFICXX/Generate/Dependency.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module FFICXX.Generate.Dependency where
@@ -23,7 +24,7 @@ import           Data.Function     ( on )
 import qualified Data.HashMap.Strict as HM
 import           Data.List         ( find, foldl', nub, nubBy )
 import qualified Data.Map as M
-import           Data.Maybe        ( catMaybes, fromMaybe )
+import           Data.Maybe        ( catMaybes, fromMaybe, mapMaybe )
 import           Data.Monoid       ( (<>) )
 import           System.FilePath   ( (<.>) )
 --
@@ -85,18 +86,22 @@ extractClassFromType (CPT (CPTClass c) _)     = [Right c]
 extractClassFromType (CPT (CPTClassRef c) _)  = [Right c]
 extractClassFromType (CPT (CPTClassCopy c) _) = [Right c]
 extractClassFromType (CPT (CPTClassMove c) _) = [Right c]
-extractClassFromType (TemplateApp (TemplateAppInfo t p _)) =
-  (Left t): case p of
-              TArg_Class c -> [Right c]
-              _            -> []
-extractClassFromType (TemplateAppRef (TemplateAppInfo t p _))   =
-  (Left t): case p of
-              TArg_Class c -> [Right c]
-              _            -> []
-extractClassFromType (TemplateAppMove (TemplateAppInfo t p _))   =
-  (Left t): case p of
-              TArg_Class c -> [Right c]
-              _            -> []
+extractClassFromType (TemplateApp (TemplateAppInfo t ps _)) =
+  Left t : (map Right $ mapMaybe (\case TArg_Class c -> Just c; _ -> Nothing) ps)
+--              TArg_Class c -> [Right c]
+--              _            -> []
+extractClassFromType (TemplateAppRef (TemplateAppInfo t ps _))   =
+  Left t : (map Right $ mapMaybe (\case TArg_Class c -> Just c; _ -> Nothing) ps)
+
+
+--  case p of
+--              TArg_Class c -> [Right c]
+--              _            -> []
+extractClassFromType (TemplateAppMove (TemplateAppInfo t ps _))   =
+  Left t : (map Right $ mapMaybe (\case TArg_Class c -> Just c; _ -> Nothing) ps)
+-- (Left t): case p of
+--              TArg_Class c -> [Right c]
+--              _            -> []
 extractClassFromType (TemplateType t)         = [Left t]
 extractClassFromType (TemplateParam _)        = []
 extractClassFromType (TemplateParamPointer _) = []

--- a/fficxx/src/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Class.hs
@@ -148,7 +148,7 @@ newtype Variable =
 -- | Member functions of a template class.
 data TemplateMemberFunction =
   TemplateMemberFunction {
-    tmf_param :: String  -- TODO: multiparameter
+    tmf_params :: [String]
   , tmf_ret :: Types
   , tmf_name :: String
   , tmf_args :: [Arg]

--- a/fficxx/src/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Class.hs
@@ -148,7 +148,7 @@ newtype Variable =
 -- | Member functions of a template class.
 data TemplateMemberFunction =
   TemplateMemberFunction {
-    tmf_param :: String
+    tmf_param :: String  -- TODO: multiparameter
   , tmf_ret :: Types
   , tmf_name :: String
   , tmf_args :: [Arg]

--- a/fficxx/src/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Class.hs
@@ -82,7 +82,7 @@ data TemplateArgType =
 data TemplateAppInfo =
   TemplateAppInfo {
     tapp_tclass :: TemplateClass
-  , tapp_tparam :: TemplateArgType
+  , tapp_tparams :: [TemplateArgType]
   , tapp_CppTypeForParam :: String
   }
   deriving Show

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -23,7 +23,11 @@ import FFICXX.Generate.Type.Cabal  ( BuildType(Simple)
                                    , Cabal(..)
                                    , CabalName(..)
                                    )
-import FFICXX.Generate.Type.Config ( ModuleUnitImports(..), ModuleUnitMap(..), ModuleUnit(..), modImports )
+import FFICXX.Generate.Type.Config ( ModuleUnitImports(..)
+                                   , ModuleUnitMap(..)
+                                   , ModuleUnit(..)
+                                   , modImports
+                                   )
 import FFICXX.Generate.Type.Class  ( Arg(..)
                                    , Class(..)
                                    , ClassAlias(..)
@@ -97,10 +101,18 @@ classes = [ deletable
 toplevelfunctions :: [TopLevelFunction]
 toplevelfunctions = [ ]
 
+t_pair :: TemplateClass
+t_pair =
+  TmplCls cabal "Pair" "std::pair" ["tp1","tp2"]
+    [ TFunNew [Arg (TemplateParam "tp1") "x", Arg (TemplateParam "tp2") "y"] Nothing
+    , TFunDelete
+    ]
+
 t_map :: TemplateClass
 t_map =
   TmplCls cabal "Map" "std::map" ["tpk","tpv"]
     [ TFunNew [] Nothing
+    -- , TFun void_ {- temporary until iterator support -} "insert" "insert" [] Nothing
     , TFun int_  "size" "size" [] Nothing
     , TFunDelete
     ]
@@ -140,7 +152,8 @@ t_shared_ptr =
 
 templates :: [TemplateClassImportHeader]
 templates =
-  [ TCIH t_map        ["map"]
+  [ TCIH t_pair       ["utility"]
+  , TCIH t_map        ["map"]
   , TCIH t_vector     ["vector"]
   , TCIH t_unique_ptr ["memory"]
   , TCIH t_shared_ptr ["memory"]


### PR DESCRIPTION
Functions like the following are now supported.
`void somefunc( T<arg1,arg2>* x )`
`class A { template <T1,T2> void member( T1* a, T2* b); }` 
