### PR TITLE
Duplicated template instances are safe

### DIFF
--- a/fficxx-multipkg-test/tmpl-dup-inst/src/Test/TemplateInstantiation/A.hs
+++ b/fficxx-multipkg-test/tmpl-dup-inst/src/Test/TemplateInstantiation/A.hs
@@ -1,1 +1,41 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE TemplateHaskell          #-}
+
 module Test.TemplateInstantiation.A where
+
+import           Foreign.C.Types             (CInt(..))
+--
+import           FFICXX.Runtime.TH           (IsCPrimitive (..),
+                                              TemplateParamInfo (..))
+import           STD.Vector.Template
+import qualified STD.Vector.TH               as TH
+import           STD.VectorIterator.Template
+import qualified STD.VectorIterator.TH       as TH
+
+
+TH.genVectorIteratorInstanceFor
+  CPrim
+  ( [t|CInt|], TPInfo { tpinfoCxxType       = "int"
+                      , tpinfoCxxHeaders    = []
+                      , tpinfoCxxNamespaces = []
+                      , tpinfoSuffix        = "int"
+                      }
+  )
+
+TH.genVectorInstanceFor
+  CPrim
+  ( [t|CInt|], TPInfo { tpinfoCxxType       = "int"
+                      , tpinfoCxxHeaders    = []
+                      , tpinfoCxxNamespaces = []
+                      , tpinfoSuffix        = "int"
+                      }
+  )
+
+test :: IO ()
+test = do
+  v <- newVector :: IO (Vector CInt)
+  n <- size v
+  print n
+  push_back v 1
+  n' <- size v
+  print n'

--- a/fficxx-multipkg-test/tmpl-dup-inst/src/Test/TemplateInstantiation/A.hs
+++ b/fficxx-multipkg-test/tmpl-dup-inst/src/Test/TemplateInstantiation/A.hs
@@ -1,0 +1,1 @@
+module Test.TemplateInstantiation.A where

--- a/fficxx-multipkg-test/tmpl-dup-inst/src/Test/TemplateInstantiation/B.hs
+++ b/fficxx-multipkg-test/tmpl-dup-inst/src/Test/TemplateInstantiation/B.hs
@@ -1,0 +1,1 @@
+module Test.TemplateInstantiation.B where

--- a/fficxx-multipkg-test/tmpl-dup-inst/src/Test/TemplateInstantiation/B.hs
+++ b/fficxx-multipkg-test/tmpl-dup-inst/src/Test/TemplateInstantiation/B.hs
@@ -1,1 +1,42 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE TemplateHaskell          #-}
+
 module Test.TemplateInstantiation.B where
+
+import           Foreign.C.Types             (CInt(..))
+--
+import           FFICXX.Runtime.TH           (IsCPrimitive (..),
+                                              TemplateParamInfo (..))
+import           STD.Vector.Template
+import qualified STD.Vector.TH               as TH
+import           STD.VectorIterator.Template
+import qualified STD.VectorIterator.TH       as TH
+
+
+TH.genVectorIteratorInstanceFor
+  CPrim
+  ( [t|CInt|], TPInfo { tpinfoCxxType       = "int"
+                      , tpinfoCxxHeaders    = []
+                      , tpinfoCxxNamespaces = []
+                      , tpinfoSuffix        = "int"
+                      }
+  )
+
+TH.genVectorInstanceFor
+  CPrim
+  ( [t|CInt|], TPInfo { tpinfoCxxType       = "int"
+                      , tpinfoCxxHeaders    = []
+                      , tpinfoCxxNamespaces = []
+                      , tpinfoSuffix        = "int"
+                      }
+  )
+
+test :: IO ()
+test = do
+  v <- newVector :: IO (Vector CInt)
+  n <- size v
+  print n
+  push_back v 10
+  push_back v 11
+  n' <- size v
+  print n'

--- a/fficxx-multipkg-test/tmpl-dup-inst/tmpl-dup-inst.cabal
+++ b/fficxx-multipkg-test/tmpl-dup-inst/tmpl-dup-inst.cabal
@@ -17,6 +17,7 @@ Source-repository head
 Library
   hs-source-dirs: src
   Build-Depends: base == 4.*
+               , fficxx-runtime
                , stdcxx
   Exposed-Modules:
                Test.TemplateInstantiation.A

--- a/fficxx-multipkg-test/tmpl-dup-inst/tmpl-dup-inst.cabal
+++ b/fficxx-multipkg-test/tmpl-dup-inst/tmpl-dup-inst.cabal
@@ -27,3 +27,4 @@ Library
                -fno-warn-unused-do-bind
                -fno-warn-missing-signatures
                -O0
+               -keep-tmp-files

--- a/fficxx-multipkg-test/tmpl-dup-inst/tmpl-dup-inst.cabal
+++ b/fficxx-multipkg-test/tmpl-dup-inst/tmpl-dup-inst.cabal
@@ -1,0 +1,28 @@
+Name:           tmpl-dup-inst
+Version:        0.0
+Synopsis:       test for fficxx template instatiation duplication
+Description:    test for fficxx template instatiation duplication
+License:        BSD3
+License-file:   LICENSE
+Author:         Ian-Woo Kim
+Maintainer:     Ian-Woo Kim <ianwookim@gmail.com>
+Build-Type:     Simple
+Category:       FFI Tools
+Cabal-Version:  >= 1.8
+
+Source-repository head
+  type: git
+  location: http://www.github.com/wavewave/fficxx
+
+Library
+  hs-source-dirs: src
+  Build-Depends: base == 4.*
+               , stdcxx
+  Exposed-Modules:
+               Test.TemplateInstantiation.A
+               Test.TemplateInstantiation.B
+  ghc-options: -Wall
+               -funbox-strict-fields
+               -fno-warn-unused-do-bind
+               -fno-warn-missing-signatures
+               -O0

--- a/fficxx-runtime/src/FFICXX/Runtime/TH.hs
+++ b/fficxx-runtime/src/FFICXX/Runtime/TH.hs
@@ -79,3 +79,7 @@ mkNew fname f typ suffix = do
 -- |
 mkDelete :: String -> (types -> String -> Q Exp) -> types -> String -> Q Dec
 mkDelete = mkMember
+
+-- | utility function for converting '.' to '_'
+dot2_ :: String -> String
+dot2_ = map (\c -> if c == '.' then '_' else c)

--- a/fficxx-test/test/VectorSpec.hs
+++ b/fficxx-test/test/VectorSpec.hs
@@ -5,21 +5,23 @@
 
 module VectorSpec ( spec ) where
 
-import Control.Exception          ( bracket )
-import qualified Data.ByteString.Char8 as B
-import Foreign.C.Types
-import Foreign.Ptr
-import Foreign.C.String
+import           Control.Exception           (bracket)
+import qualified Data.ByteString.Char8       as B
+import           Foreign.C.String
+import           Foreign.C.Types
+import           Foreign.Ptr
 --
-import FFICXX.Runtime.CodeGen.Cxx ( HeaderName(..), Namespace(..) )
-import FFICXX.Runtime.TH          ( IsCPrimitive(..), TemplateParamInfo(..) )
-import STD.CppString
-import STD.VectorIterator.Template
-import qualified STD.VectorIterator.TH as TH
-import STD.Vector.Template
-import qualified STD.Vector.TH as TH
+import           FFICXX.Runtime.CodeGen.Cxx  (HeaderName (..), Namespace (..))
+import           FFICXX.Runtime.TH           (IsCPrimitive (..),
+                                              TemplateParamInfo (..))
+import           STD.CppString
+import           STD.Vector.Template
+import qualified STD.Vector.TH               as TH
+import           STD.VectorIterator.Template
+import qualified STD.VectorIterator.TH       as TH
 --
-import Test.Hspec     ( Spec, afterAll, around, beforeAll, describe, it, shouldBe )
+import           Test.Hspec                  (Spec, afterAll, around, beforeAll,
+                                              describe, it, shouldBe)
 
 
 TH.genVectorIteratorInstanceFor

--- a/fficxx/src/FFICXX/Generate/Code/Cpp.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Cpp.hs
@@ -267,7 +267,7 @@ genTmplFunCpp ::
   -> TemplateFunction
   -> R.CMacro Identity
 genTmplFunCpp b t@TmplCls {..} f =
-    R.Define (R.sname macroname) (map R.sname tclass_params)
+    R.Define (R.sname macroname) (map R.sname ("callmod" : tclass_params))
       [ R.CExtern [R.CDeclaration decl]
       , tmplFunToDef b t f
       , autoinst
@@ -281,10 +281,9 @@ genTmplFunCpp b t@TmplCls {..} f =
     R.CInit
       (R.CVarDecl
         R.CTAuto
-        (R.CName (R.NamePart ("a_" <> tclass_name <> "_" <> ffiTmplFuncName f <> "_") : nsuffix ))
+        (R.CName (R.NamePart "a_" : R.NamePart "callmod" : R.NamePart ("_" <> tclass_name <> "_" <> ffiTmplFuncName f <> "_") : nsuffix ))
       )
       (R.CVar (R.CName (R.NamePart (tclass_name <> "_" <> ffiTmplFuncName f <> "_") : nsuffix )))
-
 
 genTmplVarCpp ::
      IsCPrimitive
@@ -299,13 +298,13 @@ genTmplVarCpp b t@TmplCls {..} var@(Variable (Arg {..})) =
     gen v a =
       let f = tmplAccessorToTFun v a
           macroname = tclass_name <> "_" <> ffiTmplFuncName f <> suffix
-      in R.Define (R.sname macroname) (map R.sname tclass_params)
+      in R.Define (R.sname macroname) (map R.sname ("callmod" : tclass_params))
            [ R.CExtern [R.CDeclaration (tmplFunToDecl b t f)]
            , tmplVarToDef b t v a
            , R.CInit
                (R.CVarDecl
                  R.CTAuto
-                 (R.CName (R.NamePart ("a_" <> tclass_name <> "_" <> ffiTmplFuncName f <> "_") : nsuffix ))
+                 (R.CName (R.NamePart "a_" : R.NamePart "callmod" : R.NamePart ("_" <> tclass_name <> "_" <> ffiTmplFuncName f <> "_") : nsuffix ))
            )
                (R.CVar (R.CName (R.NamePart (tclass_name <> "_" <> ffiTmplFuncName f <> "_") : nsuffix )))
            ]
@@ -319,7 +318,7 @@ genTmplClassCpp ::
 genTmplClassCpp b TmplCls {..} (fs,vs) =
     R.Define (R.sname macroname) params body
  where
-  params = map R.sname tclass_params
+  params = map R.sname ("callmod" : tclass_params)
   suffix = case b of { CPrim -> "_s"; NonCPrim -> "" }
   tname = tclass_name
   macroname = tname <> "_instance" <> suffix

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -310,6 +310,10 @@ genTmplInstance tcih =
     -- final RHS expression --
     --------------------------
     rhs = doE (   [ paramsstmt, suffixstmt ]
+               <> [ generator (p "callmod_") (v "fmap" `app` v "loc_module" `app` (v "location"))
+                  , letStmt [ pbind_ (p "callmod")
+                                     (v "dot2_" `app` v "callmod_") ]
+                  ]
                <> map genqtypstmt (zip tvars qtvars)
                <> map genstmt nfs
                <> concatMap genvarstmt nvfs
@@ -386,7 +390,9 @@ genTmplInstance tcih =
                               , match (p "NonCPrim") (strE "")
                               ]
                         , strE "("
-                        , v "intercalate" `app` strE ", " `app` v "params"
+                        , v "intercalate" `app`
+                            strE ", " `app`
+                              paren (inapp (v "callmod") (op ":") (v "params"))
                         , strE ")\n"
                         ]
                      )

--- a/release.nix
+++ b/release.nix
@@ -29,13 +29,14 @@ let
   newHaskellPackages = haskellPackages.override {
     overrides = self: super:
       {
-        "fficxx-runtime"       = self.callCabal2nix "fficxx-runtime"       ./fficxx-runtime {};
-        "fficxx"               = self.callCabal2nix "fficxx"               ./fficxx         {};
-        "stdcxx"               = self.callCabal2nix "stdcxx"               stdcxxSrc        {};
-        "fficxx-test"          = self.callCabal2nix "fficxx-test"          ./fficxx-test    {};
+        "fficxx-runtime"       = self.callCabal2nix "fficxx-runtime"       ./fficxx-runtime       {};
+        "fficxx"               = self.callCabal2nix "fficxx"               ./fficxx               {};
+        "stdcxx"               = self.callCabal2nix "stdcxx"               stdcxxSrc              {};
+        "fficxx-test"          = self.callCabal2nix "fficxx-test"          ./fficxx-test          {};
         "fficxx-multipkg-test" = self.callCabal2nix "fficxx-multipkg-test" ./fficxx-multipkg-test {};
-        "tmf-test"             = self.callCabal2nix "tmf-test"             tmfTestSrc       {};
-        "tmpl-dep-test"        = self.callCabal2nix "tmpl-dep-test"        tmplDepTestSrc    {};
+        "tmf-test"             = self.callCabal2nix "tmf-test"             tmfTestSrc             {};
+        "tmpl-dep-test"        = self.callCabal2nix "tmpl-dep-test"        tmplDepTestSrc         {};
+        "tmpl-dup-inst"        = self.callCabal2nix "tmpl-dup-inst"        ./fficxx-multipkg-test/tmpl-dup-inst {};
       };
   };
 
@@ -48,5 +49,6 @@ in
   "stdcxx"         = newHaskellPackages.stdcxx;
   "fficxx-test"    = newHaskellPackages.fficxx-test;
   "fficxx-multipkg-test" = newHaskellPackages.fficxx-multipkg-test;
+  "tmpl-dup-inst"  = newHaskellPackages.tmpl-dup-inst;
 
 }


### PR DESCRIPTION
If one module instantiates `Vector CInt` and another module instantiates the same `Vector CInt`, which is allowed in C++ template instantiation semantics, we had duplicated symbol errors with fficxx-generated binding. This PR resolved this issue by having call-site module name prefix for instantiated variable name.