### PR TITLE
Simplify Nix script and support for multiple GHC versions in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,33 +15,33 @@ jobs:
       uses: cachix/install-nix-action@v16
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-    - name: build fficxx-runtime
+    - name: build fficxx-runtime (GHC 9.4.2)
       run: |
-        nix build --print-build-logs .#fficxx-runtime
-    - name: build fficxx
+        nix build --print-build-logs .#ghc942.fficxx-runtime
+    - name: build fficxx (GHC 9.4.2)
       run: |
-        nix build --print-build-logs .#fficxx
-    - name: build stdcxx
+        nix build --print-build-logs .#ghc942.fficxx
+    - name: build stdcxx (GHC 9.4.2)
       run: |
-        nix build --print-build-logs .#stdcxx
-    - name: build fficxx-test
+        nix build --print-build-logs .#ghc942.stdcxx
+    - name: build fficxx-test (GHC 9.4.2)
       run: |
-        nix build --print-build-logs .#fficxx-test
-    - name: build fficxx-multipkg-test
+        nix build --print-build-logs .#ghc942.fficxx-test
+    - name: build fficxx-multipkg-test (GHC 9.4.2)
       run: |
-        nix build --print-build-logs .#fficxx-multipkg-test
-    - name: build tmf-test
+        nix build --print-build-logs .#ghc942.fficxx-multipkg-test
+    - name: build tmf-test (GHC 9.4.2)
       run: |
-        nix build --print-build-logs .#tmf-test
-    - name: build tmpl-dep-test
+        nix build --print-build-logs .#ghc942.tmf-test
+    - name: build tmpl-dep-test (GHC 9.4.2)
       run: |
-        nix build --print-build-logs .#tmpl-dep-test
-    - name: build tmpl-dup-inst
+        nix build --print-build-logs .#ghc942.tmpl-dep-test
+    - name: build tmpl-dup-inst (GHC 9.4.2)
       run: |
-        nix build --print-build-logs .#tmpl-dup-inst
-    - name: build tmpl-toplevel-test
+        nix build --print-build-logs .#ghc942.tmpl-dup-inst
+    - name: build tmpl-toplevel-test (GHC 9.4.2)
       run: |
-        nix build --print-build-logs .#tmpl-toplevel-test
+        nix build --print-build-logs .#ghc942.tmpl-toplevel-test
   format:
     runs-on: ubuntu-20.04
     steps:

--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658177757,
-        "narHash": "sha256-XjiMHb0O3Z3+QH19NiTA9vx1xCnnogq//AqDHKwnLZ0=",
+        "lastModified": 1666371646,
+        "narHash": "sha256-gLaVWLbbig3MjLbb2NzVzWe4XK8w/Qw7iJdD0u1dzDY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "31997025a4d59f09a9b4c55a3c6ff5ade48de2d6",
+        "rev": "71c5816834f93840dd301ec384c9d7947e97c27d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "31997025a4d59f09a9b4c55a3c6ff5ade48de2d6",
+        "rev": "71c5816834f93840dd301ec384c9d7947e97c27d",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -11,64 +11,49 @@
         pkgs = import nixpkgs {
           inherit system;
         };
-
-        haskellPackages = pkgs.haskellPackages;
-
-        newHaskellPackages0 = haskellPackages.override {
-          overrides = self: super: {
-            "fficxx-runtime" =
-              self.callCabal2nix "fficxx-runtime" ./fficxx-runtime { };
-            "fficxx" = self.callCabal2nix "fficxx" ./fficxx { };
+        finalHaskellOverlay = self: super: rec {
+          stdcxxSrc = import ./stdcxx-gen/gen.nix {
+            inherit (pkgs) lib stdenv;
+            haskellPackages = self;
           };
-        };
+          tmfTestSrc = import ./fficxx-multipkg-test/template-member/gen.nix {
+            inherit (pkgs) stdenv;
+            haskellPackages = self;
+          };
+          tmplDepTestSrc = import ./fficxx-multipkg-test/template-dep/gen.nix {
+            inherit (pkgs) stdenv;
+            haskellPackages = self;
+          };
+          tmplTopLevelTestSrc =
+            import ./fficxx-multipkg-test/template-toplevel/gen.nix {
+              inherit (pkgs) stdenv;
+              haskellPackages = self;
+            };
 
-        stdcxxSrc = import ./stdcxx-gen/gen.nix {
-          inherit (pkgs) lib stdenv;
-          haskellPackages = newHaskellPackages0;
-        };
 
-        finalHaskellOverlay = self: super: {
           "fficxx-runtime" =
             self.callCabal2nix "fficxx-runtime" ./fficxx-runtime { };
           "fficxx" = self.callCabal2nix "fficxx" ./fficxx { };
           "stdcxx" = self.callCabal2nix "stdcxx" stdcxxSrc { };
+          "fficxx-multipkg-test" =
+            self.callCabal2nix "fficxx-multipkg-test" ./fficxx-multipkg-test
+            { };
+          "tmf-test" = self.callCabal2nix "tmf-test" tmfTestSrc { };
+          "tmpl-dep-test" =
+            self.callCabal2nix "tmpl-dep-test" tmplDepTestSrc { };
+          "tmpl-dup-inst" = self.callCabal2nix "tmpl-dup-inst"
+            ./fficxx-multipkg-test/tmpl-dup-inst { };
+          "tmpl-toplevel-test" =
+            self.callCabal2nix "tmpl-toplevel-test" tmplTopLevelTestSrc { };
+
         };
 
-        newHaskellPackages = haskellPackages.override {
-          overrides = let
-            tmfTestSrc = import ./fficxx-multipkg-test/template-member/gen.nix {
-              inherit (pkgs) stdenv;
-              haskellPackages = newHaskellPackages0;
-            };
-            tmplDepTestSrc = import ./fficxx-multipkg-test/template-dep/gen.nix {
-              inherit (pkgs) stdenv;
-              haskellPackages = newHaskellPackages0;
-            };
-            tmplTopLevelTestSrc =
-              import ./fficxx-multipkg-test/template-toplevel/gen.nix {
-                inherit (pkgs) stdenv;
-                haskellPackages = newHaskellPackages0;
-              };
-
-          in self: super:
-          finalHaskellOverlay self super // {
-            "fficxx-test" = self.callCabal2nix "fficxx-test" ./fficxx-test { };
-            "fficxx-multipkg-test" =
-              self.callCabal2nix "fficxx-multipkg-test" ./fficxx-multipkg-test
-              { };
-            "tmf-test" = self.callCabal2nix "tmf-test" tmfTestSrc { };
-            "tmpl-dep-test" =
-              self.callCabal2nix "tmpl-dep-test" tmplDepTestSrc { };
-            "tmpl-dup-inst" = self.callCabal2nix "tmpl-dup-inst"
-              ./fficxx-multipkg-test/tmpl-dup-inst { };
-            "tmpl-toplevel-test" =
-              self.callCabal2nix "tmpl-toplevel-test" tmplTopLevelTestSrc { };
-          };
+        newHaskellPackages = pkgs.haskellPackages.override {
+          overrides = finalHaskellOverlay;
         };
 
       in {
         packages = {
-          "stdcxx-src" = stdcxxSrc;
           inherit (newHaskellPackages)
             fficxx fficxx-runtime stdcxx fficxx-test fficxx-multipkg-test tmf-test
             tmpl-dep-test tmpl-dup-inst tmpl-toplevel-test;
@@ -86,7 +71,7 @@
           });
         };
 
-        devShell = newHaskellPackages0.shellFor {
+        devShell = pkgs.haskellPackages.shellFor {
           packages = ps: [ ps.fficxx ps.fficxx-runtime ];
           buildInputs = [ pkgs.cabal-install pkgs.ormolu ];
           withHoogle = false;
@@ -94,4 +79,3 @@
       }
   );
 }
-

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
           });
         };
 
-        devShell = pkgs.haskellPackages.shellFor {
+        devShell = newHaskellPackages.shellFor {
           packages = ps: [ ps.fficxx ps.fficxx-runtime ];
           buildInputs = [ pkgs.cabal-install pkgs.ormolu ];
           withHoogle = false;

--- a/flake.nix
+++ b/flake.nix
@@ -47,23 +47,22 @@
 
         pkgs = import nixpkgs { inherit system; };
 
+        hpkgsGhc902 = pkgs.haskell.packages.ghc902.extend (haskellOverlay pkgs);
+
       in {
         packages = {
-          inherit (pkgs.haskellPackages)
+          inherit (hpkgsGhc902)
             fficxx fficxx-runtime stdcxx fficxx-test fficxx-multipkg-test
             tmf-test tmpl-dep-test tmpl-dup-inst tmpl-toplevel-test;
         };
 
         inherit haskellOverlay;
 
-        devShells.default = let
-          hpkgsGhc902 = pkgs.haskell.packages.ghc902.override {
-            overrides = haskellOverlay pkgs;
+        devShells.default =
+          hpkgsGhc902.shellFor {
+            packages = ps: [ ps.fficxx ps.fficxx-runtime ];
+            buildInputs = [ pkgs.cabal-install pkgs.ormolu pkgs.nixfmt ];
+            withHoogle = false;
           };
-        in hpkgsGhc902.shellFor {
-          packages = ps: [ ps.fficxx ps.fficxx-runtime ];
-          buildInputs = [ pkgs.cabal-install pkgs.ormolu pkgs.nixfmt ];
-          withHoogle = false;
-        };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -2,80 +2,68 @@
   description = "fficxx";
   inputs = {
     # nixpkgs/master on 2022-07-18
-    nixpkgs.url = "github:NixOS/nixpkgs/31997025a4d59f09a9b4c55a3c6ff5ade48de2d6";
+    nixpkgs.url =
+      "github:NixOS/nixpkgs/31997025a4d59f09a9b4c55a3c6ff5ade48de2d6";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
-        finalHaskellOverlay = self: super: rec {
+        haskellOverlay = final: hself: hsuper: rec {
           stdcxxSrc = import ./stdcxx-gen/gen.nix {
-            inherit (pkgs) lib stdenv;
-            haskellPackages = self;
+            inherit (final) lib stdenv;
+            haskellPackages = hself;
           };
           tmfTestSrc = import ./fficxx-multipkg-test/template-member/gen.nix {
-            inherit (pkgs) stdenv;
-            haskellPackages = self;
+            inherit (final) stdenv;
+            haskellPackages = hself;
           };
           tmplDepTestSrc = import ./fficxx-multipkg-test/template-dep/gen.nix {
-            inherit (pkgs) stdenv;
-            haskellPackages = self;
+            inherit (final) stdenv;
+            haskellPackages = hself;
           };
           tmplTopLevelTestSrc =
             import ./fficxx-multipkg-test/template-toplevel/gen.nix {
-              inherit (pkgs) stdenv;
-              haskellPackages = self;
+              inherit (final) stdenv;
+              haskellPackages = hself;
             };
 
-
           "fficxx-runtime" =
-            self.callCabal2nix "fficxx-runtime" ./fficxx-runtime { };
-          "fficxx" = self.callCabal2nix "fficxx" ./fficxx { };
-          "stdcxx" = self.callCabal2nix "stdcxx" stdcxxSrc { };
+            hself.callCabal2nix "fficxx-runtime" ./fficxx-runtime { };
+          "fficxx" = hself.callCabal2nix "fficxx" ./fficxx { };
+          "stdcxx" = hself.callCabal2nix "stdcxx" stdcxxSrc { };
           "fficxx-multipkg-test" =
-            self.callCabal2nix "fficxx-multipkg-test" ./fficxx-multipkg-test
+            hself.callCabal2nix "fficxx-multipkg-test" ./fficxx-multipkg-test
             { };
-          "tmf-test" = self.callCabal2nix "tmf-test" tmfTestSrc { };
+          "tmf-test" = hself.callCabal2nix "tmf-test" tmfTestSrc { };
           "tmpl-dep-test" =
-            self.callCabal2nix "tmpl-dep-test" tmplDepTestSrc { };
-          "tmpl-dup-inst" = self.callCabal2nix "tmpl-dup-inst"
+            hself.callCabal2nix "tmpl-dep-test" tmplDepTestSrc { };
+          "tmpl-dup-inst" = hself.callCabal2nix "tmpl-dup-inst"
             ./fficxx-multipkg-test/tmpl-dup-inst { };
           "tmpl-toplevel-test" =
-            self.callCabal2nix "tmpl-toplevel-test" tmplTopLevelTestSrc { };
+            hself.callCabal2nix "tmpl-toplevel-test" tmplTopLevelTestSrc { };
 
         };
 
-        newHaskellPackages = pkgs.haskellPackages.override {
-          overrides = finalHaskellOverlay;
-        };
+        pkgs = import nixpkgs { inherit system; };
 
       in {
         packages = {
-          inherit (newHaskellPackages)
-            fficxx fficxx-runtime stdcxx fficxx-test fficxx-multipkg-test tmf-test
-            tmpl-dep-test tmpl-dup-inst tmpl-toplevel-test;
+          inherit (pkgs.haskellPackages)
+            fficxx fficxx-runtime stdcxx fficxx-test fficxx-multipkg-test
+            tmf-test tmpl-dep-test tmpl-dup-inst tmpl-toplevel-test;
         };
 
-        # see these issues and discussions:
-        # - https://github.com/NixOS/nixpkgs/issues/16394
-        # - https://github.com/NixOS/nixpkgs/issues/25887
-        # - https://github.com/NixOS/nixpkgs/issues/26561
-        # - https://discourse.nixos.org/t/nix-haskell-development-2020/6170
-        overlay = final: prev: {
-          haskellPackages = prev.haskellPackages.override (old: {
-            overrides = final.lib.composeExtensions (old.overrides or (_: _: { }))
-              finalHaskellOverlay;
-          });
-        };
+        inherit haskellOverlay;
 
-        devShell = newHaskellPackages.shellFor {
+        devShells.default = let
+          hpkgsGhc902 = pkgs.haskell.packages.ghc902.override {
+            overrides = haskellOverlay pkgs;
+          };
+        in hpkgsGhc902.shellFor {
           packages = ps: [ ps.fficxx ps.fficxx-runtime ];
-          buildInputs = [ pkgs.cabal-install pkgs.ormolu ];
+          buildInputs = [ pkgs.cabal-install pkgs.ormolu pkgs.nixfmt ];
           withHoogle = false;
         };
-      }
-  );
+      });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,9 @@
 {
   description = "fficxx";
   inputs = {
-    # nixpkgs/master on 2022-07-18
+    # nixpkgs/master on 2022-10-21
     nixpkgs.url =
-      "github:NixOS/nixpkgs/31997025a4d59f09a9b4c55a3c6ff5ade48de2d6";
+      "github:NixOS/nixpkgs/71c5816834f93840dd301ec384c9d7947e97c27d";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs = { self, nixpkgs, flake-utils }:
@@ -27,6 +27,8 @@
               inherit (final) stdenv;
               haskellPackages = hself;
             };
+
+          "template" = final.haskell.lib.doJailbreak (hsuper.template);
 
           "fficxx-runtime" =
             hself.callCabal2nix "fficxx-runtime" ./fficxx-runtime { };
@@ -64,7 +66,7 @@
             withHoogle = false;
           };
 
-        supportedCompilers = [ "ghc902" "ghc923" ];
+        supportedCompilers = [ "ghc902" "ghc924" "ghc942" ];
       in {
         packages =
           pkgs.lib.genAttrs supportedCompilers (compiler: hpkgsFor compiler);


### PR DESCRIPTION
In the end, we do not need multi-stage haskellPackages for generating source code from fficxx.