### PR TITLE
std::map<k,v>::iterator is now supported.

### DIFF
--- a/fficxx-test/test/MapSpec.hs
+++ b/fficxx-test/test/MapSpec.hs
@@ -79,7 +79,7 @@ spec =
           n <- size m
           n `shouldBe` 0
         it "should have 1 elem after insertion" $ \m -> do
-          kv <- newPair 1 123.0 :: IO (Pair CInt CDouble)
+          kv <- newPair 1 123.0
           insert m kv
           n <- size m
           n `shouldBe` 1
@@ -89,3 +89,11 @@ spec =
           k <- first_get p
           v <- second_get p
           (k,v) `shouldBe` (1,123.0)
+        it "should retrieve multiple values via iterator" $ \m -> do
+          kv <- newPair 2 246.0
+          insert m kv
+          iter <- increment =<< begin m
+          p <- deRef iter
+          k <- first_get p
+          v <- second_get p
+          (k,v) `shouldBe` (2,246.0)

--- a/fficxx-test/test/MapSpec.hs
+++ b/fficxx-test/test/MapSpec.hs
@@ -85,4 +85,7 @@ spec =
           n `shouldBe` 1
         it "should retrieve value via iterator" $ \m -> do
           iter <- begin m
-          True `shouldBe` True
+          p <- deRef iter
+          k <- first_get p
+          v <- second_get p
+          (k,v) `shouldBe` (1,123.0)

--- a/fficxx/src/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Class.hs
@@ -252,7 +252,8 @@ instance Eq Class where
 instance Ord Class where
   compare x y = compare (class_name x) (class_name y)
 
-data OpExp = OpStar   -- unary * (deRef) operator
+data OpExp = OpStar   -- ^ unary * (deRef) operator
+           | OpFPPlus -- ^ unary prefix ++ operator
            --    | OpAdd Arg Arg
            --    | OpMul Arg Arg
 
@@ -275,12 +276,14 @@ data TemplateFunction =
     }
 
 argsFromOpExp :: OpExp -> [Arg]
-argsFromOpExp OpStar  = []
+argsFromOpExp OpStar   = []
+argsFromOpExp OpFPPlus = []
 -- argsFromOpExp (OpAdd x y) = [x,y]
 -- argsFromOpExp (OpMul x y) = [x,y]
 
 opSymbol :: OpExp -> String
-opSymbol OpStar = "*"
+opSymbol OpStar   = "*"
+opSymbol OpFPPlus = "++"
 -- opSymbol (OpAdd _ _) = "+"
 -- opSymbol (OpMul _ _) = "*"
 

--- a/fficxx/src/FFICXX/Generate/Type/Class.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Class.hs
@@ -252,7 +252,7 @@ instance Eq Class where
 instance Ord Class where
   compare x y = compare (class_name x) (class_name y)
 
-data OpExp = OpStar Arg
+data OpExp = OpStar   -- unary * (deRef) operator
            --    | OpAdd Arg Arg
            --    | OpMul Arg Arg
 
@@ -275,12 +275,12 @@ data TemplateFunction =
     }
 
 argsFromOpExp :: OpExp -> [Arg]
-argsFromOpExp (OpStar x)  = [x]
+argsFromOpExp OpStar  = []
 -- argsFromOpExp (OpAdd x y) = [x,y]
 -- argsFromOpExp (OpMul x y) = [x,y]
 
 opSymbol :: OpExp -> String
-opSymbol (OpStar _) = "*"
+opSymbol OpStar = "*"
 -- opSymbol (OpAdd _ _) = "+"
 -- opSymbol (OpMul _ _) = "*"
 

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -14,6 +14,7 @@ import FFICXX.Generate.Code.Primitive
                                    ( cppclassref, cppclassref_
                                    , cstring, cstring_
                                    , int, int_
+                                   -- , self_
                                    , void_
                                    )
 import FFICXX.Generate.Config      ( FFICXXConfig(..)
@@ -163,6 +164,17 @@ t_map_iterator =
             }
       , tfun_name = "deRef"
       , tfun_opexp = OpStar
+      }
+    , TFunOp {
+        tfun_ret = -- TODO: this should be handled with self
+          TemplateApp
+            TemplateAppInfo {
+              tapp_tclass = t_map_iterator
+            , tapp_tparams = [ TArg_TypeParam "tpk", TArg_TypeParam "tpv" ]
+            , tapp_CppTypeForParam = "std::map<tpk,tpv>::iterator"
+            }
+      , tfun_name = "increment"
+      , tfun_opexp = OpFPPlus
       }
     ]
     []

--- a/stdcxx-gen/Gen.hs
+++ b/stdcxx-gen/Gen.hs
@@ -33,6 +33,7 @@ import FFICXX.Generate.Type.Class  ( Arg(..)
                                    , ClassAlias(..)
                                    , Form(FormNested,FormSimple)
                                    , Function(..)
+                                   , OpExp(..)
                                    , TemplateAppInfo(..)
                                    , TemplateArgType(..)
                                    , TemplateClass(..)
@@ -152,7 +153,18 @@ t_map =
 t_map_iterator :: TemplateClass
 t_map_iterator =
   TmplCls cabal "MapIterator" (FormNested "std::map" "iterator") ["tpk","tpv"]
-    []
+    [ TFunOp {
+        tfun_ret =
+          TemplateApp
+            TemplateAppInfo {
+              tapp_tclass = t_pair
+            , tapp_tparams = [ TArg_TypeParam "tpk", TArg_TypeParam "tpv" ]
+            , tapp_CppTypeForParam = "std::pair<tpk,tpv>"
+            }
+      , tfun_name = "deRef"
+      , tfun_opexp = OpStar
+      }
+    ]
     []
 
 t_vector :: TemplateClass


### PR DESCRIPTION
fficxx-generated std::map binding can access elements via iterator interface.