### PR TITLE
Fix incorrect hs-boot

### DIFF
--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -16,6 +16,7 @@ import FFICXX.Generate.Config
 import qualified FFICXX.Generate.ContentMaker as C
 import FFICXX.Generate.Dependency
   ( findModuleUnitImports,
+    getClassModuleBase,
     mkHSBOOTCandidateList,
     mkPackageConfig,
   )
@@ -50,6 +51,7 @@ macrofy = map ((\x -> if x == '-' then '_' else x) . toUpper)
 
 simpleBuilder :: FFICXXConfig -> SimpleBuilderConfig -> IO ()
 simpleBuilder cfg sbc = do
+  putStrLn "THIS IS NEW"
   putStrLn "----------------------------------------------------"
   putStrLn "-- fficxx code generation for Haskell-C++ binding --"
   putStrLn "----------------------------------------------------"
@@ -163,10 +165,10 @@ simpleBuilder cfg sbc = do
   --
   -- TODO: Template.hs-boot need to be generated as well
   putStrLn "Generating hs-boot file"
-  for_ hsbootlst $ \m ->
+  for_ hsbootlst $ \c ->
     gen
-      (m <.> "Interface" <.> "hs-boot")
-      (prettyPrint (C.buildInterfaceHSBOOT m))
+      (getClassModuleBase c <.> "Interface" <.> "hs-boot")
+      (prettyPrint (C.buildInterfaceHSBOOT c))
   --
   putStrLn "Generating Module summary file"
   for_ mods $ \m ->

--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -17,7 +17,7 @@ import qualified FFICXX.Generate.ContentMaker as C
 import FFICXX.Generate.Dependency
   ( findModuleUnitImports,
     getClassModuleBase,
-    mkHSBOOTCandidateList,
+    mkHsBootCandidateList,
     mkPackageConfig,
   )
 import FFICXX.Generate.Type.Cabal
@@ -51,7 +51,6 @@ macrofy = map ((\x -> if x == '-' then '_' else x) . toUpper)
 
 simpleBuilder :: FFICXXConfig -> SimpleBuilderConfig -> IO ()
 simpleBuilder cfg sbc = do
-  putStrLn "THIS IS NEW"
   putStrLn "----------------------------------------------------"
   putStrLn "-- fficxx code generation for Haskell-C++ binding --"
   putStrLn "----------------------------------------------------"
@@ -78,7 +77,7 @@ simpleBuilder cfg sbc = do
           (classes, toplevelfunctions, templates, extramods)
           (cabal_additional_c_incs cabal)
           (cabal_additional_c_srcs cabal)
-      hsbootlst = mkHSBOOTCandidateList mods
+      hsbootlst = mkHsBootCandidateList mods
       cabalFileName = unCabalName pkgname <.> "cabal"
       jsonFileName = unCabalName pkgname <.> "json"
   --
@@ -165,10 +164,10 @@ simpleBuilder cfg sbc = do
   --
   -- TODO: Template.hs-boot need to be generated as well
   putStrLn "Generating hs-boot file"
-  for_ hsbootlst $ \c ->
+  for_ hsbootlst $ \m -> do
     gen
-      (getClassModuleBase c <.> "Interface" <.> "hs-boot")
-      (prettyPrint (C.buildInterfaceHSBOOT c))
+      (cmModule m <.> "Interface" <.> "hs-boot")
+      (prettyPrint (C.buildInterfaceHsBoot m))
   --
   putStrLn "Generating Module summary file"
   for_ mods $ \m ->

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -72,8 +72,12 @@ import FFICXX.Generate.Code.HsTemplate
     genTmplInstance,
     genTmplInterface,
   )
+import FFICXX.Generate.Code.Primitive
+  ( classConstraints,
+  )
 import FFICXX.Generate.Dependency
   ( class_allparents,
+    getClassModuleBase,
     mkDaughterMap,
     mkDaughterSelfMap,
   )
@@ -81,6 +85,7 @@ import FFICXX.Generate.Name
   ( ffiClassName,
     hsClassName,
     hsFrontNameForTopLevel,
+    typeclassName,
   )
 import FFICXX.Generate.Type.Annotate (AnnotateMap)
 import FFICXX.Generate.Type.Class
@@ -567,11 +572,11 @@ buildTHHs m =
     tmplInsts = genTmplInstance (tcmTCIH m)
 
 -- |
-buildInterfaceHSBOOT :: String -> Module ()
-buildInterfaceHSBOOT mname = mkModule (mname <.> "Interface") [] [] hsbootBody
+buildInterfaceHSBOOT :: Class -> Module ()
+buildInterfaceHSBOOT c = mkModule (mname <.> "Interface") [] [] hsbootBody
   where
-    cname = last (splitOn "." mname)
-    hsbootBody = [mkClass cxEmpty ('I' : cname) [mkTBind "a"] []]
+    mname = getClassModuleBase c
+    hsbootBody = [mkClass (classConstraints c) (typeclassName c) [mkTBind "a"] []]
 
 -- |
 buildModuleHs :: ClassModule -> Module ()

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -8,7 +8,6 @@ import Control.Monad.Trans.Reader (runReader)
 import Data.Either (rights)
 import Data.Functor.Identity (Identity)
 import Data.List (intercalate, nub)
-import Data.List.Split (splitOn)
 import qualified Data.Map as M
 import Data.Maybe (mapMaybe)
 import FFICXX.Generate.Code.Cpp
@@ -112,8 +111,7 @@ import FFICXX.Generate.Type.PackageInterface
   )
 import FFICXX.Generate.Util (firstUpper)
 import FFICXX.Generate.Util.HaskellSrcExts
-  ( cxEmpty,
-    emodule,
+  ( emodule,
     evar,
     lang,
     mkClass,
@@ -427,6 +425,24 @@ buildInterfaceHs amap m =
         <> (concatMap genHsFrontDowncastClass . filter (not . isAbstractClass)) classes
 
 -- |
+buildInterfaceHsBoot :: ClassModule -> Module ()
+buildInterfaceHsBoot m =
+  mkModule (cmModule m <.> "Interface") [] hsbootImports hsbootBody
+  where
+    c = cihClass (cmCIH m)
+    hsbootImports =
+      [ mkImport "Data.Word",
+        mkImport "Data.Int",
+        mkImport "Foreign.C",
+        mkImport "Foreign.Ptr",
+        mkImport "FFICXX.Runtime.Cast"
+      ]
+        <> genImportInInterface m
+        <> genExtraImport m
+    hsbootBody =
+      runReader (mapM genHsFrontDecl [c]) M.empty
+
+-- |
 buildCastHs :: ClassModule -> Module ()
 buildCastHs m =
   mkModule
@@ -570,13 +586,6 @@ buildTHHs m =
     body = tmplImpls <> tmplInsts
     tmplImpls = genTmplImplementation t
     tmplInsts = genTmplInstance (tcmTCIH m)
-
--- |
-buildInterfaceHSBOOT :: Class -> Module ()
-buildInterfaceHSBOOT c = mkModule (mname <.> "Interface") [] [] hsbootBody
-  where
-    mname = getClassModuleBase c
-    hsbootBody = [mkClass (classConstraints c) (typeclassName c) [mkTBind "a"] []]
 
 -- |
 buildModuleHs :: ClassModule -> Module ()

--- a/fficxx/src/FFICXX/Generate/Dependency.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency.hs
@@ -23,6 +23,7 @@ import Data.Either (rights)
 import Data.Function (on)
 import qualified Data.HashMap.Strict as HM
 import Data.List (find, foldl', nub, nubBy)
+import qualified Data.List as L
 import qualified Data.Map as M
 import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import FFICXX.Generate.Name (ffiClassName, hsClassName, hsTemplateClassName)
@@ -368,12 +369,13 @@ mkPackageConfig (pkgname, getImports) (cs, fs, ts, extra) acincs acsrcs =
           pcfg_additional_c_srcs = acsrcs
         }
 
--- TODO: change [String] to Set String
-mkHSBOOTCandidateList :: [ClassModule] -> [String]
+mkHSBOOTCandidateList :: [ClassModule] -> [Class]
 mkHSBOOTCandidateList ms =
   let -- get only class dependencies, not template classes.
       cs = rights (concatMap cmImportedModulesHighSource ms)
-   in nub (map getClassModuleBase cs)
+   in L.nubBy ((==) `on` getClassModuleBase)
+        . L.sortBy (compare `on` getClassModuleBase)
+        $ cs
 
 -- |
 mkPkgHeaderFileName :: Class -> HeaderName

--- a/fficxx/src/FFICXX/Generate/Dependency.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency.hs
@@ -23,7 +23,6 @@ import Data.Either (rights)
 import Data.Function (on)
 import qualified Data.HashMap.Strict as HM
 import Data.List (find, foldl', nub, nubBy)
-import qualified Data.List as L
 import qualified Data.Map as M
 import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import FFICXX.Generate.Name (ffiClassName, hsClassName, hsTemplateClassName)
@@ -369,13 +368,12 @@ mkPackageConfig (pkgname, getImports) (cs, fs, ts, extra) acincs acsrcs =
           pcfg_additional_c_srcs = acsrcs
         }
 
-mkHSBOOTCandidateList :: [ClassModule] -> [Class]
-mkHSBOOTCandidateList ms =
+mkHsBootCandidateList :: [ClassModule] -> [ClassModule]
+mkHsBootCandidateList ms =
   let -- get only class dependencies, not template classes.
       cs = rights (concatMap cmImportedModulesHighSource ms)
-   in L.nubBy ((==) `on` getClassModuleBase)
-        . L.sortBy (compare `on` getClassModuleBase)
-        $ cs
+      candidateModBases = fmap getClassModuleBase cs
+   in filter (\m -> cmModule m `elem` candidateModBases) ms
 
 -- |
 mkPkgHeaderFileName :: Class -> HeaderName


### PR DESCRIPTION
The types declared in the Interface.hs-boot file were not matched with Interface.hs, which becomes build error since GHC 9.4. This PR resolves the issue.