### PR TITLE
accessor for member variables of C++ template

### DIFF
--- a/fficxx-multipkg-test/template-dep/Gen.hs
+++ b/fficxx-multipkg-test/template-dep/Gen.hs
@@ -105,6 +105,7 @@ tT1 cabal =
         , tfun_args = []
         }
     ]
+  , tclass_vars = []
   }
 
 tT2 :: Cabal -> TemplateClass
@@ -135,13 +136,14 @@ tT2 cabal =
                       ]
         }
     ]
+  , tclass_vars = []
   }
 
 classes :: Cabal -> [Class]
-classes cabal = [ ]
+classes cabal = []
 
 toplevelfunctions :: [TopLevelFunction]
-toplevelfunctions = [ ]
+toplevelfunctions = []
 
 templates :: Cabal -> [TemplateClassImportHeader]
 templates cabal =
@@ -151,7 +153,7 @@ templates cabal =
 
 headers :: [(ModuleUnit, ModuleUnitImports)]
 headers =
-  [ ]
+  []
 
 main :: IO ()
 main = do

--- a/fficxx-multipkg-test/template-dep/Gen.hs
+++ b/fficxx-multipkg-test/template-dep/Gen.hs
@@ -103,7 +103,6 @@ tT1 cabal =
         , tfun_name = "method"
         , tfun_oname = "method"
         , tfun_args = []
-        , tfun_alias = Nothing
         }
     ]
   }
@@ -134,7 +133,6 @@ tT2 cabal =
                           )
                           "tmpl1"
                       ]
-        , tfun_alias = Nothing
         }
     ]
   }

--- a/fficxx-multipkg-test/template-member/Gen.hs
+++ b/fficxx-multipkg-test/template-member/Gen.hs
@@ -109,24 +109,28 @@ string =
     False
 
 t_vector :: TemplateClass
-t_vector = TmplCls stdcxx_cabal "Vector" (FormSimple "std::vector") ["tp1"]
-             [ TFunNew [] Nothing
-             , TFun void_ "push_back" "push_back"   [Arg (TemplateParam "tp1") "x"]
-             , TFun void_ "pop_back"  "pop_back"    []
-             , TFun (TemplateParam "tp1") "at" "at" [int "n"]
-             , TFun int_  "size"      "size"        []
-             , TFunDelete
-             ]
+t_vector =
+  TmplCls stdcxx_cabal "Vector" (FormSimple "std::vector") ["tp1"]
+    [ TFunNew [] Nothing
+    , TFun void_ "push_back" "push_back"   [Arg (TemplateParam "tp1") "x"]
+    , TFun void_ "pop_back"  "pop_back"    []
+    , TFun (TemplateParam "tp1") "at" "at" [int "n"]
+    , TFun int_  "size"      "size"        []
+    , TFunDelete
+    ]
+    []
 
 t_unique_ptr :: TemplateClass
-t_unique_ptr = TmplCls stdcxx_cabal "UniquePtr" (FormSimple "std::unique_ptr") ["tp1"]
-             [ TFunNew [] (Just "newUniquePtr0")
-             , TFunNew [Arg (TemplateParamPointer "tp1") "p"] Nothing
-             , TFun (TemplateParamPointer "tp1") "get" "get" []
-             , TFun (TemplateParamPointer "tp1") "release" "release" []
-             , TFun void_ "reset" "reset" []
-             , TFunDelete
-             ]
+t_unique_ptr =
+  TmplCls stdcxx_cabal "UniquePtr" (FormSimple "std::unique_ptr") ["tp1"]
+    [ TFunNew [] (Just "newUniquePtr0")
+    , TFunNew [Arg (TemplateParamPointer "tp1") "p"] Nothing
+    , TFun (TemplateParamPointer "tp1") "get" "get" []
+    , TFun (TemplateParamPointer "tp1") "release" "release" []
+    , TFun void_ "reset" "reset" []
+    , TFunDelete
+    ]
+    []
 
 -- -------------------------------------------------------------------
 -- tmf-test

--- a/fficxx-multipkg-test/template-member/Gen.hs
+++ b/fficxx-multipkg-test/template-member/Gen.hs
@@ -111,10 +111,10 @@ string =
 t_vector :: TemplateClass
 t_vector = TmplCls stdcxx_cabal "Vector" (FormSimple "std::vector") ["tp1"]
              [ TFunNew [] Nothing
-             , TFun void_ "push_back" "push_back"   [Arg (TemplateParam "tp1") "x"] Nothing
-             , TFun void_ "pop_back"  "pop_back"    []                        Nothing
-             , TFun (TemplateParam "tp1") "at" "at" [int "n"]                 Nothing
-             , TFun int_  "size"      "size"        []                        Nothing
+             , TFun void_ "push_back" "push_back"   [Arg (TemplateParam "tp1") "x"]
+             , TFun void_ "pop_back"  "pop_back"    []
+             , TFun (TemplateParam "tp1") "at" "at" [int "n"]
+             , TFun int_  "size"      "size"        []
              , TFunDelete
              ]
 
@@ -122,9 +122,9 @@ t_unique_ptr :: TemplateClass
 t_unique_ptr = TmplCls stdcxx_cabal "UniquePtr" (FormSimple "std::unique_ptr") ["tp1"]
              [ TFunNew [] (Just "newUniquePtr0")
              , TFunNew [Arg (TemplateParamPointer "tp1") "p"] Nothing
-             , TFun (TemplateParamPointer "tp1") "get" "get" [] Nothing
-             , TFun (TemplateParamPointer "tp1") "release" "release" [] Nothing
-             , TFun void_ "reset" "reset" [] Nothing
+             , TFun (TemplateParamPointer "tp1") "get" "get" []
+             , TFun (TemplateParamPointer "tp1") "release" "release" []
+             , TFun void_ "reset" "reset" []
              , TFunDelete
              ]
 

--- a/fficxx-runtime/src/FFICXX/Runtime/TH.hs
+++ b/fficxx-runtime/src/FFICXX/Runtime/TH.hs
@@ -43,15 +43,14 @@ data FunctionParamInfo =
   }
   deriving Show
 
-
 con :: String -> Type
 con = ConT . mkNameS
 
-
+-- |
 mkInstance :: Cxt -> Type -> [Dec] -> Dec
 mkInstance = InstanceD Nothing
 
-
+-- |
 mkTFunc :: (types, String, String -> String, types -> Q Type) -> Q Exp
 mkTFunc (typs, suffix, nf, tyf)
   = do let fn = nf suffix
@@ -61,7 +60,7 @@ mkTFunc (typs, suffix, nf, tyf)
        addTopDecls [d]
        [| $( varE n ) |]
 
-
+-- |
 mkMember :: String -> (types -> String -> Q Exp) -> types -> String -> Q Dec
 mkMember fname f typ suffix = do
   let x = mkNameS "x"
@@ -69,7 +68,7 @@ mkMember fname f typ suffix = do
   pure $
     FunD (mkNameS fname) [ Clause [VarP x] (NormalB (AppE e (VarE x))) [] ]
 
-
+-- |
 mkNew :: String -> (types -> String -> Q Exp) -> types -> String -> Q Dec
 mkNew fname f typ suffix = do
   e <- f typ suffix
@@ -77,6 +76,6 @@ mkNew fname f typ suffix = do
     FunD (mkNameS fname)
       [ Clause [] (NormalB e) [] ]
 
-
+-- |
 mkDelete :: String -> (types -> String -> Q Exp) -> types -> String -> Q Dec
 mkDelete = mkMember

--- a/fficxx-test/fficxx-test.cabal
+++ b/fficxx-test/fficxx-test.cabal
@@ -25,6 +25,7 @@ test-suite hspec
   main-is:       Main.hs
   other-modules: FunctionSpec
                  MapSpec
+                 PairSpec
                  SharedPtrSpec
                  UniquePtrSpec
                  VectorSpec

--- a/fficxx-test/test/PairSpec.hs
+++ b/fficxx-test/test/PairSpec.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables      #-}
 {-# LANGUAGE TemplateHaskell          #-}
 
-module MapSpec ( spec ) where
+module PairSpec ( spec ) where
 
 import Control.Exception          ( bracket )
 import qualified Data.ByteString.Char8 as B
@@ -14,15 +14,30 @@ import Foreign.C.String
 --
 import FFICXX.Runtime.CodeGen.Cxx ( HeaderName(..), Namespace(..) )
 import FFICXX.Runtime.TH          ( IsCPrimitive(..), TemplateParamInfo(..) )
-import STD.Map.Template
-import STD.Map.TH
-import STD.MapIterator.Template
-import STD.MapIterator.TH
 import STD.Pair.Template
 import STD.Pair.TH
 --
 import Test.Hspec     ( Spec, afterAll, beforeAll, describe, it, shouldBe )
 
+
+genPairInstanceFor
+  CPrim
+  ( [t|CInt|], TPInfo { tpinfoCxxType       = "int"
+                      , tpinfoCxxHeaders    = []
+                      , tpinfoCxxNamespaces = []
+                      , tpinfoSuffix        = "int"
+                      }
+  )
+  ( [t|CInt|], TPInfo { tpinfoCxxType       = "int"
+                      , tpinfoCxxHeaders    = []
+                      , tpinfoCxxNamespaces = []
+                      , tpinfoSuffix        = "int"
+                      }
+  )
+
+{-
+-- TODO: resolve this.
+-- this caused conflict with MapSpec.
 
 genPairInstanceFor
   CPrim
@@ -38,51 +53,25 @@ genPairInstanceFor
                          , tpinfoSuffix        = "double"
                          }
   )
-
-genMapInstanceFor
-  CPrim
-  ( [t|CInt|], TPInfo { tpinfoCxxType       = "int"
-                      , tpinfoCxxHeaders    = []
-                      , tpinfoCxxNamespaces = []
-                      , tpinfoSuffix        = "int"
-                      }
-  )
-  ( [t|CDouble|], TPInfo { tpinfoCxxType       = "double"
-                         , tpinfoCxxHeaders    = []
-                         , tpinfoCxxNamespaces = []
-                         , tpinfoSuffix        = "double"
-                         }
-  )
-
-genMapIteratorInstanceFor
-  CPrim
-  ( [t|CInt|], TPInfo { tpinfoCxxType       = "int"
-                      , tpinfoCxxHeaders    = []
-                      , tpinfoCxxNamespaces = []
-                      , tpinfoSuffix        = "int"
-                      }
-  )
-  ( [t|CDouble|], TPInfo { tpinfoCxxType       = "double"
-                         , tpinfoCxxHeaders    = []
-                         , tpinfoCxxNamespaces = []
-                         , tpinfoSuffix        = "double"
-                         }
-  )
-
-
+-}
 spec :: Spec
 spec =
-  describe "FFI to map" $ do
-    beforeAll (newMap :: IO (Map CInt CDouble)) . afterAll deleteMap $
-      describe "map<int,double>" $ do
-        it "should have no elements at first" $ \m -> do
-          n <- size m
-          n `shouldBe` 0
-        it "should have 1 elem after insertion" $ \m -> do
-          kv <- newPair 1 123.0 :: IO (Pair CInt CDouble)
-          insert m kv
-          n <- size m
-          n `shouldBe` 1
-        it "should retrieve value via iterator" $ \m -> do
-          iter <- begin m
-          True `shouldBe` True
+  describe "FFI to pair" $ do
+    beforeAll (newPair 1 123 :: IO (Pair CInt CInt)) . afterAll deletePair $
+      describe "pair<int,int>" $ do
+        it "should get first element" $ \kv -> do
+          k <- first_get kv
+          k `shouldBe` 1
+        it "should get second element" $ \kv -> do
+          v <- second_get kv
+          v `shouldBe` 123
+-- TODO: make the following work or prohibited.
+{-        it "should change first element" $ \kv -> do
+          first_set kv 2
+          k <- first_get kv
+          k `shouldBe` 2
+        it "should change second element" $ \kv -> do
+          second_set kv 246
+          v <- second_get kv
+          v `shouldBe` 246
+-}

--- a/fficxx-test/test/PairSpec.hs
+++ b/fficxx-test/test/PairSpec.hs
@@ -65,8 +65,7 @@ spec =
         it "should get second element" $ \kv -> do
           v <- second_get kv
           v `shouldBe` 123
--- TODO: make the following work or prohibited.
-{-        it "should change first element" $ \kv -> do
+        it "should change first element" $ \kv -> do
           first_set kv 2
           k <- first_get kv
           k `shouldBe` 2
@@ -74,4 +73,3 @@ spec =
           second_set kv 246
           v <- second_get kv
           v `shouldBe` 246
--}

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -181,12 +181,12 @@ genImportInTemplate t0 =
   in     flip map deps_raw
            (\case
              Left t -> mkImport (getTClassModuleBase t <.> "Template")
-             Right c -> mkImport (getClassModuleBase c <.>"RawType")
+             Right c -> mkImport (getClassModuleBase c <.> "RawType")
            )
       <> flip map deps_high
            (\case
              Left t -> mkImport (getTClassModuleBase t <.> "Template")
-             Right c -> mkImport (getClassModuleBase c <.>"Interface")
+             Right c -> mkImport (getClassModuleBase c <.> "Interface")
            )
 
 -- |

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -320,6 +320,13 @@ genTmplInstance tcih =
                                                      `app` typs_v
                                                      `app` v    "suffix"
                                        )
+        genstmt (n,f@TFunOp  {..}) = generator
+                                       (p ("f"<>show n))
+                                       (v "mkMember" `app` strE (hsTmplFuncName t f)
+                                                     `app` v    (hsTmplFuncNameTH t f)
+                                                     `app` typs_v
+                                                     `app` v    "suffix"
+                                       )
         lststmt xs = [ pbind_ (p "lst") (listE (map (v . (\n->"f"<>show n) . fst) xs)) ]
         -- TODO: refactor out the following code.
         foreignSrcStmt =

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -35,9 +35,11 @@ import FFICXX.Generate.Name           ( ffiTmplFuncName
                                       , hsTemplateMemberFunctionNameTH
                                       , hsTmplFuncName
                                       , hsTmplFuncNameTH
+                                      , tmplAccessorName
                                       , typeclassNameT
                                       )
-import FFICXX.Generate.Type.Class     ( Arg(..)
+import FFICXX.Generate.Type.Class     ( Accessor(Getter,Setter)
+                                      , Arg(..)
                                       , Class(..)
                                       , TemplateClass(..)
                                       , TemplateFunction(..)
@@ -206,14 +208,14 @@ genTmplInterface t =
    hightype    = foldl1 tyapp (tycon hname : map mkTVar tps)
    sigdecl f   = mkFunSig (hsTmplFuncName t f) (functionSignatureT t f)
    sigdeclV vf = let Variable (Arg {..}) = vf
-                     fg = TFun { tfun_ret  = arg_type
-                               , tfun_name = arg_name <> "_get"
-                               , tfun_oname = arg_name <> "_get"
-                               , tfun_args = []
+                     fg = TFun { tfun_ret   = arg_type
+                               , tfun_name  = tmplAccessorName vf Getter
+                               , tfun_oname = tmplAccessorName vf Getter
+                               , tfun_args  = []
                                }
-                     fs = TFun { tfun_ret  = Void
-                               , tfun_name = arg_name <> "_set"
-                               , tfun_oname = arg_name <> "_set"
+                     fs = TFun { tfun_ret   = Void
+                               , tfun_name  = tmplAccessorName vf Setter
+                               , tfun_oname = tmplAccessorName vf Setter
                                , tfun_args = [Arg arg_type "value"]
                                }
                  in [sigdecl fg, sigdecl fs]

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -386,8 +386,8 @@ genTmplInstance tcih =
                  ++ map (genTmplFunCpp CPrim    t) fs
                  ++ concatMap (genTmplVarCpp NonCPrim t) vfs
                  ++ concatMap (genTmplVarCpp CPrim    t) vfs
-                 ++ [ genTmplClassCpp NonCPrim t fs
-                    , genTmplClassCpp CPrim    t fs
+                 ++ [ genTmplClassCpp NonCPrim t (fs,vfs)
+                    , genTmplClassCpp CPrim    t (fs,vfs)
                     ]
         includeStatic =
           strE $ concatMap (<> "\n")

--- a/fficxx/src/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Primitive.hs
@@ -15,6 +15,7 @@ import FFICXX.Generate.Name         ( ffiClassName
                                     , hsClassName
                                     , hsClassNameForTArg
                                     , hsTemplateClassName
+                                    , tmplAccessorName
                                     , typeclassName
                                     , typeclassNameFromStr
                                     )
@@ -33,7 +34,7 @@ import FFICXX.Generate.Type.Class   ( Accessor(Getter,Setter)
                                     , TemplateFunction(..)
                                     , TemplateMemberFunction(..)
                                     , Types(..)
-                                    , Variable(unVariable)
+                                    , Variable(..)
                                     , argsFromOpExp
                                     , isNonVirtualFunc
                                     , isVirtualFunc
@@ -881,6 +882,21 @@ functionSignatureTMF c f = foldr1 tyfun (lst <> [tyapp (tycon "IO") ctyp])
     ctyp = convertCpp2HS4Tmpl e Nothing spls (tmf_ret f)
     e = tycon (fst (hsClassName c))
     lst = e : map (convertCpp2HS4Tmpl e Nothing spls . arg_type) (tmf_args f)
+
+
+tmplAccessorToTFun :: Variable -> Accessor -> TemplateFunction
+tmplAccessorToTFun v@(Variable (Arg {..})) a =
+  case a of
+    Getter -> TFun { tfun_ret   = arg_type
+                   , tfun_name  = tmplAccessorName v Getter
+                   , tfun_oname = tmplAccessorName v Getter
+                   , tfun_args  = []
+                   }
+    Setter -> TFun { tfun_ret   = Void
+                   , tfun_name  = tmplAccessorName v Setter
+                   , tfun_oname = tmplAccessorName v Setter
+                   , tfun_args = [Arg arg_type "value"]
+                   }
 
 
 accessorCFunSig :: Types -> Accessor -> CFunSig

--- a/fficxx/src/FFICXX/Generate/Dependency.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency.hs
@@ -156,7 +156,7 @@ extractClassDep (Destructor _) =
 
 -- |
 extractClassDepForTmplFun :: TemplateFunction -> Dep4Func
-extractClassDepForTmplFun (TFun ret  _ _ args _) =
+extractClassDepForTmplFun (TFun ret  _ _ args) =
     Dep4Func (extractClassFromType ret) (concatMap classFromArg args)
 extractClassDepForTmplFun (TFunNew args _) =
     Dep4Func [] (concatMap classFromArg args)

--- a/fficxx/src/FFICXX/Generate/Dependency.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency.hs
@@ -48,6 +48,7 @@ import FFICXX.Generate.Type.Class  ( Arg(..)
                                    , TopLevelFunction(..)
                                    , Types(..)
                                    , Variable(unVariable)
+                                   , argsFromOpExp
                                    )
 import FFICXX.Generate.Type.Config ( ModuleUnit(..)
                                    , ModuleUnitImports(..)
@@ -162,6 +163,8 @@ extractClassDepForTmplFun (TFunNew args _) =
     Dep4Func [] (concatMap classFromArg args)
 extractClassDepForTmplFun TFunDelete =
     Dep4Func [] []
+extractClassDepForTmplFun (TFunOp ret  _ e) =
+    Dep4Func (extractClassFromType ret) (concatMap classFromArg $ argsFromOpExp e)
 
 -- |
 extractClassDep4TmplMemberFun :: TemplateMemberFunction -> Dep4Func

--- a/fficxx/src/FFICXX/Generate/Name.hs
+++ b/fficxx/src/FFICXX/Generate/Name.hs
@@ -108,6 +108,7 @@ cppTmplFuncName f =
     TFunDelete   -> "delete"
     TFunOp {..}  -> tfun_name
 
+-- |
 accessorName :: Class -> Variable -> Accessor -> String
 accessorName c v a =    nonvirtualName c (arg_name (unVariable v))
                      <> "_"
@@ -115,13 +116,20 @@ accessorName c v a =    nonvirtualName c (arg_name (unVariable v))
                           Getter -> "get"
                           Setter -> "set"
 
+-- |
 hscAccessorName :: Class -> Variable -> Accessor -> String
 hscAccessorName c v a = "c_" <> toLowers (accessorName c v a)
 
+-- |
+tmplAccessorName :: Variable -> Accessor -> String
+tmplAccessorName (Variable (Arg _ n)) a =
+     n <> "_" <> case a of { Getter -> "get"; Setter -> "set" }
 
+-- |
 cppStaticName :: Class -> Function -> String
 cppStaticName c f = class_name c <> "::" <> func_name f
 
+-- |
 cppFuncName :: Class -> Function -> String
 cppFuncName c f =   case f of
     Constructor _ _ -> "new"

--- a/fficxx/src/FFICXX/Generate/Name.hs
+++ b/fficxx/src/FFICXX/Generate/Name.hs
@@ -94,7 +94,7 @@ hsTemplateMemberFunctionNameTH c f = "t_" <> hsTemplateMemberFunctionName c f
 ffiTmplFuncName :: TemplateFunction -> String
 ffiTmplFuncName f =
   case f of
-    TFun {..}    -> fromMaybe tfun_name tfun_alias
+    TFun {..}    -> tfun_name
     TFunNew {..} -> fromMaybe "new" tfun_new_alias
     TFunDelete   -> "delete"
 

--- a/fficxx/src/FFICXX/Generate/Name.hs
+++ b/fficxx/src/FFICXX/Generate/Name.hs
@@ -70,15 +70,16 @@ aliasedFuncName c f =
     Static _ str _ a     -> fromMaybe (nonvirtualName c str) a
     Destructor a         -> fromMaybe destructorName a
 
-
+-- |
 hsTmplFuncName :: TemplateClass -> TemplateFunction -> String
 hsTmplFuncName t f =
   case f of
-    TFun {..}    -> tfun_name  -- TODO: alias
+    TFun {..}    -> tfun_name
     TFunNew {..} -> fromMaybe ("new"<> tclass_name t) tfun_new_alias
     TFunDelete   -> "delete" <> tclass_name t
+    TFunOp {..}  -> tfun_name
 
-
+-- |
 hsTmplFuncNameTH :: TemplateClass -> TemplateFunction -> String
 hsTmplFuncNameTH t f = "t_" <> hsTmplFuncName t f
 
@@ -97,7 +98,7 @@ ffiTmplFuncName f =
     TFun {..}    -> tfun_name
     TFunNew {..} -> fromMaybe "new" tfun_new_alias
     TFunDelete   -> "delete"
-
+    TFunOp {..}  -> tfun_name
 
 cppTmplFuncName :: TemplateFunction -> String
 cppTmplFuncName f =
@@ -105,6 +106,7 @@ cppTmplFuncName f =
     TFun {..}    -> tfun_name
     TFunNew {..} -> "new"
     TFunDelete   -> "delete"
+    TFunOp {..}  -> tfun_name
 
 accessorName :: Class -> Variable -> Accessor -> String
 accessorName c v a =    nonvirtualName c (arg_name (unVariable v))

--- a/fficxx/src/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Class.hs
@@ -259,7 +259,7 @@ data TemplateFunction =
     , tfun_name :: String
     , tfun_oname :: String
     , tfun_args :: [Arg]
-    , tfun_alias :: Maybe String
+    -- , tfun_alias :: Maybe String
     }
   | TFunNew {
       tfun_new_args :: [Arg]

--- a/fficxx/src/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Class.hs
@@ -252,6 +252,9 @@ instance Eq Class where
 instance Ord Class where
   compare x y = compare (class_name x) (class_name y)
 
+data OpExp = OpStar Arg
+           --    | OpAdd Arg Arg
+           --    | OpMul Arg Arg
 
 data TemplateFunction =
     TFun {
@@ -259,13 +262,29 @@ data TemplateFunction =
     , tfun_name :: String
     , tfun_oname :: String
     , tfun_args :: [Arg]
-    -- , tfun_alias :: Maybe String
     }
   | TFunNew {
       tfun_new_args :: [Arg]
     , tfun_new_alias :: Maybe String
     }
   | TFunDelete
+  | TFunOp {
+      tfun_ret :: Types
+    , tfun_name :: String  -- ^ haskell alias for the operator
+    , tfun_opexp :: OpExp
+    -- , tfun_oname :: String -- ^ operator
+    -- , tfun_args :: [Arg]
+    }
+
+argsFromOpExp :: OpExp -> [Arg]
+argsFromOpExp (OpStar x)  = [x]
+-- argsFromOpExp (OpAdd x y) = [x,y]
+-- argsFromOpExp (OpMul x y) = [x,y]
+
+opSymbol :: OpExp -> String
+opSymbol (OpStar _) = "*"
+-- opSymbol (OpAdd _ _) = "+"
+-- opSymbol (OpMul _ _) = "*"
 
 -- TODO: Generalize this further.
 -- | Positional string interpolation form.

--- a/fficxx/src/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Class.hs
@@ -272,8 +272,6 @@ data TemplateFunction =
       tfun_ret :: Types
     , tfun_name :: String  -- ^ haskell alias for the operator
     , tfun_opexp :: OpExp
-    -- , tfun_oname :: String -- ^ operator
-    -- , tfun_args :: [Arg]
     }
 
 argsFromOpExp :: OpExp -> [Arg]
@@ -299,6 +297,7 @@ data TemplateClass =
   , tclass_cxxform :: Form
   , tclass_params  :: [String]
   , tclass_funcs   :: [TemplateFunction]
+  , tclass_vars :: [Variable]
   }
 
 -- TODO: we had better not override standard definitions

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -110,6 +110,7 @@ t_pair =
     [ TFunNew [Arg (TemplateParam "tp1") "x", Arg (TemplateParam "tp2") "y"] Nothing
     , TFunDelete
     ]
+    []
 
 t_map :: TemplateClass
 t_map =
@@ -143,12 +144,13 @@ t_map =
     , TFun int_  "size" "size" []
     , TFunDelete
     ]
+    []
 
 t_map_iterator :: TemplateClass
 t_map_iterator =
   TmplCls cabal "MapIterator" (FormNested "std::map" "iterator") ["tpk","tpv"]
-    [
-    ]
+    []
+    []
 
 t_vector :: TemplateClass
 t_vector =
@@ -160,6 +162,7 @@ t_vector =
     , TFun int_  "size"      "size"         []
     , TFunDelete
     ]
+    []
 
 t_unique_ptr :: TemplateClass
 t_unique_ptr =
@@ -171,6 +174,7 @@ t_unique_ptr =
     , TFun void_ "reset" "reset" []
     , TFunDelete
     ]
+    []
 
 t_shared_ptr :: TemplateClass
 t_shared_ptr =
@@ -182,6 +186,7 @@ t_shared_ptr =
     , TFun int_ "use_count" "use_count" []
     , TFunDelete
     ]
+    []
 
 templates :: [TemplateClassImportHeader]
 templates =

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -126,7 +126,6 @@ t_map =
         "begin"
         "begin"
         []
-        Nothing
     , TFun
         void_ -- until pair<iterator,bool> is allowed
         "insert"
@@ -141,8 +140,7 @@ t_map =
             )
             "val"
         ]
-        Nothing
-    , TFun int_  "size" "size" [] Nothing
+    , TFun int_  "size" "size" []
     , TFunDelete
     ]
 
@@ -156,10 +154,10 @@ t_vector :: TemplateClass
 t_vector =
   TmplCls cabal "Vector" (FormSimple "std::vector") ["tp1"]
     [ TFunNew [] Nothing
-    , TFun void_ "push_back" "push_back"    [Arg (TemplateParam "tp1") "x"] Nothing
-    , TFun void_ "pop_back"  "pop_back"     []                        Nothing
-    , TFun (TemplateParam "tp1") "at" "at" [int "n"]                 Nothing
-    , TFun int_  "size"      "size"         []                        Nothing
+    , TFun void_ "push_back" "push_back"    [Arg (TemplateParam "tp1") "x"]
+    , TFun void_ "pop_back"  "pop_back"     []
+    , TFun (TemplateParam "tp1") "at" "at" [int "n"]
+    , TFun int_  "size"      "size"         []
     , TFunDelete
     ]
 
@@ -168,9 +166,9 @@ t_unique_ptr =
   TmplCls cabal "UniquePtr" (FormSimple "std::unique_ptr") ["tp1"]
     [ TFunNew [] (Just "newUniquePtr0")
     , TFunNew [Arg (TemplateParamPointer "tp1") "p"] Nothing
-    , TFun (TemplateParamPointer "tp1") "get" "get" [] Nothing
-    , TFun (TemplateParamPointer "tp1") "release" "release" [] Nothing
-    , TFun void_ "reset" "reset" [] Nothing
+    , TFun (TemplateParamPointer "tp1") "get" "get" []
+    , TFun (TemplateParamPointer "tp1") "release" "release" []
+    , TFun void_ "reset" "reset" []
     , TFunDelete
     ]
 
@@ -179,9 +177,9 @@ t_shared_ptr =
   TmplCls cabal "SharedPtr" (FormSimple "std::shared_ptr") ["tp1"]
     [ TFunNew [] (Just "newSharedPtr0")
     , TFunNew [Arg (TemplateParamPointer "tp1") "p"] Nothing
-    , TFun (TemplateParamPointer "tp1") "get" "get" [] Nothing
-    , TFun void_ "reset" "reset" [] Nothing
-    , TFun int_ "use_count" "use_count" [] Nothing
+    , TFun (TemplateParamPointer "tp1") "get" "get" []
+    , TFun void_ "reset" "reset" []
+    , TFun int_ "use_count" "use_count" []
     , TFunDelete
     ]
 

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -39,6 +39,7 @@ import FFICXX.Generate.Type.Class  ( Arg(..)
                                    , TemplateFunction(..)
                                    , TopLevelFunction
                                    , Types(..)
+                                   , Variable(..)
                                    )
 import FFICXX.Generate.Type.Module ( TemplateClassImportHeader(..) )
 import FFICXX.Generate.Type.PackageInterface ()
@@ -110,7 +111,9 @@ t_pair =
     [ TFunNew [Arg (TemplateParam "tp1") "x", Arg (TemplateParam "tp2") "y"] Nothing
     , TFunDelete
     ]
-    []
+    [ Variable $ Arg (TemplateParam "tp1") "first"
+    , Variable $ Arg (TemplateParam "tp2") "second"
+    ]
 
 t_map :: TemplateClass
 t_map =


### PR DESCRIPTION
support `first`, `second` in `std::pair<T1,T2>`. 