### PR TITLE
Submodule dependency computation and cyclic dep hs-boot resolution system 

### DIFF
--- a/fficxx-runtime/src/FFICXX/Runtime/Cast.hs
+++ b/fficxx-runtime/src/FFICXX/Runtime/Cast.hs
@@ -12,6 +12,7 @@ module FFICXX.Runtime.Cast where
 
 import Data.ByteString.Char8 (ByteString, packCString, useAsCString)
 import Data.Int (Int16, Int32, Int64, Int8)
+import Data.Kind (Type)
 import Data.Word (Word16, Word32, Word64, Word8)
 import Foreign.C
   ( CBool,
@@ -55,14 +56,14 @@ class Castable a b where
   uncast :: b -> (a -> IO r) -> IO r
 
 class FPtr a where
-  type Raw a :: *
+  type Raw a :: Type
   get_fptr :: a -> Ptr (Raw a)
   cast_fptr_to_obj :: Ptr (Raw a) -> a
 
 class FunPtrWrappable a where
-  type FunPtrHsType a :: *
-  type FunPtrType a :: *
-  data FunPtrWrapped a :: *
+  type FunPtrHsType a :: Type
+  type FunPtrType a :: Type
+  data FunPtrWrapped a :: Type
   fptrWrap :: FunPtrWrapped a -> IO (FunPtr (FunPtrType a))
   wrap :: FunPtrHsType a -> FunPtrWrapped a
 

--- a/fficxx-runtime/src/FFICXX/Runtime/CodeGen/Cxx.hs
+++ b/fficxx-runtime/src/FFICXX/Runtime/CodeGen/Cxx.hs
@@ -5,6 +5,7 @@ module FFICXX.Runtime.CodeGen.Cxx where
 
 import Data.Functor.Identity (Identity)
 import Data.Hashable (Hashable)
+import Data.Kind (Type)
 import Data.List (intercalate)
 import Data.String (IsString (..))
 
@@ -23,9 +24,9 @@ instance IsString Namespace where
 data PragmaParam = Once
 
 -- | parts for interpolation
-newtype NamePart (f :: * -> *) = NamePart String
+newtype NamePart (f :: Type -> Type) = NamePart String
 
-newtype CName (f :: * -> *) = CName [NamePart f]
+newtype CName (f :: Type -> Type) = CName [NamePart f]
 
 sname :: String -> CName Identity
 sname s = CName [NamePart s]
@@ -34,7 +35,7 @@ renderCName :: CName Identity -> String
 renderCName (CName ps) = intercalate "##" $ map (\(NamePart p) -> p) ps
 
 -- | Types
-data CType (f :: * -> *)
+data CType (f :: Type -> Type)
   = CTVoid
   | CTSimple (CName f)
   | CTStar (CType f)
@@ -56,7 +57,7 @@ renderCOp :: COp -> String
 renderCOp CArrow = "->"
 renderCOp CAssign = "="
 
-data CExp (f :: * -> *)
+data CExp (f :: Type -> Type)
   = -- | variable
     CVar (CName f)
   | -- | C function app:  f(a1,a2,..)
@@ -84,11 +85,11 @@ data CExp (f :: * -> *)
   | -- | empty C expression. (for convenience)
     CNull
 
-data CFunDecl (f :: * -> *)
+data CFunDecl (f :: Type -> Type)
   = -- | type func( type1 arg1, type2 arg2, ... )
     CFunDecl (CType f) (CName f) [(CType f, CName f)]
 
-data CVarDecl (f :: * -> *)
+data CVarDecl (f :: Type -> Type)
   = CVarDecl
       (CType f)
       -- ^ type
@@ -97,7 +98,7 @@ data CVarDecl (f :: * -> *)
 
 data CQual = Inline
 
-data CStatement (f :: * -> *)
+data CStatement (f :: Type -> Type)
   = -- | using namespace <namespace>;
     UsingNamespace Namespace
   | -- | typedef origtype newname;
@@ -125,7 +126,7 @@ data CStatement (f :: * -> *)
   | -- | temporary verbatim
     CVerbatim String
 
-data CMacro (f :: * -> *)
+data CMacro (f :: Type -> Type)
   = -- | regular C++ statement
     CRegular (CStatement f)
   | -- | #include "<header>"
@@ -141,7 +142,7 @@ data CMacro (f :: * -> *)
   | -- | temporary verbatim
     Verbatim String
 
-data CBlock (f :: * -> *) = ExternC [CMacro f] -- extern "C" with #ifdef __cplusplus guard.
+data CBlock (f :: Type -> Type) = ExternC [CMacro f] -- extern "C" with #ifdef __cplusplus guard.
 
 renderPragmaParam :: PragmaParam -> String
 renderPragmaParam Once = "once"

--- a/fficxx/fficxx.cabal
+++ b/fficxx/fficxx.cabal
@@ -20,6 +20,7 @@ Library
   Build-Depends: base == 4.*
                , aeson
                , aeson-pretty
+               , array
                , bytestring
                , Cabal
                , containers

--- a/fficxx/fficxx.cabal
+++ b/fficxx/fficxx.cabal
@@ -54,6 +54,7 @@ Library
                FFICXX.Generate.Code.Primitive
                FFICXX.Generate.ContentMaker
                FFICXX.Generate.Dependency
+               FFICXX.Generate.Dependency.Graph
                FFICXX.Generate.Name
                FFICXX.Generate.QQ.Verbatim
                FFICXX.Generate.Util

--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -16,7 +16,6 @@ import FFICXX.Generate.Config
 import qualified FFICXX.Generate.ContentMaker as C
 import FFICXX.Generate.Dependency
   ( findModuleUnitImports,
-    getClassModuleBase,
     mkHsBootCandidateList,
     mkPackageConfig,
   )

--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -169,11 +169,13 @@ simpleBuilder cfg sbc = do
       (prettyPrint (C.buildTHHs m))
   --
   -- TODO: Template.hs-boot need to be generated as well
+  {-
   putStrLn "Generating hs-boot file"
   for_ hsbootlst $ \m -> do
     gen
       (cmModule m <.> "Interface" <.> "hs-boot")
       (prettyPrint (C.buildInterfaceHsBoot depCycles m))
+  -}
   --
   putStrLn "Generating Module summary file"
   for_ mods $ \m ->

--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -8,6 +8,7 @@ import qualified Data.ByteString.Lazy.Char8 as L
 import Data.Char (toUpper)
 import Data.Digest.Pure.MD5 (md5)
 import Data.Foldable (for_)
+import qualified Data.Text as T
 import FFICXX.Generate.Code.Cabal (buildCabalFile, buildJSONFile)
 import FFICXX.Generate.Config
   ( FFICXXConfig (..),
@@ -179,10 +180,14 @@ simpleBuilder cfg sbc = do
   --
   -- TODO: Template.hs-boot need to be generated as well
   putStrLn "Generating hs-boot file"
+  -- This is a hack since haskell-src-exts always codegen () => instead of empty
+  -- string for an empty context, which have different meanings in hs-boot file.
+  -- Therefore, we get rid of them.
+  let hsBootHackClearEmptyContexts = T.unpack . T.replace "() =>" "" . T.pack
   for_ hsbootlst $ \m -> do
     gen
       (cmModule m <.> "Interface" <.> "hs-boot")
-      (prettyPrint (C.buildInterfaceHsBoot depCycles m))
+      (hsBootHackClearEmptyContexts $ prettyPrint (C.buildInterfaceHsBoot depCycles m))
   --
   putStrLn "Generating Module summary file"
   for_ mods $ \m ->

--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -51,6 +51,7 @@ macrofy = map ((\x -> if x == '-' then '_' else x) . toUpper)
 
 simpleBuilder :: FFICXXConfig -> SimpleBuilderConfig -> IO ()
 simpleBuilder cfg sbc = do
+  let depCycles = []
   putStrLn "----------------------------------------------------"
   putStrLn "-- fficxx code generation for Haskell-C++ binding --"
   putStrLn "----------------------------------------------------"
@@ -131,7 +132,7 @@ simpleBuilder cfg sbc = do
   for_ mods $ \m ->
     gen
       (cmModule m <.> "Interface" <.> "hs")
-      (prettyPrint (C.buildInterfaceHs mempty m))
+      (prettyPrint (C.buildInterfaceHs mempty depCycles m))
   --
   putStrLn "Generating Cast.hs"
   for_ mods $ \m ->
@@ -167,7 +168,7 @@ simpleBuilder cfg sbc = do
   for_ hsbootlst $ \m -> do
     gen
       (cmModule m <.> "Interface" <.> "hs-boot")
-      (prettyPrint (C.buildInterfaceHsBoot m))
+      (prettyPrint (C.buildInterfaceHsBoot depCycles m))
   --
   putStrLn "Generating Module summary file"
   for_ mods $ \m ->

--- a/fficxx/src/FFICXX/Generate/Code/HsFFI.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsFFI.hs
@@ -13,12 +13,12 @@ import FFICXX.Generate.Code.Primitive
   )
 import FFICXX.Generate.Dependency
   ( class_allparents,
-    getClassModuleBase,
-    getTClassModuleBase,
   )
 import FFICXX.Generate.Name
   ( aliasedFuncName,
     ffiClassName,
+    getClassModuleBase,
+    getTClassModuleBase,
     hscAccessorName,
     hscFuncName,
   )

--- a/fficxx/src/FFICXX/Generate/Code/HsFFI.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsFFI.hs
@@ -17,10 +17,9 @@ import FFICXX.Generate.Dependency
 import FFICXX.Generate.Name
   ( aliasedFuncName,
     ffiClassName,
-    getClassModuleBase,
-    getTClassModuleBase,
     hscAccessorName,
     hscFuncName,
+    subModuleName,
   )
 import FFICXX.Generate.Type.Class
   ( Accessor (Getter, Setter),
@@ -89,12 +88,8 @@ hsFFIAccessor c v a =
    in mkForImpCcall cname (hscAccessorName c v a) typ
 
 -- import for FFI
-
 genImportInFFI :: ClassModule -> [ImportDecl ()]
-genImportInFFI = map mkMod . cmImportedModulesFFI
-  where
-    mkMod (Left t) = mkImport (getTClassModuleBase t <.> "Template")
-    mkMod (Right c) = mkImport (getClassModuleBase c <.> "RawType")
+genImportInFFI = fmap (mkImport . subModuleName) . cmImportedSubmodulesForFFI
 
 ----------------------------
 -- for top level function --

--- a/fficxx/src/FFICXX/Generate/Code/HsFrontEnd.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsFrontEnd.hs
@@ -23,14 +23,14 @@ import FFICXX.Generate.Dependency
     class_allparents,
     extractClassDepForTLOrdinary,
     extractClassDepForTLTemplate,
-    getClassModuleBase,
-    getTClassModuleBase,
     returnDependency,
   )
 import FFICXX.Generate.Dependency.Graph (DepCycles)
 import FFICXX.Generate.Name
   ( accessorName,
     aliasedFuncName,
+    getClassModuleBase,
+    getTClassModuleBase,
     hsClassName,
     hsFrontNameForTopLevel,
     hsFuncName,

--- a/fficxx/src/FFICXX/Generate/Code/HsFrontEnd.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsFrontEnd.hs
@@ -6,7 +6,6 @@
 module FFICXX.Generate.Code.HsFrontEnd where
 
 import Control.Monad.Reader (Reader)
-import Data.Bifunctor (bimap)
 import Data.Either (lefts, rights)
 import qualified Data.List as L
 import FFICXX.Generate.Code.Primitive
@@ -21,8 +20,6 @@ import FFICXX.Generate.Code.Primitive
   )
 import FFICXX.Generate.Dependency
   ( argumentDependency,
-    calculateDependency,
-    class_allparents,
     extractClassDepForTLOrdinary,
     extractClassDepForTLTemplate,
     returnDependency,
@@ -60,9 +57,7 @@ import FFICXX.Generate.Type.Class
     virtualFuncs,
   )
 import FFICXX.Generate.Type.Module
-  ( ClassImportHeader (..),
-    ClassModule (..),
-    ClassSubmoduleType (..),
+  ( ClassModule (..),
     DepCycles,
     TemplateClassModule (..),
   )

--- a/fficxx/src/FFICXX/Generate/Code/HsFrontEnd.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsFrontEnd.hs
@@ -26,8 +26,7 @@ import FFICXX.Generate.Dependency
     returnDependency,
   )
 import FFICXX.Generate.Dependency.Graph
-  ( DepCycles,
-    locateInDepCycles,
+  ( locateInDepCycles,
   )
 import FFICXX.Generate.Name
   ( accessorName,
@@ -60,6 +59,7 @@ import FFICXX.Generate.Type.Class
 import FFICXX.Generate.Type.Module
   ( ClassImportHeader (..),
     ClassModule (..),
+    DepCycles,
     TemplateClassModule (..),
   )
 import FFICXX.Generate.Util (toLowers)

--- a/fficxx/src/FFICXX/Generate/Code/HsFrontEnd.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsFrontEnd.hs
@@ -27,6 +27,7 @@ import FFICXX.Generate.Dependency
     getTClassModuleBase,
     returnDependency,
   )
+import FFICXX.Generate.Dependency.Graph (DepCycles)
 import FFICXX.Generate.Name
   ( accessorName,
     aliasedFuncName,
@@ -324,8 +325,8 @@ genImportInModule :: Class -> [ImportDecl ()]
 genImportInModule x = map (\y -> mkImport (getClassModuleBase x <.> y)) ["RawType", "Interface", "Implementation"]
 
 -- TODO: this dependency should be refactored out and analyzed separately, particularly for cyclic deps.
-genImportInInterface :: ClassModule -> [ImportDecl ()]
-genImportInInterface m =
+genImportInInterface :: DepCycles -> ClassModule -> [ImportDecl ()]
+genImportInInterface _ m =
   let modsRaw = cmImportedModulesRaw m
       modsExt = cmImportedModulesExternal m
       modsInplace = cmImportedModulesInplace m

--- a/fficxx/src/FFICXX/Generate/Code/HsFrontEnd.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsFrontEnd.hs
@@ -343,10 +343,8 @@ mkImportWithDepCycles depCycles self imported =
 genImportInInterface :: DepCycles -> ClassModule -> [ImportDecl ()]
 genImportInInterface depCycles m =
   let modSelf = cmModule m <.> "Interface"
-      modSelfRaw = cmModule m <.> "RawType"
       imported = cmImportedSubmodulesForInterface m
-   in mkImport modSelfRaw :
-      fmap (\x -> mkImportWithDepCycles depCycles modSelf (subModuleName x)) imported
+   in fmap (\x -> mkImportWithDepCycles depCycles modSelf (subModuleName x)) imported
 
 -- |
 genImportInCast :: ClassModule -> [ImportDecl ()]

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -19,10 +19,7 @@ import FFICXX.Generate.Code.Primitive
     functionSignatureTT,
     tmplAccessorToTFun,
   )
-import FFICXX.Generate.Dependency
-  ( calculateDependency,
-    mkModuleDepInplace,
-  )
+import FFICXX.Generate.Dependency (calculateDependency)
 import FFICXX.Generate.Name
   ( ffiTmplFuncName,
     getClassModuleBase,
@@ -238,19 +235,7 @@ genTMFInstance cih f =
 
 genImportInTemplate :: TemplateClass -> [ImportDecl ()]
 genImportInTemplate t0 =
-  let depsRaw =
-        fmap (mkImport . subModuleName) $
-          calculateDependency $
-            Left (TCSTTemplate, t0)
-      depsInplace = mkModuleDepInplace (Left t0)
-   in depsRaw
-        <> flip
-          map
-          depsInplace
-          ( \case
-              Left t -> mkImport (getTClassModuleBase t <.> "Template")
-              Right c -> mkImport (getClassModuleBase c <.> "Interface")
-          )
+  fmap (mkImport . subModuleName) $ calculateDependency $ Left (TCSTTemplate, t0)
 
 -- |
 genTmplInterface :: TemplateClass -> [Decl ()]
@@ -287,16 +272,7 @@ genTmplInterface t =
 -- |
 genImportInTH :: TemplateClass -> [ImportDecl ()]
 genImportInTH t0 =
-  let depsRaw = fmap (mkImport . subModuleName) $ calculateDependency $ Left (TCSTTH, t0)
-      depsInplace = mkModuleDepInplace (Left t0)
-   in depsRaw
-        <> flip
-          concatMap
-          depsInplace
-          ( \case
-              Left t -> [mkImport (getTClassModuleBase t <.> "Template")]
-              Right c -> map (\y -> mkImport (getClassModuleBase c <.> y)) ["RawType", "Cast", "Interface"]
-          )
+  fmap (mkImport . subModuleName) $ calculateDependency $ Left (TCSTTH, t0)
 
 -- |
 genTmplImplementation :: TemplateClass -> [Decl ()]

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -20,13 +20,13 @@ import FFICXX.Generate.Code.Primitive
     tmplAccessorToTFun,
   )
 import FFICXX.Generate.Dependency
-  ( getClassModuleBase,
-    getTClassModuleBase,
-    mkModuleDepInplace,
+  ( mkModuleDepInplace,
     mkModuleDepRaw,
   )
 import FFICXX.Generate.Name
   ( ffiTmplFuncName,
+    getClassModuleBase,
+    getTClassModuleBase,
     hsTemplateClassName,
     hsTemplateMemberFunctionName,
     hsTemplateMemberFunctionNameTH,

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -22,8 +22,6 @@ import FFICXX.Generate.Code.Primitive
 import FFICXX.Generate.Dependency (calculateDependency)
 import FFICXX.Generate.Name
   ( ffiTmplFuncName,
-    getClassModuleBase,
-    getTClassModuleBase,
     hsTemplateClassName,
     hsTemplateMemberFunctionName,
     hsTemplateMemberFunctionNameTH,
@@ -109,7 +107,6 @@ import Language.Haskell.Exts.Build
     wildcard,
   )
 import Language.Haskell.Exts.Syntax (Boxed (Boxed), Decl (..), ImportDecl (..), Type (TyTuple))
-import System.FilePath ((<.>))
 
 ------------------------------
 -- Template member function --

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -80,6 +80,7 @@ import FFICXX.Generate.Dependency
     mkDaughterMap,
     mkDaughterSelfMap,
   )
+import FFICXX.Generate.Dependency.Graph (DepCycles)
 import FFICXX.Generate.Name
   ( ffiClassName,
     hsClassName,
@@ -390,8 +391,12 @@ buildRawTypeHs m =
        in if isAbstractClass c then [] else hsClassRawType c
 
 -- |
-buildInterfaceHs :: AnnotateMap -> ClassModule -> Module ()
-buildInterfaceHs amap m =
+buildInterfaceHs ::
+  AnnotateMap ->
+  DepCycles ->
+  ClassModule ->
+  Module ()
+buildInterfaceHs amap depCycles m =
   mkModule
     (cmModule m <.> "Interface")
     [ lang
@@ -417,7 +422,7 @@ buildInterfaceHs amap m =
         mkImport "Foreign.Ptr",
         mkImport "FFICXX.Runtime.Cast"
       ]
-        <> genImportInInterface m
+        <> genImportInInterface depCycles m
         <> genExtraImport m
     ifaceBody =
       runReader (mapM genHsFrontDecl classes) amap
@@ -425,8 +430,8 @@ buildInterfaceHs amap m =
         <> (concatMap genHsFrontDowncastClass . filter (not . isAbstractClass)) classes
 
 -- |
-buildInterfaceHsBoot :: ClassModule -> Module ()
-buildInterfaceHsBoot m =
+buildInterfaceHsBoot :: DepCycles -> ClassModule -> Module ()
+buildInterfaceHsBoot depCycles m =
   mkModule
     (cmModule m <.> "Interface")
     [ lang
@@ -452,7 +457,7 @@ buildInterfaceHsBoot m =
         mkImport "Foreign.Ptr",
         mkImport "FFICXX.Runtime.Cast"
       ]
-        <> genImportInInterface m
+        <> genImportInInterface depCycles m
         <> genExtraImport m
     hsbootBody =
       runReader (mapM genHsFrontDecl [c]) M.empty

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -71,12 +71,8 @@ import FFICXX.Generate.Code.HsTemplate
     genTmplInstance,
     genTmplInterface,
   )
-import FFICXX.Generate.Code.Primitive
-  ( classConstraints,
-  )
 import FFICXX.Generate.Dependency
   ( class_allparents,
-    getClassModuleBase,
     mkDaughterMap,
     mkDaughterSelfMap,
   )
@@ -85,7 +81,6 @@ import FFICXX.Generate.Name
   ( ffiClassName,
     hsClassName,
     hsFrontNameForTopLevel,
-    typeclassName,
   )
 import FFICXX.Generate.Type.Annotate (AnnotateMap)
 import FFICXX.Generate.Type.Class
@@ -115,11 +110,9 @@ import FFICXX.Generate.Util.HaskellSrcExts
   ( emodule,
     evar,
     lang,
-    mkClass,
     mkImport,
     mkModule,
     mkModuleE,
-    mkTBind,
     unqual,
   )
 import FFICXX.Runtime.CodeGen.Cxx (HeaderName (..))

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -415,10 +415,10 @@ buildInterfaceHs amap depCycles m =
         mkImport "Foreign.Ptr",
         mkImport "FFICXX.Runtime.Cast"
       ]
-        <> genImportInInterface depCycles m
+        <> genImportInInterface False depCycles m
         <> genExtraImport m
     ifaceBody =
-      runReader (mapM genHsFrontDecl classes) amap
+      runReader (mapM (genHsFrontDecl False) classes) amap
         <> (concatMap genHsFrontUpcastClass . filter (not . isAbstractClass)) classes
         <> (concatMap genHsFrontDowncastClass . filter (not . isAbstractClass)) classes
 
@@ -450,10 +450,10 @@ buildInterfaceHsBoot depCycles m =
         mkImport "Foreign.Ptr",
         mkImport "FFICXX.Runtime.Cast"
       ]
-        <> genImportInInterface depCycles m
+        <> genImportInInterface True depCycles m
         <> genExtraImport m
     hsbootBody =
-      runReader (mapM genHsFrontDecl [c]) M.empty
+      runReader (mapM (genHsFrontDecl True) [c]) M.empty
 
 -- |
 buildCastHs :: ClassModule -> Module ()

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -76,7 +76,6 @@ import FFICXX.Generate.Dependency
     mkDaughterMap,
     mkDaughterSelfMap,
   )
-import FFICXX.Generate.Dependency.Graph (DepCycles)
 import FFICXX.Generate.Name
   ( ffiClassName,
     hsClassName,
@@ -96,6 +95,7 @@ import FFICXX.Generate.Type.Class
 import FFICXX.Generate.Type.Module
   ( ClassImportHeader (..),
     ClassModule (..),
+    DepCycles,
     TemplateClassImportHeader (..),
     TemplateClassModule (..),
     TopLevelImportHeader (..),

--- a/fficxx/src/FFICXX/Generate/Dependency.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency.hs
@@ -30,6 +30,8 @@ import FFICXX.Generate.Name
   ( ClassModuleType (..),
     TemplateClassModuleType (..),
     ffiClassName,
+    getClassModuleBase,
+    getTClassModuleBase,
     hsClassName,
     hsTemplateClassName,
   )
@@ -118,12 +120,6 @@ class_allparents c =
    in if null ps
         then []
         else nub (ps <> (concatMap class_allparents ps))
-
-getClassModuleBase :: Class -> String
-getClassModuleBase = (<.>) <$> (cabal_moduleprefix . class_cabal) <*> (fst . hsClassName)
-
-getTClassModuleBase :: TemplateClass -> String
-getTClassModuleBase = (<.>) <$> (cabal_moduleprefix . tclass_cabal) <*> (fst . hsTemplateClassName)
 
 -- | Daughter map not including itself
 mkDaughterMap :: [Class] -> DaughterMap

--- a/fficxx/src/FFICXX/Generate/Dependency.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency.hs
@@ -59,6 +59,7 @@ import FFICXX.Generate.Type.Class
     Variable (unVariable),
     argsFromOpExp,
     filterTLOrdinary,
+    virtualFuncs,
   )
 import FFICXX.Generate.Type.Config
   ( ModuleUnit (..),
@@ -256,10 +257,10 @@ calculateDependency (Right (CSTRawType, _)) = []
 calculateDependency (Right (CSTFFI, cls)) = mkDepFFI cls
 calculateDependency (Right (CSTInterface, cls)) =
   let retDepClasses =
-        concatMap (returnDependency . extractClassDep) (class_funcs cls)
+        concatMap (returnDependency . extractClassDep) (virtualFuncs $ class_funcs cls)
           ++ concatMap (returnDependency . extractClassDep4TmplMemberFun) (class_tmpl_funcs cls)
       argDepClasses =
-        concatMap (argumentDependency . extractClassDep) (class_funcs cls)
+        concatMap (argumentDependency . extractClassDep) (virtualFuncs $ class_funcs cls)
           ++ concatMap (argumentDependency . extractClassDep4TmplMemberFun) (class_tmpl_funcs cls)
       rawSelf = Right (CSTRawType, cls)
       raws =

--- a/fficxx/src/FFICXX/Generate/Dependency.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency.hs
@@ -268,6 +268,7 @@ calculateDependency (Right (CSTInterface, cls)) =
           L.nub $
             filter (`isInSamePackageButNotInheritedBy` Right cls) $ argDepClasses
    in raws ++ exts ++ inplaces
+calculateDependency (Right (CSTCast, cls)) = [Right (CSTRawType, cls), Right (CSTInterface, cls)]
 calculateDependency _ = undefined
 
 -- |

--- a/fficxx/src/FFICXX/Generate/Dependency.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency.hs
@@ -252,6 +252,7 @@ calculateDependency (Left (typ, tcl)) = raws <> inplaces
             L.nub $
               filter (`isInSamePackageButNotInheritedBy` Left tcl) $
                 concatMap (argumentDependency . extractClassDepForTmplFun) fs
+calculateDependency (Right (CSTRawType, _)) = []
 calculateDependency (Right (CSTFFI, cls)) = mkDepFFI cls
 calculateDependency (Right (CSTInterface, cls)) =
   let retDepClasses =

--- a/fficxx/src/FFICXX/Generate/Dependency.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency.hs
@@ -27,9 +27,7 @@ import Data.List (find, foldl', nub, nubBy)
 import qualified Data.Map as M
 import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import FFICXX.Generate.Name
-  ( ClassModuleType (..),
-    TemplateClassModuleType (..),
-    ffiClassName,
+  ( ffiClassName,
     getClassModuleBase,
     getTClassModuleBase,
     hsClassName,
@@ -72,9 +70,11 @@ import FFICXX.Generate.Type.Config
 import FFICXX.Generate.Type.Module
   ( ClassImportHeader (..),
     ClassModule (..),
+    ClassSubmoduleType (..),
     PackageConfig (..),
     TemplateClassImportHeader (..),
     TemplateClassModule (..),
+    TemplateClassSubmoduleType (..),
     TopLevelImportHeader (..),
   )
 import FFICXX.Runtime.CodeGen.Cxx (HeaderName (..))
@@ -232,6 +232,8 @@ isInSamePackageButNotInheritedBy ::
 isInSamePackageButNotInheritedBy x y =
   x /= y && not (x `elem` getparents y) && (getPkgName x == getPkgName y)
 
+-- calculateDependency :: Either (
+
 -- TODO: Confirm the following answer
 -- NOTE: Q: why returnDependency is not considered?
 --       A: See explanation in mkModuleDepRaw
@@ -312,20 +314,20 @@ mkModuleDepFFI (Left _) = []
 mkTopLevelDep ::
   TopLevel ->
   [ Either
-      (TemplateClassModuleType, TemplateClass)
-      (ClassModuleType, Class)
+      (TemplateClassSubmoduleType, TemplateClass)
+      (ClassSubmoduleType, Class)
   ]
 mkTopLevelDep (TLOrdinary f) =
   let dep4func = extractClassDepForTLOrdinary f
       allDeps = returnDependency dep4func ++ argumentDependency dep4func
-      mkTags (Left tcl) = [Left (TCMTTemplate, tcl)]
-      mkTags (Right cls) = fmap (Right . (,cls)) [CMTRawType, CMTCast, CMTInterface]
+      mkTags (Left tcl) = [Left (TCSTTemplate, tcl)]
+      mkTags (Right cls) = fmap (Right . (,cls)) [CSTRawType, CSTCast, CSTInterface]
    in concatMap mkTags allDeps
 mkTopLevelDep (TLTemplate f) =
   let dep4func = extractClassDepForTLTemplate f
       allDeps = returnDependency dep4func ++ argumentDependency dep4func
-      mkTags (Left tcl) = [Left (TCMTTemplate, tcl)]
-      mkTags (Right cls) = fmap (Right . (,cls)) [CMTRawType, CMTCast, CMTInterface]
+      mkTags (Left tcl) = [Left (TCSTTemplate, tcl)]
+      mkTags (Right cls) = fmap (Right . (,cls)) [CSTRawType, CSTCast, CSTInterface]
    in concatMap mkTags allDeps
 
 -- |

--- a/fficxx/src/FFICXX/Generate/Dependency.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency.hs
@@ -290,11 +290,11 @@ calculateDependency (Right (CSTImplementation, cls)) =
       deps =
         concatMap
           ( \case
-              Left tcl -> [Left (TCSTTemplate, tcl)]
-              Right cls ->
-                [ Right (CSTRawType, cls),
-                  Right (CSTCast, cls),
-                  Right (CSTInterface, cls)
+              Left t -> [Left (TCSTTemplate, t)]
+              Right c ->
+                [ Right (CSTRawType, c),
+                  Right (CSTCast, c),
+                  Right (CSTInterface, c)
                 ]
           )
           (dsNonParents <> dsParents)

--- a/fficxx/src/FFICXX/Generate/Dependency.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency.hs
@@ -408,17 +408,6 @@ mkPackageConfig (pkgname, getImports) (cs, fs, ts, extra) acincs acsrcs =
           pcfg_additional_c_srcs = acsrcs
         }
 
--- for now
-mkHsBootCandidateList :: [ClassModule] -> [ClassModule]
-mkHsBootCandidateList ms = []
-
-{-
-  let -- get only class dependencies, not template classes.
-      cs = rights (concatMap cmImportedModulesInplace ms)
-      candidateModBases = fmap getClassModuleBase cs
-   in filter (\m -> cmModule m `elem` candidateModBases) ms
--}
-
 -- |
 mkPkgHeaderFileName :: Class -> HeaderName
 mkPkgHeaderFileName c =

--- a/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
@@ -63,8 +63,8 @@ constructDepGraph allclasses allTopLevels = (allSyms, depmap')
     mkCastDep :: Class -> (String, [String])
     mkCastDep c =
       let cast = subModuleName $ Right (CSTCast, c)
-          depsSelf = fmap (subModuleName . Right . (,c)) [CSTRawType, CSTInterface]
-       in (cast, depsSelf)
+          deps = fmap subModuleName $ calculateDependency (Right (CSTCast, c))
+       in (cast, deps)
     -- Implementation
     -- TODO: THIS IS INVOLVED! NEED TO REFACTOR THINGS OUT.
     mkImplementationDep :: Class -> (String, [String])

--- a/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
@@ -4,8 +4,8 @@
 module FFICXX.Generate.Dependency.Graph where
 
 import Data.Array (listArray)
-import qualified Data.Graph as G
 import Data.Foldable (for_)
+import qualified Data.Graph as G
 import qualified Data.HashMap.Strict as HM
 import qualified Data.List as L
 import Data.Maybe (fromMaybe, mapMaybe)
@@ -33,7 +33,6 @@ import FFICXX.Generate.Type.Class
   )
 import System.FilePath ((<.>))
 import System.IO (IOMode (..), hPutStrLn, withFile)
-
 
 -- TODO: Should be used everywhere.
 
@@ -176,12 +175,12 @@ constructDepGraph allclasses allTopLevels = (allSyms, depmap')
 
 -- | find grouped dependency cycles
 findDepCycles :: ([String], [(Int, [Int])]) -> [[String]]
-findDepCycles (syms, deps) = do
-  let symMap = zip [0..] syms
+findDepCycles (syms, deps) =
+  let symMap = zip [0 ..] syms
       lookupSym i = fromMaybe "<NOTFOUND>" (L.lookup i symMap)
       n = length syms
       bounds = (0, n - 1)
-      gr = listArray bounds $ fmap (\i -> fromMaybe [] (L.lookup i deps)) [0..n-1]
+      gr = listArray bounds $ fmap (\i -> fromMaybe [] (L.lookup i deps)) [0 .. n - 1]
       cycleGroups =
         fmap (fmap lookupSym) $ filter (\xs -> length xs > 1) $ fmap flatten (G.scc gr)
    in cycleGroups

--- a/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
@@ -1,5 +1,170 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TupleSections #-}
+
 module FFICXX.Generate.Dependency.Graph where
 
-import Data.Graph ()
+-- import Data.Graph ()
+import Data.Foldable (for_)
+import qualified Data.HashMap.Strict as HM
+import qualified Data.List as L
+import Data.Maybe (mapMaybe)
+import Data.Tuple (swap)
+import FFICXX.Generate.Dependency
+  ( class_allparents,
+    mkModuleDepExternal,
+    mkModuleDepFFI,
+    mkModuleDepInplace,
+    mkModuleDepRaw,
+    mkTopLevelDep,
+  )
+import FFICXX.Generate.Name
+  ( ClassModuleType (..),
+    TemplateClassModuleType (..),
+    hsClassName,
+    hsTemplateClassName,
+    subModuleName,
+  )
+import FFICXX.Generate.Type.Class
+  ( Class (..),
+    TemplateClass (..),
+    TopLevel (..),
+  )
+import System.FilePath ((<.>))
+import System.IO (IOMode (..), hPutStrLn, withFile)
 
 
+-- TODO: Should be used everywhere.
+
+-- | UClass = Unified Class, either template class or ordinary class
+type UClass = Either TemplateClass Class
+
+-- | construct dependency graph
+constructDepGraph ::
+  -- | list of all classes, either template class or ordinary class.
+  [UClass] ->
+  -- | list of all top-level functions.
+  [TopLevel] ->
+  -- | (all submodules, [(submodule, submodule dependencies)])
+  ([String], [(Int, [Int])])
+constructDepGraph allclasses allTopLevels = (allSyms, depmap')
+  where
+    -- RawType dependency is trivial
+    mkRawTypeDep :: Class -> (String, [String])
+    mkRawTypeDep c =
+      let rawtype = subModuleName (Right (CMTRawType, c))
+       in (rawtype, [])
+    -- FFI
+    mkFFIDep :: Class -> (String, [String])
+    mkFFIDep c =
+      let ffi = subModuleName (Right (CMTFFI, c))
+          depRawSelf = subModuleName (Right (CMTRawType, c))
+          depsFFI =
+            let ds = mkModuleDepFFI (Right c)
+                format' (Left tcl) = subModuleName $ Left (TCMTTemplate, tcl)
+                format' (Right cls) = subModuleName $ Right (CMTRawType, cls)
+             in fmap format' ds
+       in (ffi, [depRawSelf] ++ depsFFI)
+    mkInterfaceDep :: Class -> (String, [String])
+    mkInterfaceDep c =
+      let interface = subModuleName $ Right (CMTInterface, c)
+          depRawSelf = subModuleName $ Right (CMTRawType, c)
+          depsRaw =
+            let ds = mkModuleDepRaw (Right c)
+                format' (Left tcl) = subModuleName $ Left (TCMTTemplate, tcl)
+                format' (Right cls) = subModuleName $ Right (CMTRawType, cls)
+             in fmap format' ds
+          depsExt =
+            let ds = mkModuleDepExternal (Right c)
+                format' (Left tcl) = subModuleName $ Left (TCMTTemplate, tcl)
+                format' (Right cls) = subModuleName $ Right (CMTInterface, cls)
+             in fmap format' ds
+          depsInplace =
+            let ds = mkModuleDepInplace (Right c)
+                format' (Left tcl) = subModuleName $ Left (TCMTTemplate, tcl)
+                format' (Right cls) = subModuleName $ Right (CMTInterface, cls)
+             in fmap format' ds
+       in (interface, [depRawSelf] ++ depsRaw ++ depsExt ++ depsInplace)
+    -- Cast
+    mkCastDep :: Class -> (String, [String])
+    mkCastDep c =
+      let cast = subModuleName $ Right (CMTCast, c)
+          depsSelf = fmap (subModuleName . Right . (,c)) [CMTRawType, CMTInterface]
+       in (cast, depsSelf)
+    -- Implementation
+    -- TODO: THIS IS INVOLVED! NEED TO REFACTOR THINGS OUT.
+    mkImplementationDep :: Class -> (String, [String])
+    mkImplementationDep c =
+      let implementation = subModuleName $ Right (CMTImplementation, c)
+          depsSelf =
+            fmap (subModuleName . Right . (,c)) [CMTRawType, CMTFFI, CMTInterface, CMTCast]
+          deps =
+            let dsFFI = mkModuleDepFFI (Right c)
+                dsParents = L.nub $ map Right $ class_allparents c
+                dsNonParents = filter (not . (flip elem dsParents)) dsFFI
+                format (Left tcl) = [subModuleName $ Left (TCMTTemplate, tcl)]
+                format (Right cls) =
+                  fmap (subModuleName . Right . (,cls)) [CMTRawType, CMTCast, CMTInterface]
+             in concatMap format (dsNonParents ++ dsParents)
+       in (implementation, depsSelf ++ deps)
+    -- Template Class part
+    -- <TClass>.Template
+    mkTemplateDep :: TemplateClass -> (String, [String])
+    mkTemplateDep t =
+      let template = subModuleName $ Left (TCMTTemplate, t)
+          depsRaw =
+            let ds = mkModuleDepRaw (Left t)
+                format' (Left tcl) = subModuleName $ Left (TCMTTemplate, tcl)
+                format' (Right cls) = subModuleName $ Right (CMTRawType, cls)
+             in fmap format' ds
+          depsInplace =
+            let ds = mkModuleDepInplace (Left t)
+                format' (Left tcl) = subModuleName $ Left (TCMTTemplate, tcl)
+                format' (Right cls) = subModuleName $ Right (CMTInterface, cls)
+             in fmap format' ds
+       in (template, depsRaw ++ depsInplace)
+    -- <TClass>.TH
+    mkTHDep :: TemplateClass -> (String, [String])
+    mkTHDep t =
+      let th = subModuleName $ Left (TCMTTH, t)
+          deps =
+            let dsRaw = mkModuleDepRaw (Left t)
+                dsInplace = mkModuleDepInplace (Left t)
+
+                format' (Left tcl) = [subModuleName $ Left (TCMTTemplate, tcl)]
+                format' (Right cls) =
+                  fmap (subModuleName . Right . (,cls)) [CMTRawType, CMTCast, CMTInterface]
+             in concatMap format' (dsRaw ++ dsInplace)
+       in (th, deps)
+    -- TopLevel
+    topLevelDeps :: (String, [String])
+    topLevelDeps =
+      let deps =
+            L.nub . L.sort $ concatMap (fmap subModuleName . mkTopLevelDep) allTopLevels
+       in ("[TopLevel]", deps)
+
+    depmapAllClasses =
+      concatMap
+        ( \case
+            Left tcl -> [mkTemplateDep tcl]
+            Right cls ->
+              [ mkRawTypeDep cls,
+                mkFFIDep cls,
+                mkInterfaceDep cls,
+                mkCastDep cls,
+                mkImplementationDep cls
+              ]
+        )
+        allclasses
+    depmap = topLevelDeps : depmapAllClasses
+    allSyms =
+      L.nub . L.sort $
+        fmap fst depmap ++ concatMap snd depmap
+    allISyms :: [(Int, String)]
+    allISyms = zip [0 ..] allSyms
+    symMap = HM.fromList allISyms
+    symRevMap = HM.fromList $ fmap swap allISyms
+    replace (c, ds) = do
+      i <- HM.lookup c symRevMap
+      js <- traverse (\d -> HM.lookup d symRevMap) ds
+      pure (i, js)
+    depmap' = mapMaybe replace depmap

--- a/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
@@ -30,8 +30,6 @@ import FFICXX.Generate.Type.Module
     UClassSubmodule,
   )
 
--- TODO: Should be used everywhere.
-
 -- | construct dependency graph
 constructDepGraph ::
   -- | list of all classes, either template class or ordinary class.

--- a/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
@@ -95,6 +95,11 @@ findDepCycles (syms, deps) =
         fmap lookupSymAndRestrictDeps $ filter (\xs -> length xs > 1) $ fmap flatten (G.scc gr)
    in cycleGroups
 
+getCyclicDepSubmodules :: String -> DepCycles -> ([String], [String])
+getCyclicDepSubmodules self depCycles = fromMaybe ([], []) $ do
+  cycl <- L.find (\xs -> self `L.elem` fmap fst xs) depCycles
+  L.lookup self cycl
+
 -- | locate importing module and imported module in dependency cycles
 locateInDepCycles :: (String, String) -> DepCycles -> Maybe (Int, Int)
 locateInDepCycles (self, imported) depCycles = do

--- a/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
@@ -24,6 +24,8 @@ import FFICXX.Generate.Type.Module
     UClassSubmodule,
   )
 
+-- TODO: Introduce unique id per submodule.
+
 -- | construct dependency graph
 constructDepGraph ::
   -- | list of all classes, either template class or ordinary class.
@@ -73,21 +75,38 @@ constructDepGraph allClasses allTopLevels = (allSyms, depmap')
     depmap' = mapMaybe replace depmap
 
 -- | find grouped dependency cycles
-findDepCycles :: ([String], [(Int, [Int])]) -> [[String]]
+findDepCycles :: ([String], [(Int, [Int])]) -> DepCycles
 findDepCycles (syms, deps) =
   let symMap = zip [0 ..] syms
       lookupSym i = fromMaybe "<NOTFOUND>" (L.lookup i symMap)
       n = length syms
       bounds = (0, n - 1)
       gr = listArray bounds $ fmap (\i -> fromMaybe [] (L.lookup i deps)) [0 .. n - 1]
+      lookupSymAndRestrictDeps :: [Int] -> [(String, ([String], [String]))]
+      lookupSymAndRestrictDeps cycl = fmap go cycl
+        where
+          go i =
+            let sym = lookupSym i
+                (rdepsU, rdepsL) =
+                  L.partition (< i) $ filter (`elem` cycl) $ fromMaybe [] (L.lookup i deps)
+                (rdepsU', rdepsL') = (fmap lookupSym rdepsU, fmap lookupSym rdepsL)
+             in (sym, (rdepsU', rdepsL'))
       cycleGroups =
-        fmap (fmap lookupSym) $ filter (\xs -> length xs > 1) $ fmap flatten (G.scc gr)
+        fmap lookupSymAndRestrictDeps $ filter (\xs -> length xs > 1) $ fmap flatten (G.scc gr)
    in cycleGroups
 
 -- | locate importing module and imported module in dependency cycles
 locateInDepCycles :: (String, String) -> DepCycles -> Maybe (Int, Int)
 locateInDepCycles (self, imported) depCycles = do
-  cycl <- L.find (self `L.elem`) depCycles
-  idxSelf <- self `L.elemIndex` cycl
-  idxImported <- imported `L.elemIndex` cycl
+  cycl <- L.find (\xs -> self `L.elem` fmap fst xs) depCycles
+  let cyclNoDeps = fmap fst cycl
+  idxSelf <- self `L.elemIndex` cyclNoDeps
+  idxImported <- imported `L.elemIndex` cyclNoDeps
   pure (idxSelf, idxImported)
+
+gatherHsBootSubmodules :: DepCycles -> [String]
+gatherHsBootSubmodules depCycles = do
+  cycl <- depCycles
+  (_, (_us, ds)) <- cycl
+  d <- ds
+  pure d

--- a/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
@@ -70,18 +70,8 @@ constructDepGraph allclasses allTopLevels = (allSyms, depmap')
     mkImplementationDep :: Class -> (String, [String])
     mkImplementationDep c =
       let implementation = subModuleName $ Right (CSTImplementation, c)
-          depsSelf =
-            fmap (subModuleName . Right . (,c)) [CSTRawType, CSTFFI, CSTInterface, CSTCast]
-          deps =
-            let -- TODO: should not use CSTFFI.
-                dsFFI = fmap (bimap snd snd) $ calculateDependency (Right (CSTFFI, c))
-                dsParents = L.nub $ map Right $ class_allparents c
-                dsNonParents = filter (not . (flip elem dsParents)) dsFFI
-                format (Left tcl) = [subModuleName $ Left (TCSTTemplate, tcl)]
-                format (Right cls) =
-                  fmap (subModuleName . Right . (,cls)) [CSTRawType, CSTCast, CSTInterface]
-             in concatMap format (dsNonParents ++ dsParents)
-       in (implementation, depsSelf ++ deps)
+          deps = fmap subModuleName $ calculateDependency $ Right (CSTImplementation, c)
+       in (implementation, deps)
     -- Template Class part
     -- <TClass>.Template
     mkTemplateDep :: TemplateClass -> (String, [String])

--- a/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
@@ -184,3 +184,11 @@ findDepCycles (syms, deps) =
       cycleGroups =
         fmap (fmap lookupSym) $ filter (\xs -> length xs > 1) $ fmap flatten (G.scc gr)
    in cycleGroups
+
+-- | locate importing module and imported module in dependency cycles
+locateInDepCycles :: (String, String) -> DepCycles -> Maybe (Int, Int)
+locateInDepCycles (self, imported) depCycles = do
+  cycl <- L.find (self `L.elem`) depCycles
+  idxSelf <- self `L.elemIndex` cycl
+  idxImported <- imported `L.elemIndex` cycl
+  pure (idxSelf, idxImported)

--- a/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
@@ -4,7 +4,6 @@
 module FFICXX.Generate.Dependency.Graph where
 
 import Data.Array (listArray)
-import Data.Bifunctor (bimap)
 import qualified Data.Graph as G
 import qualified Data.HashMap.Strict as HM
 import qualified Data.List as L
@@ -13,15 +12,10 @@ import Data.Tree (flatten)
 import Data.Tuple (swap)
 import FFICXX.Generate.Dependency
   ( calculateDependency,
-    class_allparents,
     mkTopLevelDep,
   )
 import FFICXX.Generate.Name (subModuleName)
-import FFICXX.Generate.Type.Class
-  ( Class (..),
-    TemplateClass (..),
-    TopLevel (..),
-  )
+import FFICXX.Generate.Type.Class (TopLevel (..))
 import FFICXX.Generate.Type.Module
   ( ClassSubmoduleType (..),
     DepCycles,

--- a/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
@@ -1,0 +1,5 @@
+module FFICXX.Generate.Dependency.Graph where
+
+import Data.Graph ()
+
+

--- a/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
+++ b/fficxx/src/FFICXX/Generate/Dependency/Graph.hs
@@ -45,20 +45,20 @@ constructDepGraph allclasses allTopLevels = (allSyms, depmap')
     mkRawTypeDep :: Class -> (String, [String])
     mkRawTypeDep c =
       let rawtype = subModuleName (Right (CSTRawType, c))
-       in (rawtype, [])
+          deps = fmap subModuleName $ calculateDependency $ Right (CSTRawType, c)
+       in (rawtype, deps)
     -- FFI
     mkFFIDep :: Class -> (String, [String])
     mkFFIDep c =
       let ffi = subModuleName (Right (CSTFFI, c))
-          depRawSelf = subModuleName (Right (CSTRawType, c))
           deps = fmap subModuleName $ calculateDependency $ Right (CSTFFI, c)
-       in (ffi, depRawSelf : deps)
+       in (ffi, deps)
+    -- Interface
     mkInterfaceDep :: Class -> (String, [String])
     mkInterfaceDep c =
       let interface = subModuleName $ Right (CSTInterface, c)
-          depRawSelf = subModuleName $ Right (CSTRawType, c)
           deps = fmap subModuleName $ calculateDependency $ Right (CSTInterface, c)
-       in (interface, depRawSelf : deps)
+       in (interface, deps)
     -- Cast
     mkCastDep :: Class -> (String, [String])
     mkCastDep c =
@@ -66,7 +66,6 @@ constructDepGraph allclasses allTopLevels = (allSyms, depmap')
           deps = fmap subModuleName $ calculateDependency (Right (CSTCast, c))
        in (cast, deps)
     -- Implementation
-    -- TODO: THIS IS INVOLVED! NEED TO REFACTOR THINGS OUT.
     mkImplementationDep :: Class -> (String, [String])
     mkImplementationDep c =
       let implementation = subModuleName $ Right (CSTImplementation, c)

--- a/fficxx/src/FFICXX/Generate/Name.hs
+++ b/fficxx/src/FFICXX/Generate/Name.hs
@@ -21,6 +21,7 @@ import FFICXX.Generate.Type.Class
     Variable (..),
   )
 import FFICXX.Generate.Util (firstLower, toLowers)
+import System.FilePath ((<.>))
 
 data ClassModuleType
   = CMTRawType
@@ -172,3 +173,29 @@ nonvirtualName c str = (firstLower . fst . hsClassName) c <> "_" <> str
 
 destructorName :: String
 destructorName = "delete"
+
+--
+-- Submodule names in ClassModule
+--
+
+subModuleName ::
+  Either
+    (TemplateClassModuleType, TemplateClass)
+    (ClassModuleType, Class) ->
+  String
+subModuleName (Left (typ, tcl)) = "<" ++ highName <.> submod ++ ">"
+  where
+    (highName, _rawName) = hsTemplateClassName tcl
+    submod = case typ of
+      TCMTTH -> "TH"
+      TCMTTemplate -> "Template"
+subModuleName (Right (typ, cls)) = highName <.> submod
+  where
+    (highName, _rawName) = hsClassName cls
+    submod =
+      case typ of
+        CMTRawType -> "RawType"
+        CMTInterface -> "Interface"
+        CMTImplementation -> "Implementation"
+        CMTFFI -> "FFI"
+        CMTCast -> "Cast"

--- a/fficxx/src/FFICXX/Generate/Name.hs
+++ b/fficxx/src/FFICXX/Generate/Name.hs
@@ -21,19 +21,12 @@ import FFICXX.Generate.Type.Class
     TopLevel (..),
     Variable (..),
   )
+import FFICXX.Generate.Type.Module
+  ( ClassSubmoduleType (..),
+    TemplateClassSubmoduleType (..),
+  )
 import FFICXX.Generate.Util (firstLower, toLowers)
 import System.FilePath ((<.>))
-
-data ClassModuleType
-  = CMTRawType
-  | CMTInterface
-  | CMTImplementation
-  | CMTFFI
-  | CMTCast
-
-data TemplateClassModuleType
-  = TCMTTH
-  | TCMTTemplate
 
 hsFrontNameForTopLevel :: TopLevel -> String
 hsFrontNameForTopLevel tfn =
@@ -187,22 +180,22 @@ getTClassModuleBase = (<.>) <$> (cabal_moduleprefix . tclass_cabal) <*> (fst . h
 
 subModuleName ::
   Either
-    (TemplateClassModuleType, TemplateClass)
-    (ClassModuleType, Class) ->
+    (TemplateClassSubmoduleType, TemplateClass)
+    (ClassSubmoduleType, Class) ->
   String
 subModuleName (Left (typ, tcl)) = modBase <.> submod
   where
     modBase = getTClassModuleBase tcl
     submod = case typ of
-      TCMTTH -> "TH"
-      TCMTTemplate -> "Template"
+      TCSTTH -> "TH"
+      TCSTTemplate -> "Template"
 subModuleName (Right (typ, cls)) = modBase <.> submod
   where
     modBase = getClassModuleBase cls
     submod =
       case typ of
-        CMTRawType -> "RawType"
-        CMTInterface -> "Interface"
-        CMTImplementation -> "Implementation"
-        CMTFFI -> "FFI"
-        CMTCast -> "Cast"
+        CSTRawType -> "RawType"
+        CSTInterface -> "Interface"
+        CSTImplementation -> "Implementation"
+        CSTFFI -> "FFI"
+        CSTCast -> "Cast"

--- a/fficxx/src/FFICXX/Generate/Name.hs
+++ b/fficxx/src/FFICXX/Generate/Name.hs
@@ -5,6 +5,7 @@ module FFICXX.Generate.Name where
 
 import Data.Char (toLower)
 import Data.Maybe (fromMaybe)
+import FFICXX.Generate.Type.Cabal (cabal_moduleprefix)
 import FFICXX.Generate.Type.Class
   ( Accessor (..),
     Arg (..),
@@ -175,23 +176,29 @@ destructorName :: String
 destructorName = "delete"
 
 --
--- Submodule names in ClassModule
+-- Module base and Submodule names in ClassModule
 --
+
+getClassModuleBase :: Class -> String
+getClassModuleBase = (<.>) <$> (cabal_moduleprefix . class_cabal) <*> (fst . hsClassName)
+
+getTClassModuleBase :: TemplateClass -> String
+getTClassModuleBase = (<.>) <$> (cabal_moduleprefix . tclass_cabal) <*> (fst . hsTemplateClassName)
 
 subModuleName ::
   Either
     (TemplateClassModuleType, TemplateClass)
     (ClassModuleType, Class) ->
   String
-subModuleName (Left (typ, tcl)) = "<" ++ highName <.> submod ++ ">"
+subModuleName (Left (typ, tcl)) = modBase <.> submod
   where
-    (highName, _rawName) = hsTemplateClassName tcl
+    modBase = getTClassModuleBase tcl
     submod = case typ of
       TCMTTH -> "TH"
       TCMTTemplate -> "Template"
-subModuleName (Right (typ, cls)) = highName <.> submod
+subModuleName (Right (typ, cls)) = modBase <.> submod
   where
-    (highName, _rawName) = hsClassName cls
+    modBase = getClassModuleBase cls
     submod =
       case typ of
         CMTRawType -> "RawType"

--- a/fficxx/src/FFICXX/Generate/Type/Module.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Module.hs
@@ -62,6 +62,11 @@ data ClassModule = ClassModule
     cmImportedSubmodulesForInterface :: [UClassSubmodule],
     -- | imported submodules for FFI.hs
     cmImportedSubmodulesForFFI :: [UClassSubmodule],
+    -- | imported submodules for Cast.hs
+    cmImportedSubmodulesForCast,
+    -- imported submodules for Implementation.hs
+    cmImportedSubmodulesForImplementation ::
+      [UClassSubmodule],
     cmExtraImport :: [String]
   }
   deriving (Show)

--- a/fficxx/src/FFICXX/Generate/Type/Module.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Module.hs
@@ -58,9 +58,10 @@ type DepCycles = [[String]]
 data ClassModule = ClassModule
   { cmModule :: String,
     cmCIH :: ClassImportHeader,
-    -- | imported submodules
-    cmImportedSubmodules :: [UClassSubmodule],
-    cmImportedModulesFFI :: [Either TemplateClass Class],
+    -- | imported submodules for Interface.hs
+    cmImportedSubmodulesForInterface :: [UClassSubmodule],
+    -- | imported submodules for FFI.hs
+    cmImportedSubmodulesForFFI :: [UClassSubmodule],
     cmExtraImport :: [String]
   }
   deriving (Show)

--- a/fficxx/src/FFICXX/Generate/Type/Module.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Module.hs
@@ -5,6 +5,10 @@ import FFICXX.Generate.Type.Cabal (AddCInc, AddCSrc)
 import FFICXX.Generate.Type.Class (Class, TemplateClass, TopLevel)
 import FFICXX.Runtime.CodeGen.Cxx (HeaderName (..), Namespace (..))
 
+--
+-- C++
+--
+
 -- | C++ side
 --   HPkg is generated C++ headers by fficxx, CPkg is original C++ headers
 data ClassImportHeader = ClassImportHeader
@@ -23,9 +27,30 @@ data ClassImportHeader = ClassImportHeader
   }
   deriving (Show)
 
--------------------------
--- Haskell side module --
--------------------------
+--
+-- Haskell side
+--
+
+--
+-- Submodule
+--
+
+data ClassSubmoduleType
+  = CSTRawType
+  | CSTInterface
+  | CSTImplementation
+  | CSTFFI
+  | CSTCast
+
+data TemplateClassSubmoduleType
+  = TCSTTH
+  | TCSTTemplate
+
+-- | UClass = Unified Class, either template class or ordinary class
+type UClass = Either TemplateClass Class
+
+-- | Dependency cycle information. Currently just a string
+type DepCycles = [[String]]
 
 data ClassModule = ClassModule
   { cmModule :: String,

--- a/fficxx/src/FFICXX/Generate/Type/Module.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Module.hs
@@ -6,10 +6,8 @@ import FFICXX.Generate.Type.Class (Class, TemplateClass, TopLevel)
 import FFICXX.Runtime.CodeGen.Cxx (HeaderName (..), Namespace (..))
 
 --
--- C++
+-- Import/Header
 --
-
--- | C++ side
 --   HPkg is generated C++ headers by fficxx, CPkg is original C++ headers
 data ClassImportHeader = ClassImportHeader
   { cihClass :: Class,
@@ -26,10 +24,6 @@ data ClassImportHeader = ClassImportHeader
     cihIncludedCPkgHeaders :: [HeaderName]
   }
   deriving (Show)
-
---
--- Haskell side
---
 
 --
 -- Submodule
@@ -49,8 +43,15 @@ data TemplateClassSubmoduleType
 -- | UClass = Unified Class, either template class or ordinary class
 type UClass = Either TemplateClass Class
 
+type UClassSubmodule =
+  Either (TemplateClassSubmoduleType, TemplateClass) (ClassSubmoduleType, Class)
+
 -- | Dependency cycle information. Currently just a string
 type DepCycles = [[String]]
+
+--
+-- Module
+--
 
 data ClassModule = ClassModule
   { cmModule :: String,
@@ -91,6 +92,10 @@ data TopLevelImportHeader = TopLevelImportHeader
     tihExtraHeadersInCPP :: [HeaderName]
   }
   deriving (Show)
+
+--
+-- Package-level
+--
 
 data PackageConfig = PkgConfig
   { pcfg_classModules :: [ClassModule],

--- a/fficxx/src/FFICXX/Generate/Type/Module.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Module.hs
@@ -49,7 +49,8 @@ type UClassSubmodule =
   Either (TemplateClassSubmoduleType, TemplateClass) (ClassSubmoduleType, Class)
 
 -- | Dependency cycle information. Currently just a string
-type DepCycles = [[String]]
+--                  self,    former,   latter
+type DepCycles = [[(String, ([String], [String]))]]
 
 --
 -- Module

--- a/fficxx/src/FFICXX/Generate/Type/Module.hs
+++ b/fficxx/src/FFICXX/Generate/Type/Module.hs
@@ -35,10 +35,12 @@ data ClassSubmoduleType
   | CSTImplementation
   | CSTFFI
   | CSTCast
+  deriving (Show)
 
 data TemplateClassSubmoduleType
   = TCSTTH
   | TCSTTemplate
+  deriving (Show)
 
 -- | UClass = Unified Class, either template class or ordinary class
 type UClass = Either TemplateClass Class
@@ -56,12 +58,8 @@ type DepCycles = [[String]]
 data ClassModule = ClassModule
   { cmModule :: String,
     cmCIH :: ClassImportHeader,
-    -- | imported modules external to the current package unit.
-    cmImportedModulesExternal :: [Either TemplateClass Class],
-    -- | imported modules for raw types.
-    cmImportedModulesRaw :: [Either TemplateClass Class],
-    -- | imported modules in the current package-in-place
-    cmImportedModulesInplace :: [Either TemplateClass Class],
+    -- | imported submodules
+    cmImportedSubmodules :: [UClassSubmodule],
     cmImportedModulesFFI :: [Either TemplateClass Class],
     cmExtraImport :: [String]
   }

--- a/fficxx/src/FFICXX/Generate/Util/DepGraph.hs
+++ b/fficxx/src/FFICXX/Generate/Util/DepGraph.hs
@@ -8,14 +8,6 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.List as L
 import Data.Maybe (mapMaybe)
 import Data.Tuple (swap)
-import FFICXX.Generate.Dependency
-  ( class_allparents,
-    mkModuleDepExternal,
-    mkModuleDepFFI,
-    mkModuleDepInplace,
-    mkModuleDepRaw,
-    mkTopLevelDep,
-  )
 import FFICXX.Generate.Dependency.Graph
   ( constructDepGraph,
   )

--- a/fficxx/src/FFICXX/Generate/Util/DepGraph.hs
+++ b/fficxx/src/FFICXX/Generate/Util/DepGraph.hs
@@ -17,13 +17,10 @@ import FFICXX.Generate.Dependency
     mkTopLevelDep,
   )
 import FFICXX.Generate.Dependency.Graph
-  ( UClass,
-    constructDepGraph,
+  ( constructDepGraph,
   )
 import FFICXX.Generate.Name
-  ( ClassModuleType (..),
-    TemplateClassModuleType (..),
-    hsClassName,
+  ( hsClassName,
     hsTemplateClassName,
     subModuleName,
   )
@@ -31,6 +28,11 @@ import FFICXX.Generate.Type.Class
   ( Class (..),
     TemplateClass (..),
     TopLevel (..),
+  )
+import FFICXX.Generate.Type.Module
+  ( ClassSubmoduleType (..),
+    TemplateClassSubmoduleType (..),
+    UClass,
   )
 import System.FilePath ((<.>))
 import System.IO (IOMode (..), hPutStrLn, withFile)

--- a/fficxx/src/FFICXX/Generate/Util/DepGraph.hs
+++ b/fficxx/src/FFICXX/Generate/Util/DepGraph.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TupleSections #-}
-
 module FFICXX.Generate.Util.DepGraph
   ( drawDepGraph,
   )
@@ -18,6 +15,10 @@ import FFICXX.Generate.Dependency
     mkModuleDepInplace,
     mkModuleDepRaw,
     mkTopLevelDep,
+  )
+import FFICXX.Generate.Dependency.Graph
+  ( UClass,
+    constructDepGraph,
   )
 import FFICXX.Generate.Name
   ( ClassModuleType (..),
@@ -40,11 +41,6 @@ src label = node $ [("shape", "none"), ("label", label)]
 box label = node $ [("shape", "box"), ("style", "rounded"), ("label", label)]
 diamond label = node $ [("shape", "diamond"), ("label", label), ("fontsize", "10")]
 
--- TODO: Should be used everywhere.
-
--- | UClass = Unified Class, either template class or ordinary class
-type UClass = Either TemplateClass Class
-
 -- | Draw dependency graph of modules in graphviz dot format.
 drawDepGraph ::
   -- | list of all classes, either template class or ordinary class.
@@ -62,123 +58,4 @@ drawDepGraph allclasses allTopLevels =
       for_ js $ \j ->
         (cs !! i) .->. (cs !! j)
   where
-    -- RawType dependency is trivial
-    mkRawTypeDep :: Class -> (String, [String])
-    mkRawTypeDep c =
-      let rawtype = subModuleName (Right (CMTRawType, c))
-       in (rawtype, [])
-    -- FFI
-    mkFFIDep :: Class -> (String, [String])
-    mkFFIDep c =
-      let ffi = subModuleName (Right (CMTFFI, c))
-          depRawSelf = subModuleName (Right (CMTRawType, c))
-          depsFFI =
-            let ds = mkModuleDepFFI (Right c)
-                format' (Left tcl) = subModuleName $ Left (TCMTTemplate, tcl)
-                format' (Right cls) = subModuleName $ Right (CMTRawType, cls)
-             in fmap format' ds
-       in (ffi, [depRawSelf] ++ depsFFI)
-    mkInterfaceDep :: Class -> (String, [String])
-    mkInterfaceDep c =
-      let interface = subModuleName $ Right (CMTInterface, c)
-          depRawSelf = subModuleName $ Right (CMTRawType, c)
-          depsRaw =
-            let ds = mkModuleDepRaw (Right c)
-                format' (Left tcl) = subModuleName $ Left (TCMTTemplate, tcl)
-                format' (Right cls) = subModuleName $ Right (CMTRawType, cls)
-             in fmap format' ds
-          depsExt =
-            let ds = mkModuleDepExternal (Right c)
-                format' (Left tcl) = subModuleName $ Left (TCMTTemplate, tcl)
-                format' (Right cls) = subModuleName $ Right (CMTInterface, cls)
-             in fmap format' ds
-          depsInplace =
-            let ds = mkModuleDepInplace (Right c)
-                format' (Left tcl) = subModuleName $ Left (TCMTTemplate, tcl)
-                format' (Right cls) = subModuleName $ Right (CMTInterface, cls)
-             in fmap format' ds
-       in (interface, [depRawSelf] ++ depsRaw ++ depsExt ++ depsInplace)
-    -- Cast
-    mkCastDep :: Class -> (String, [String])
-    mkCastDep c =
-      let cast = subModuleName $ Right (CMTCast, c)
-          depsSelf = fmap (subModuleName . Right . (,c)) [CMTRawType, CMTInterface]
-       in (cast, depsSelf)
-    -- Implementation
-    -- TODO: THIS IS INVOLVED! NEED TO REFACTOR THINGS OUT.
-    mkImplementationDep :: Class -> (String, [String])
-    mkImplementationDep c =
-      let implementation = subModuleName $ Right (CMTImplementation, c)
-          depsSelf =
-            fmap (subModuleName . Right . (,c)) [CMTRawType, CMTFFI, CMTInterface, CMTCast]
-          deps =
-            let dsFFI = mkModuleDepFFI (Right c)
-                dsParents = L.nub $ map Right $ class_allparents c
-                dsNonParents = filter (not . (flip elem dsParents)) dsFFI
-                format (Left tcl) = [subModuleName $ Left (TCMTTemplate, tcl)]
-                format (Right cls) =
-                  fmap (subModuleName . Right . (,cls)) [CMTRawType, CMTCast, CMTInterface]
-             in concatMap format (dsNonParents ++ dsParents)
-       in (implementation, depsSelf ++ deps)
-    -- Template Class part
-    -- <TClass>.Template
-    mkTemplateDep :: TemplateClass -> (String, [String])
-    mkTemplateDep t =
-      let template = subModuleName $ Left (TCMTTemplate, t)
-          depsRaw =
-            let ds = mkModuleDepRaw (Left t)
-                format' (Left tcl) = subModuleName $ Left (TCMTTemplate, tcl)
-                format' (Right cls) = subModuleName $ Right (CMTRawType, cls)
-             in fmap format' ds
-          depsInplace =
-            let ds = mkModuleDepInplace (Left t)
-                format' (Left tcl) = subModuleName $ Left (TCMTTemplate, tcl)
-                format' (Right cls) = subModuleName $ Right (CMTInterface, cls)
-             in fmap format' ds
-       in (template, depsRaw ++ depsInplace)
-    -- <TClass>.TH
-    mkTHDep :: TemplateClass -> (String, [String])
-    mkTHDep t =
-      let th = subModuleName $ Left (TCMTTH, t)
-          deps =
-            let dsRaw = mkModuleDepRaw (Left t)
-                dsInplace = mkModuleDepInplace (Left t)
-
-                format' (Left tcl) = [subModuleName $ Left (TCMTTemplate, tcl)]
-                format' (Right cls) =
-                  fmap (subModuleName . Right . (,cls)) [CMTRawType, CMTCast, CMTInterface]
-             in concatMap format' (dsRaw ++ dsInplace)
-       in (th, deps)
-    -- TopLevel
-    topLevelDeps :: (String, [String])
-    topLevelDeps =
-      let deps =
-            L.nub . L.sort $ concatMap (fmap subModuleName . mkTopLevelDep) allTopLevels
-       in ("[TopLevel]", deps)
-
-    depmapAllClasses =
-      concatMap
-        ( \case
-            Left tcl -> [mkTemplateDep tcl]
-            Right cls ->
-              [ mkRawTypeDep cls,
-                mkFFIDep cls,
-                mkInterfaceDep cls,
-                mkCastDep cls,
-                mkImplementationDep cls
-              ]
-        )
-        allclasses
-    depmap = topLevelDeps : depmapAllClasses
-    allSyms =
-      L.nub . L.sort $
-        fmap fst depmap ++ concatMap snd depmap
-    allISyms :: [(Int, String)]
-    allISyms = zip [0 ..] allSyms
-    symMap = HM.fromList allISyms
-    symRevMap = HM.fromList $ fmap swap allISyms
-    replace (c, ds) = do
-      i <- HM.lookup c symRevMap
-      js <- traverse (\d -> HM.lookup d symRevMap) ds
-      pure (i, js)
-    depmap' = mapMaybe replace depmap
+    (allSyms, depmap') = constructDepGraph allclasses allTopLevels

--- a/fficxx/src/FFICXX/Generate/Util/DepGraph.hs
+++ b/fficxx/src/FFICXX/Generate/Util/DepGraph.hs
@@ -4,30 +4,11 @@ module FFICXX.Generate.Util.DepGraph
 where
 
 import Data.Foldable (for_)
-import qualified Data.HashMap.Strict as HM
-import qualified Data.List as L
-import Data.Maybe (mapMaybe)
-import Data.Tuple (swap)
 import FFICXX.Generate.Dependency.Graph
   ( constructDepGraph,
   )
-import FFICXX.Generate.Name
-  ( hsClassName,
-    hsTemplateClassName,
-    subModuleName,
-  )
-import FFICXX.Generate.Type.Class
-  ( Class (..),
-    TemplateClass (..),
-    TopLevel (..),
-  )
-import FFICXX.Generate.Type.Module
-  ( ClassSubmoduleType (..),
-    TemplateClassSubmoduleType (..),
-    UClass,
-  )
-import System.FilePath ((<.>))
-import System.IO (IOMode (..), hPutStrLn, withFile)
+import FFICXX.Generate.Type.Class (TopLevel (..))
+import FFICXX.Generate.Type.Module (UClass)
 import Text.Dot (Dot, NodeId, attribute, node, showDot, (.->.))
 
 src, box, diamond :: String -> Dot NodeId


### PR DESCRIPTION
Submodules (RawType, FFI, Interface, Cast, Implementation for class, Template, TH for template class) had been explicitly defined in the last commit and their dependencies are more precisely computed for producing dependency graph. 
Now the codegen system uses the dep graph information for import modules and detect cyclic dependencies by strongly connected components  from the graph. The cycles are made broken by restricted dependency analysis and proper hs-boot generation (relatively correct compared with previous naive implementation)
Now stdcxx, OGDF, HROOT and hgdal are buildable again.