### PR TITLE
no more impure <nixpkgs>

### DIFF
--- a/fficxx-multipkg-test/shell.nix
+++ b/fficxx-multipkg-test/shell.nix
@@ -1,6 +1,6 @@
 # NOTE: this doesn't include stdcxx intentionally.
 
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import ../nix/pinnedNixpkgs.nix {} }:
 
 with pkgs;
 

--- a/fficxx-test/shell.nix
+++ b/fficxx-test/shell.nix
@@ -1,6 +1,6 @@
 # NOTE: this doesn't include stdcxx intentionally.
 
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import ../nix/pinnedNixpkgs {} }:
 
 with pkgs;
 

--- a/nix/pinnedNixpkgs.nix
+++ b/nix/pinnedNixpkgs.nix
@@ -1,0 +1,5 @@
+import (builtins.fetchTarball {
+  name = "nixos-20.03";
+  url = "https://github.com/nixos/nixpkgs/archive/5272327b81ed355bbed5659b8d303cf2979b6953.tar.gz";
+  sha256 = "0182ys095dfx02vl2a20j1hz92dx3mfgz2a6fhn31bqlp1wa8hlq";
+})

--- a/release.nix
+++ b/release.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import ./nix/pinnedNixpkgs.nix {} }:
 
 with pkgs;
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import ./nix/pinnedNixpkgs.nix {} }:
 
 with pkgs;
 

--- a/use.nix
+++ b/use.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import ./nix/pinnedNixpkgs.nix {} }:
 
 with pkgs;
 


### PR DESCRIPTION
use pinned version of nixpkgs. Pinning it to 20.03.