### PR TITLE
Support nested types inside template class

### DIFF
--- a/fficxx-multipkg-test/template-dep/Gen.hs
+++ b/fficxx-multipkg-test/template-dep/Gen.hs
@@ -27,6 +27,7 @@ import FFICXX.Generate.Type.Config    ( ModuleUnit(..), ModuleUnitMap(..), Modul
 import FFICXX.Generate.Type.Class     ( Arg(..)
                                       , Class(..)
                                       , CTypes(CTDouble)
+                                      , Form(FormSimple)
                                       , Function(..)
                                       , ProtectedMethod(..)
                                       , TopLevelFunction(..)
@@ -90,7 +91,7 @@ tT1 cabal =
   TmplCls {
     tclass_cabal = cabal
   , tclass_name = "T1"
-  , tclass_oname = "T1"
+  , tclass_cxxform = FormSimple "T1"
   , tclass_params = [ "p1" ]
   , tclass_funcs = [
         TFunNew {
@@ -112,7 +113,7 @@ tT2 cabal =
   TmplCls {
     tclass_cabal = cabal
   , tclass_name = "T2"
-  , tclass_oname = "T2"
+  , tclass_cxxform = FormSimple "T2"
   , tclass_params = [ "p1" ]
   , tclass_funcs = [
         TFunNew {

--- a/fficxx-multipkg-test/template-member/Gen.hs
+++ b/fficxx-multipkg-test/template-member/Gen.hs
@@ -27,6 +27,7 @@ import FFICXX.Generate.Type.Config    ( ModuleUnit(..), ModuleUnitMap(..), Modul
 import FFICXX.Generate.Type.Class     ( Arg(..)
                                       , Class(..)
                                       , CTypes(CTDouble)
+                                      , Form(FormSimple)
                                       , Function(..)
                                       , ProtectedMethod(..)
                                       , TopLevelFunction(..)
@@ -108,7 +109,7 @@ string =
     False
 
 t_vector :: TemplateClass
-t_vector = TmplCls stdcxx_cabal "Vector" "std::vector" ["tp1"]
+t_vector = TmplCls stdcxx_cabal "Vector" (FormSimple "std::vector") ["tp1"]
              [ TFunNew [] Nothing
              , TFun void_ "push_back" "push_back"   [Arg (TemplateParam "tp1") "x"] Nothing
              , TFun void_ "pop_back"  "pop_back"    []                        Nothing
@@ -118,7 +119,7 @@ t_vector = TmplCls stdcxx_cabal "Vector" "std::vector" ["tp1"]
              ]
 
 t_unique_ptr :: TemplateClass
-t_unique_ptr = TmplCls stdcxx_cabal "UniquePtr" "std::unique_ptr" ["tp1"]
+t_unique_ptr = TmplCls stdcxx_cabal "UniquePtr" (FormSimple "std::unique_ptr") ["tp1"]
              [ TFunNew [] (Just "newUniquePtr0")
              , TFunNew [Arg (TemplateParamPointer "tp1") "p"] Nothing
              , TFun (TemplateParamPointer "tp1") "get" "get" [] Nothing

--- a/fficxx-test/test/MapSpec.hs
+++ b/fficxx-test/test/MapSpec.hs
@@ -16,6 +16,8 @@ import FFICXX.Runtime.CodeGen.Cxx ( HeaderName(..), Namespace(..) )
 import FFICXX.Runtime.TH          ( IsCPrimitive(..), TemplateParamInfo(..) )
 import STD.Map.Template
 import STD.Map.TH
+import STD.MapIterator.Template
+import STD.MapIterator.TH
 import STD.Pair.Template
 import STD.Pair.TH
 --
@@ -52,6 +54,21 @@ genMapInstanceFor
                          }
   )
 
+genMapIteratorInstanceFor
+  CPrim
+  ( [t|CInt|], TPInfo { tpinfoCxxType       = "int"
+                      , tpinfoCxxHeaders    = []
+                      , tpinfoCxxNamespaces = []
+                      , tpinfoSuffix        = "int"
+                      }
+  )
+  ( [t|CDouble|], TPInfo { tpinfoCxxType       = "double"
+                         , tpinfoCxxHeaders    = []
+                         , tpinfoCxxNamespaces = []
+                         , tpinfoSuffix        = "double"
+                         }
+  )
+
 
 spec :: Spec
 spec =
@@ -66,3 +83,6 @@ spec =
           insert m kv
           n <- size m
           n `shouldBe` 1
+        it "should retrieve value via iterator" $ \m -> do
+          iter <- begin m
+          True `shouldBe` True

--- a/fficxx/src/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Class.hs
@@ -267,14 +267,19 @@ data TemplateFunction =
     }
   | TFunDelete
 
+-- TODO: Generalize this further.
+-- | Positional string interpolation form.
+--   For example, "std::map<K,V>::iterator" is FormNested "std::map" "iterator"].
+data Form = FormSimple String
+          | FormNested String String
 
 data TemplateClass =
   TmplCls {
-    tclass_cabal  :: Cabal
-  , tclass_name   :: String
-  , tclass_oname  :: String
-  , tclass_params :: [String]
-  , tclass_funcs  :: [TemplateFunction]
+    tclass_cabal   :: Cabal
+  , tclass_name    :: String
+  , tclass_cxxform :: Form
+  , tclass_params  :: [String]
+  , tclass_funcs   :: [TemplateFunction]
   }
 
 -- TODO: we had better not override standard definitions

--- a/fficxx/src/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Class.hs
@@ -83,7 +83,7 @@ data TemplateAppInfo =
   TemplateAppInfo {
     tapp_tclass :: TemplateClass
   , tapp_tparams :: [TemplateArgType]
-  , tapp_CppTypeForParam :: String
+  , tapp_CppTypeForParam :: String -- TODO: remove this
   }
   deriving Show
 

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -31,7 +31,7 @@ import FFICXX.Generate.Type.Config ( ModuleUnitImports(..)
 import FFICXX.Generate.Type.Class  ( Arg(..)
                                    , Class(..)
                                    , ClassAlias(..)
-                                   , Form(FormSimple)
+                                   , Form(FormNested,FormSimple)
                                    , Function(..)
                                    , TemplateAppInfo(..)
                                    , TemplateArgType(..)
@@ -116,7 +116,19 @@ t_map =
   TmplCls cabal "Map" (FormSimple "std::map") ["tpk","tpv"]
     [ TFunNew [] Nothing
     , TFun
-        void_ {- temporary until iterator support -}
+        (TemplateAppRef
+          TemplateAppInfo {
+            tapp_tclass = t_map_iterator
+          , tapp_tparams = [TArg_TypeParam "tpk", TArg_TypeParam "tpv"]
+          , tapp_CppTypeForParam = "std::map<tpk,tpv>::iterator"
+          }
+        )
+        "begin"
+        "begin"
+        []
+        Nothing
+    , TFun
+        void_ -- until pair<iterator,bool> is allowed
         "insert"
         "insert"
         [ Arg
@@ -132,6 +144,12 @@ t_map =
         Nothing
     , TFun int_  "size" "size" [] Nothing
     , TFunDelete
+    ]
+
+t_map_iterator :: TemplateClass
+t_map_iterator =
+  TmplCls cabal "MapIterator" (FormNested "std::map" "iterator") ["tpk","tpv"]
+    [
     ]
 
 t_vector :: TemplateClass
@@ -169,11 +187,12 @@ t_shared_ptr =
 
 templates :: [TemplateClassImportHeader]
 templates =
-  [ TCIH t_pair       ["utility"]
-  , TCIH t_map        ["map"]
-  , TCIH t_vector     ["vector"]
-  , TCIH t_unique_ptr ["memory"]
-  , TCIH t_shared_ptr ["memory"]
+  [ TCIH t_pair         ["utility"]
+  , TCIH t_map          ["map"]
+  , TCIH t_map_iterator ["map"]
+  , TCIH t_vector       ["vector"]
+  , TCIH t_unique_ptr   ["memory"]
+  , TCIH t_shared_ptr   ["memory"]
   ]
 
 headers :: [ (ModuleUnit, ModuleUnitImports) ]

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -31,6 +31,7 @@ import FFICXX.Generate.Type.Config ( ModuleUnitImports(..)
 import FFICXX.Generate.Type.Class  ( Arg(..)
                                    , Class(..)
                                    , ClassAlias(..)
+                                   , Form(FormSimple)
                                    , Function(..)
                                    , TemplateAppInfo(..)
                                    , TemplateArgType(..)
@@ -105,14 +106,14 @@ toplevelfunctions = [ ]
 
 t_pair :: TemplateClass
 t_pair =
-  TmplCls cabal "Pair" "std::pair" ["tp1","tp2"]
+  TmplCls cabal "Pair" (FormSimple "std::pair") ["tp1","tp2"]
     [ TFunNew [Arg (TemplateParam "tp1") "x", Arg (TemplateParam "tp2") "y"] Nothing
     , TFunDelete
     ]
 
 t_map :: TemplateClass
 t_map =
-  TmplCls cabal "Map" "std::map" ["tpk","tpv"]
+  TmplCls cabal "Map" (FormSimple "std::map") ["tpk","tpv"]
     [ TFunNew [] Nothing
     , TFun
         void_ {- temporary until iterator support -}
@@ -135,7 +136,7 @@ t_map =
 
 t_vector :: TemplateClass
 t_vector =
-  TmplCls cabal "Vector" "std::vector"      ["tp1"]
+  TmplCls cabal "Vector" (FormSimple "std::vector") ["tp1"]
     [ TFunNew [] Nothing
     , TFun void_ "push_back" "push_back"    [Arg (TemplateParam "tp1") "x"] Nothing
     , TFun void_ "pop_back"  "pop_back"     []                        Nothing
@@ -146,7 +147,7 @@ t_vector =
 
 t_unique_ptr :: TemplateClass
 t_unique_ptr =
-  TmplCls cabal "UniquePtr" "std::unique_ptr" ["tp1"]
+  TmplCls cabal "UniquePtr" (FormSimple "std::unique_ptr") ["tp1"]
     [ TFunNew [] (Just "newUniquePtr0")
     , TFunNew [Arg (TemplateParamPointer "tp1") "p"] Nothing
     , TFun (TemplateParamPointer "tp1") "get" "get" [] Nothing
@@ -157,7 +158,7 @@ t_unique_ptr =
 
 t_shared_ptr :: TemplateClass
 t_shared_ptr =
-  TmplCls cabal "SharedPtr" "std::shared_ptr" ["tp1"]
+  TmplCls cabal "SharedPtr" (FormSimple "std::shared_ptr") ["tp1"]
     [ TFunNew [] (Just "newSharedPtr0")
     , TFunNew [Arg (TemplateParamPointer "tp1") "p"] Nothing
     , TFun (TemplateParamPointer "tp1") "get" "get" [] Nothing


### PR DESCRIPTION
Towards `map<k,v>::iterator`, introduce `Form` supporting both simple template and nested class inside template.