### PR TITLE
Start migrating to direct GHC API use and ghc-exactprint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         nix build --print-build-logs .#ghc962.fficxx-runtime
     - name: build fficxx (GHC 9.6.2)
       run: |
-        nix build --print-build-logs .#ghc945.fficxx
+        nix build --print-build-logs .#ghc962.fficxx
     - name: build stdcxx (GHC 9.6.2)
       run: |
         nix build --print-build-logs .#ghc962.stdcxx

--- a/examples/proxy/Gen.hs
+++ b/examples/proxy/Gen.hs
@@ -45,7 +45,8 @@ import FFICXX.Generate.Type.Class
     Class (..),
     Function (..),
     ProtectedMethod (..),
-    TopLevelFunction (..),
+    TLOrdinary (..),
+    TopLevel (..),
     Variable (..),
   )
 import FFICXX.Generate.Type.Config
@@ -69,7 +70,7 @@ stdcxx_cabal :: Cabal
 stdcxx_cabal =
   Cabal
     { cabal_pkgname = CabalName "stdcxx",
-      cabal_version = "0.7.0.1",
+      cabal_version = "0.8",
       cabal_cheaderprefix = "STD",
       cabal_moduleprefix = "STD",
       cabal_additional_c_incs = [],
@@ -97,54 +98,6 @@ deletable =
       class_vars = [],
       class_tmpl_funcs = []
     }
-
--- import from stdcxx
-string :: Class
-string =
-  Class
-    stdcxx_cabal
-    "string"
-    [deletable]
-    mempty
-    (Just (ClassAlias {caHaskellName = "CppString", caFFIName = "string"}))
-    [ Constructor [cstring "p"] Nothing,
-      NonVirtual cstring_ "c_str" [] Nothing,
-      NonVirtual (cppclassref_ string) "append" [cppclassref string "str"] Nothing,
-      NonVirtual (cppclassref_ string) "erase" [] Nothing
-    ]
-    []
-    []
-    False
-
-t_vector :: TemplateClass
-t_vector =
-  TmplCls
-    stdcxx_cabal
-    "Vector"
-    "std::vector"
-    ["tp1"]
-    [ TFunNew [] Nothing,
-      TFun void_ "push_back" "push_back" [Arg (TemplateParam "tp1") "x"] Nothing,
-      TFun void_ "pop_back" "pop_back" [] Nothing,
-      TFun (TemplateParam "tp1") "at" "at" [int "n"] Nothing,
-      TFun int_ "size" "size" [] Nothing,
-      TFunDelete
-    ]
-
-t_unique_ptr :: TemplateClass
-t_unique_ptr =
-  TmplCls
-    stdcxx_cabal
-    "UniquePtr"
-    "std::unique_ptr"
-    ["tp1"]
-    [ TFunNew [] (Just "newUniquePtr0"),
-      TFunNew [Arg (TemplateParamPointer "tp1") "p"] Nothing,
-      TFun (TemplateParamPointer "tp1") "get" "get" [] Nothing,
-      TFun (TemplateParamPointer "tp1") "release" "release" [] Nothing,
-      TFun void_ "reset" "reset" [] Nothing,
-      TFunDelete
-    ]
 
 -- -------------------------------------------------------------------
 -- proxy-test
@@ -218,7 +171,7 @@ main = do
   let tmpldir =
         if length args == 1
           then args !! 0
-          else "../template"
+          else "./template"
 
   cwd <- getCurrentDirectory
 

--- a/examples/proxy/cabal.project
+++ b/examples/proxy/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  ../../fficxx/
+  ../../fficxx-runtime/
+optional-packages:
+  ./stdcxx/
+  ./proxy-test/

--- a/experiments/ghc-exactprint.hs
+++ b/experiments/ghc-exactprint.hs
@@ -1,0 +1,14 @@
+module Main where
+
+import Language.Haskell.GHC.ExactPrint
+  ( makeDeltaAst,
+    parseModule,
+    showAst,
+  )
+
+main :: IO ()
+main = do
+  e <- parseModule "/nix/store/1dccaqdx3v2acc4zk5cnln14jf5q7h04-ghc-9.6.2-with-packages/lib/ghc-9.6.2/lib" "./sample.hs"
+  case e of
+    Left msg -> print "error" -- print msg
+    Right parsed -> putStrLn (showAst (makeDeltaAst parsed))

--- a/experiments/sample.hs
+++ b/experiments/sample.hs
@@ -1,0 +1,1 @@
+module MyModule where

--- a/experiments/sample.hs
+++ b/experiments/sample.hs
@@ -6,4 +6,4 @@ module MyModule where
 
 test :: IO ()
 test = do
-  pure ()
+  pure ( )

--- a/experiments/sample.hs
+++ b/experiments/sample.hs
@@ -3,7 +3,9 @@
 
 module MyModule where
 
+data K = K Int
 
 test :: IO ()
 test = do
-  pure ( )
+  addModFinalizer (addForeignSource LangCxx "\n#include \"test\"")
+

--- a/experiments/sample.hs
+++ b/experiments/sample.hs
@@ -1,1 +1,4 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# OPTIONS_GHC -w #-}
+
 module MyModule where

--- a/experiments/sample.hs
+++ b/experiments/sample.hs
@@ -2,3 +2,6 @@
 {-# OPTIONS_GHC -w #-}
 
 module MyModule where
+
+
+test :: Double

--- a/experiments/sample.hs
+++ b/experiments/sample.hs
@@ -4,4 +4,6 @@
 module MyModule where
 
 
-test :: Double
+test :: IO ()
+test = do
+  pure ()

--- a/experiments/sample.hs
+++ b/experiments/sample.hs
@@ -8,4 +8,3 @@ data K = K Int
 test :: IO ()
 test = do
   addModFinalizer (addForeignSource LangCxx "\n#include \"test\"")
-

--- a/fficxx/LICENSE
+++ b/fficxx/LICENSE
@@ -1,7 +1,7 @@
 The following license covers this documentation, and the source code, except
 where otherwise indicated.
 
-Copyright 2011-2022, Ian-Woo Kim. All rights reserved.
+Copyright 2011-2023, Ian-Woo Kim. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/fficxx/fficxx.cabal
+++ b/fficxx/fficxx.cabal
@@ -1,4 +1,4 @@
-Cabal-Version:  3.0
+Cabal-Version:  3.6
 Name:           fficxx
 Version:        0.8.0.0
 Synopsis:       Automatic C++ binding generation
@@ -31,7 +31,6 @@ Library
                , fficxx-runtime
                , filepath>1
                , hashable
-               , haskell-src-exts >= 1.22
                , lens > 3
                , mtl>2
                , process
@@ -42,6 +41,14 @@ Library
                , template-haskell
                , text
                , unordered-containers
+               , haskell-src-exts
+  if impl (ghc >= 9.6)
+    Build-Depends:
+      ghc-exactprint >= 1.7.0.0
+  else
+    Build-Depends:
+      ghc-exactprint
+
   Exposed-Modules:
                FFICXX.Generate.Builder
                FFICXX.Generate.Config

--- a/fficxx/fficxx.cabal
+++ b/fficxx/fficxx.cabal
@@ -44,9 +44,11 @@ Library
                , haskell-src-exts
   if impl (ghc >= 9.6)
     Build-Depends:
+      ghc >= 9.6,
       ghc-exactprint >= 1.7.0.0
   else
     Build-Depends:
+      ghc,
       ghc-exactprint
 
   Exposed-Modules:
@@ -67,6 +69,7 @@ Library
                FFICXX.Generate.QQ.Verbatim
                FFICXX.Generate.Util
                FFICXX.Generate.Util.DepGraph
+               FFICXX.Generate.Util.GHCExactPrint
                FFICXX.Generate.Util.HaskellSrcExts
                FFICXX.Generate.Type.Annotate
                FFICXX.Generate.Type.Cabal

--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -168,7 +168,9 @@ simpleBuilder cfg sbc = do
     when (hasProxy . cihClass . cmCIH $ m) $ do
       let x = C.buildProxyHs m
       putStrLn (Exact.showAst x)
-      print (exactPrint (C.buildProxyHs m))
+      putStrLn "-------"
+      putStrLn (exactPrint (C.buildProxyHs m))
+      putStrLn "-------"
       gen (cmModule m <.> "Proxy" <.> "hs") (exactPrint (C.buildProxyHs m))
   --
   putStrLn "Generating Template.hs"

--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -40,8 +40,8 @@ import FFICXX.Generate.Type.Module
     TopLevelImportHeader (..),
   )
 import FFICXX.Generate.Util (moduleDirFile)
+import FFICXX.Generate.Util.HaskellSrcExts (prettyPrint)
 import FFICXX.Runtime.CodeGen.Cxx (HeaderName (..))
-import Language.Haskell.Exts.Pretty (prettyPrint)
 import System.Directory
   ( copyFile,
     createDirectoryIfMissing,

--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -40,8 +40,10 @@ import FFICXX.Generate.Type.Module
     TopLevelImportHeader (..),
   )
 import FFICXX.Generate.Util (moduleDirFile)
+import FFICXX.Generate.Util.GHCExactPrint (exactPrint)
 import FFICXX.Generate.Util.HaskellSrcExts (prettyPrint)
 import FFICXX.Runtime.CodeGen.Cxx (HeaderName (..))
+import qualified Language.Haskell.GHC.ExactPrint as Exact
 import System.Directory
   ( copyFile,
     createDirectoryIfMissing,
@@ -163,8 +165,11 @@ simpleBuilder cfg sbc = do
   --
   putStrLn "Generating Proxy.hs"
   for_ mods $ \m ->
-    when (hasProxy . cihClass . cmCIH $ m) $
-      gen (cmModule m <.> "Proxy" <.> "hs") (prettyPrint (C.buildProxyHs m))
+    when (hasProxy . cihClass . cmCIH $ m) $ do
+      let x = C.buildProxyHs m
+      putStrLn (Exact.showAst x)
+      print (exactPrint (C.buildProxyHs m))
+      gen (cmModule m <.> "Proxy" <.> "hs") (exactPrint (C.buildProxyHs m))
   --
   putStrLn "Generating Template.hs"
   for_ tcms $ \m ->

--- a/fficxx/src/FFICXX/Generate/Code/HsCast.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsCast.hs
@@ -4,7 +4,8 @@ module FFICXX.Generate.Code.HsCast where
 import FFICXX.Generate.Name (hsClassName, typeclassName)
 import FFICXX.Generate.Type.Class (Class (..), isAbstractClass)
 import FFICXX.Generate.Util.HaskellSrcExts
-  ( classA,
+  ( app,
+    classA,
     cxEmpty,
     cxTuple,
     insDecl,
@@ -18,8 +19,7 @@ import FFICXX.Generate.Util.HaskellSrcExts
     tycon,
     unqual,
   )
-import Language.Haskell.Exts.Build (app)
-import Language.Haskell.Exts.Syntax (Decl (..), InstDecl (..))
+import Language.Haskell.Exts.Syntax (Decl, InstDecl)
 
 -----
 

--- a/fficxx/src/FFICXX/Generate/Code/HsFFI.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsFFI.hs
@@ -42,7 +42,7 @@ import FFICXX.Generate.Type.Module
 import FFICXX.Generate.Util (toLowers)
 import FFICXX.Generate.Util.HaskellSrcExts (mkForImpCcall, mkImport)
 import FFICXX.Runtime.CodeGen.Cxx (HeaderName (..))
-import Language.Haskell.Exts.Syntax (Decl (..), ImportDecl (..))
+import Language.Haskell.Exts.Syntax (Decl, ImportDecl)
 import System.FilePath ((<.>))
 
 genHsFFI :: ClassImportHeader -> [Decl ()]

--- a/fficxx/src/FFICXX/Generate/Code/HsFrontEnd.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsFrontEnd.hs
@@ -105,10 +105,9 @@ import FFICXX.Generate.Util.HaskellSrcExts
   )
 import Language.Haskell.Exts.Build (app, letE, name, pApp)
 import Language.Haskell.Exts.Syntax
-  ( Context (CxTuple),
-    Decl (..),
-    ExportSpec (..),
-    ImportDecl (..),
+  ( Decl,
+    ExportSpec,
+    ImportDecl,
   )
 import System.FilePath ((<.>))
 
@@ -120,7 +119,7 @@ genHsFrontDecl isHsBoot c = do
   -- let cann = maybe "" id $ M.lookup (PkgClass,class_name c) amap
   let cdecl = mkClass (classConstraints c) (typeclassName c) [mkTBind "a"] body
       -- for hs-boot, we only have instance head.
-      cdecl' = mkClass (CxTuple () []) (typeclassName c) [mkTBind "a"] []
+      cdecl' = mkClass (cxTuple []) (typeclassName c) [mkTBind "a"] []
       sigdecl f = mkFunSig (hsFuncName c f) (functionSignature c f)
       body = map (clsDecl . sigdecl) . virtualFuncs . class_funcs $ c
   if isHsBoot

--- a/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
@@ -5,22 +5,18 @@ module FFICXX.Generate.Code.HsProxy where
 import qualified Data.List as L (foldr1)
 --
 
-{-
-import FFICXX.Generate.Util.HaskellSrcExts
-  ( con,
-    inapp,
-    op,
-    qualifier,
-    strE,
-  )
--}
 import FFICXX.Generate.Util.GHCExactPrint
   ( app,
+    con,
     doE,
+    inapp,
     listE,
     mkBodyStmt,
     mkFun,
     mkVar,
+    op,
+    par,
+    strE,
     tyapp,
     tycon,
     tylist,
@@ -36,25 +32,25 @@ genProxyInstance = mkFun fname sig [] rhs Nothing
   where
     fname = "genImplProxy"
     sig = tycon "Q" `tyapp` tylist (tycon "Dec")
-    rhs = doE [retstmt] -- [foreignSrcStmt, qualStmt retstmt]
+    rhs = doE [foreignSrcStmt, retstmt]
 
     v = mkVar
     retstmt = mkBodyStmt (v "pure" `app` listE [])
 
-{-  foreignSrcStmt =
-      qualifier $
+    foreignSrcStmt =
+      mkBodyStmt $
         (v "addModFinalizer")
-          `app` ( v "addForeignSource"
-                    `app` con "LangCxx"
-                    `app` ( L.foldr1
-                              (\x y -> inapp x (op "++") y)
-                              [includeStatic]
-                          )
-                )
+          `app` par
+            ( v "addForeignSource"
+                `app` con "LangCxx"
+                `app` ( L.foldr1
+                          (\x y -> inapp x (op "++") y)
+                          [includeStatic]
+                      )
+            )
       where
         includeStatic =
           strE $
             concatMap
               (<> "\n")
               [R.renderCMacro (R.Include "MacroPatternMatch.h")]
--}

--- a/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
@@ -3,8 +3,6 @@
 module FFICXX.Generate.Code.HsProxy where
 
 import qualified Data.List as L (foldr1)
---
-
 import FFICXX.Generate.Util.GHCExactPrint
   ( app,
     con,
@@ -43,10 +41,11 @@ genProxyInstance = mkFun fname sig [] rhs Nothing
           `app` par
             ( v "addForeignSource"
                 `app` con "LangCxx"
-                `app` ( L.foldr1
-                          (\x y -> inapp x (op "++") y)
-                          [includeStatic]
-                      )
+                `app` par
+                  ( L.foldr1
+                      (\x y -> inapp x (op "++") y)
+                      [includeStatic]
+                  )
             )
       where
         includeStatic =

--- a/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
@@ -6,18 +6,22 @@ import qualified Data.List as L (foldr1)
 --
 
 import FFICXX.Generate.Util.HaskellSrcExts
-  ( con,
+  ( app,
+    con,
+    doE,
     inapp,
+    listE,
     mkFun,
     mkVar,
     op,
+    qualStmt,
     qualifier,
+    strE,
     tyapp,
     tycon,
     tylist,
   )
 import qualified FFICXX.Runtime.CodeGen.Cxx as R
-import Language.Haskell.Exts.Build (app, doE, listE, qualStmt, strE)
 import Language.Haskell.Exts.Syntax (Decl)
 
 genProxyInstance :: [Decl ()]

--- a/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
@@ -5,6 +5,7 @@ module FFICXX.Generate.Code.HsProxy where
 import qualified Data.List as L (foldr1)
 --
 
+{-
 import FFICXX.Generate.Util.HaskellSrcExts
   ( app,
     con,
@@ -21,14 +22,23 @@ import FFICXX.Generate.Util.HaskellSrcExts
     tycon,
     tylist,
   )
+-}
+import FFICXX.Generate.Util.GHCExactPrint
+  ( mkFun,
+    testTyp,
+  )
 import qualified FFICXX.Runtime.CodeGen.Cxx as R
-import Language.Haskell.Exts.Syntax (Decl)
+import GHC.Hs.Extension
+  ( GhcPs,
+  )
+import Language.Haskell.Syntax.Decls (HsDecl)
 
-genProxyInstance :: [Decl ()]
-genProxyInstance =
-  mkFun fname sig [] rhs Nothing
+genProxyInstance :: [HsDecl GhcPs]
+genProxyInstance = mkFun fname testTyp
   where
     fname = "genImplProxy"
+
+{-  mkFun fname sig [] rhs Nothing
     v = mkVar
     sig = tycon "Q" `tyapp` tylist (tycon "Dec")
     rhs = doE [foreignSrcStmt, qualStmt retstmt]
@@ -49,3 +59,4 @@ genProxyInstance =
               (<> "\n")
               [R.renderCMacro (R.Include "MacroPatternMatch.h")]
     retstmt = v "pure" `app` listE []
+-}

--- a/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
@@ -10,7 +10,6 @@ import FFICXX.Generate.Util.HaskellSrcExts
   ( con,
     inapp,
     op,
-    qualStmt,
     qualifier,
     strE,
   )

--- a/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
@@ -18,7 +18,7 @@ import FFICXX.Generate.Util.HaskellSrcExts
   )
 import qualified FFICXX.Runtime.CodeGen.Cxx as R
 import Language.Haskell.Exts.Build (app, doE, listE, qualStmt, strE)
-import Language.Haskell.Exts.Syntax (Decl (..))
+import Language.Haskell.Exts.Syntax (Decl)
 
 genProxyInstance :: [Decl ()]
 genProxyInstance =

--- a/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsProxy.hs
@@ -7,25 +7,24 @@ import qualified Data.List as L (foldr1)
 
 {-
 import FFICXX.Generate.Util.HaskellSrcExts
-  ( app,
-    con,
-    doE,
+  ( con,
     inapp,
-    listE,
-    mkFun,
-    mkVar,
     op,
     qualStmt,
     qualifier,
     strE,
-    tyapp,
-    tycon,
-    tylist,
   )
 -}
 import FFICXX.Generate.Util.GHCExactPrint
-  ( mkFun,
-    testTyp,
+  ( app,
+    doE,
+    listE,
+    mkBodyStmt,
+    mkFun,
+    mkVar,
+    tyapp,
+    tycon,
+    tylist,
   )
 import qualified FFICXX.Runtime.CodeGen.Cxx as R
 import GHC.Hs.Extension
@@ -34,15 +33,16 @@ import GHC.Hs.Extension
 import Language.Haskell.Syntax.Decls (HsDecl)
 
 genProxyInstance :: [HsDecl GhcPs]
-genProxyInstance = mkFun fname testTyp
+genProxyInstance = mkFun fname sig [] rhs Nothing
   where
     fname = "genImplProxy"
-
-{-  mkFun fname sig [] rhs Nothing
-    v = mkVar
     sig = tycon "Q" `tyapp` tylist (tycon "Dec")
-    rhs = doE [foreignSrcStmt, qualStmt retstmt]
-    foreignSrcStmt =
+    rhs = doE [retstmt] -- [foreignSrcStmt, qualStmt retstmt]
+
+    v = mkVar
+    retstmt = mkBodyStmt (v "pure" `app` listE [])
+
+{-  foreignSrcStmt =
       qualifier $
         (v "addModFinalizer")
           `app` ( v "addForeignSource"
@@ -58,5 +58,4 @@ genProxyInstance = mkFun fname testTyp
             concatMap
               (<> "\n")
               [R.renderCMacro (R.Include "MacroPatternMatch.h")]
-    retstmt = v "pure" `app` listE []
 -}

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -79,6 +79,7 @@ import FFICXX.Generate.Util.HaskellSrcExts
     qualifier,
     tyPtr,
     tySplice,
+    tyTupleBoxed,
     tyapp,
     tycon,
     tyfun,
@@ -106,7 +107,10 @@ import Language.Haskell.Exts.Build
     tuple,
     wildcard,
   )
-import Language.Haskell.Exts.Syntax (Boxed (Boxed), Decl (..), ImportDecl (..), Type (TyTuple))
+import Language.Haskell.Exts.Syntax
+  ( Decl,
+    ImportDecl,
+  )
 
 ------------------------------
 -- Template member function --
@@ -127,7 +131,7 @@ genTMFExp c f = mkFun nh sig (tvars_p ++ [p "suffix"]) rhs (Just bstmts)
     itps = zip ([1 ..] :: [Int]) (tmf_params f)
     tvars = map (\(i, _) -> "typ" ++ show i) itps
     nparams = length itps
-    tparams = if nparams == 1 then tycon "Type" else TyTuple () Boxed (replicate nparams (tycon "Type"))
+    tparams = if nparams == 1 then tycon "Type" else tyTupleBoxed (replicate nparams (tycon "Type"))
     sig = foldr1 tyfun [tparams, tycon "String", tyapp (tycon "Q") (tycon "Exp")]
     tvars_p = if nparams == 1 then map p tvars else [pTuple (map p tvars)]
     lit' = strE (hsTemplateMemberFunctionName c f <> "_")
@@ -165,7 +169,7 @@ genTMFInstance cih f =
     v = mkVar
     sig =
       tycon "IsCPrimitive"
-        `tyfun` TyTuple () Boxed [tycon "Q" `tyapp` tycon "Type", tycon "TemplateParamInfo"]
+        `tyfun` tyTupleBoxed [tycon "Q" `tyapp` tycon "Type", tycon "TemplateParamInfo"]
         `tyfun` (tycon "Q" `tyapp` tylist (tycon "Dec"))
     rhs = doE [suffixstmt, qtypstmt, genstmt, foreignSrcStmt, letStmt lststmt, qualStmt retstmt]
     suffixstmt = letStmt [pbind_ (p "suffix") (v "tpinfoSuffix" `app` v "param")]
@@ -278,7 +282,7 @@ genTmplImplementation t =
     itps = zip ([1 ..] :: [Int]) (tclass_params t)
     tvars = map (\(i, _) -> "typ" ++ show i) itps
     nparams = length itps
-    tparams = if nparams == 1 then tycon "Type" else TyTuple () Boxed (replicate nparams (tycon "Type"))
+    tparams = if nparams == 1 then tycon "Type" else tyTupleBoxed (replicate nparams (tycon "Type"))
     sig = foldr1 tyfun [tparams, tycon "String", tyapp (tycon "Q") (tycon "Exp")]
     tvars_p = if nparams == 1 then map p tvars else [pTuple (map p tvars)]
     prefix = tclass_name t
@@ -340,7 +344,7 @@ genTmplInstance tcih =
         [tycon "IsCPrimitive"]
           ++ replicate
             nparams
-            (TyTuple () Boxed [tycon "Q" `tyapp` tycon "Type", tycon "TemplateParamInfo"])
+            (tyTupleBoxed [tycon "Q" `tyapp` tycon "Type", tycon "TemplateParamInfo"])
           ++ [tycon "Q" `tyapp` tylist (tycon "Dec")]
     nfs = zip ([1 ..] :: [Int]) fs
     nvfs = zip ([1 ..] :: [Int]) vfs
@@ -519,7 +523,7 @@ genTLTemplateImplementation t =
     itps = zip ([1 ..] :: [Int]) (topleveltfunc_params t)
     tvars = map (\(i, _) -> "typ" ++ show i) itps
     nparams = length itps
-    tparams = if nparams == 1 then tycon "Type" else TyTuple () Boxed (replicate nparams (tycon "Type"))
+    tparams = if nparams == 1 then tycon "Type" else tyTupleBoxed (replicate nparams (tycon "Type"))
     sig = foldr1 tyfun [tparams, tycon "String", tyapp (tycon "Q") (tycon "Exp")]
     tvars_p = if nparams == 1 then map p tvars else [pTuple (map p tvars)]
     prefix = "TL"
@@ -578,7 +582,7 @@ genTLTemplateInstance tih t =
         [tycon "IsCPrimitive"]
           ++ replicate
             nparams
-            (TyTuple () Boxed [tycon "Q" `tyapp` tycon "Type", tycon "TemplateParamInfo"])
+            (tyTupleBoxed [tycon "Q" `tyapp` tycon "Type", tycon "TemplateParamInfo"])
           ++ [tycon "Q" `tyapp` tylist (tycon "Dec")]
     -- nvfs = zip ([1..] :: [Int]) vfs
 

--- a/fficxx/src/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Primitive.hs
@@ -41,6 +41,7 @@ import FFICXX.Generate.Util.HaskellSrcExts
     mkTVar,
     mkVar,
     parenSplice,
+    tyForall,
     tyPtr,
     tySplice,
     tyapp,
@@ -51,7 +52,11 @@ import FFICXX.Generate.Util.HaskellSrcExts
   )
 import qualified FFICXX.Runtime.CodeGen.Cxx as R
 import FFICXX.Runtime.TH (IsCPrimitive (CPrim, NonCPrim))
-import Language.Haskell.Exts.Syntax (Asst (..), Context, Type (..))
+import Language.Haskell.Exts.Syntax
+  ( Asst,
+    Context,
+    Type,
+  )
 
 data CFunSig = CFunSig
   { cArgTypes :: [Arg],
@@ -869,7 +874,7 @@ functionSignature c f =
         | isVirtualFunc f = (mkTVar "a" :)
         | isNonVirtualFunc f = (mkTVar (fst (hsClassName c)) :)
         | otherwise = id
-   in TyForall () Nothing (Just ctxt) (foldr1 tyfun (arg0 typs))
+   in tyForall Nothing (Just ctxt) (foldr1 tyfun (arg0 typs))
 
 functionSignatureT :: TemplateClass -> TemplateFunction -> Type ()
 functionSignatureT t TFun {..} =
@@ -948,7 +953,7 @@ accessorSignature c v accessor =
       HsFunSig typs assts = extractArgRetTypes (Just c) False csig
       ctxt = cxTuple assts
       arg0 = (mkTVar (fst (hsClassName c)) :)
-   in TyForall () Nothing (Just ctxt) (foldr1 tyfun (arg0 typs))
+   in tyForall Nothing (Just ctxt) (foldr1 tyfun (arg0 typs))
 
 -- | this is for FFI type.
 hsFFIFuncTyp :: Maybe (Selfness, Class) -> CFunSig -> Type ()

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -522,6 +522,9 @@ buildProxyHs :: ClassModule -> HsModule GhcPs
 buildProxyHs m =
   Ex.mkModule
     (cmModule m <.> "Proxy")
+    [ "ForeignFunctionInterface",
+      "FlexibleInstances"
+    ]
 
 {-  [ Ex.lang
         [ "FlexibleInstances",

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -522,15 +522,9 @@ buildProxyHs :: ClassModule -> HsModule GhcPs
 buildProxyHs m =
   Ex.mkModule
     (cmModule m <.> "Proxy")
-    [ "ForeignFunctionInterface",
-      "FlexibleInstances"
-    ]
-
-{-  [ Ex.lang
-        [ "FlexibleInstances",
-          "OverloadedStrings",
-          "TemplateHaskell"
-        ]
+    [ "FlexibleInstances",
+      "OverloadedStrings",
+      "TemplateHaskell"
     ]
     [ Ex.mkImport "Foreign.Ptr",
       Ex.mkImport "FFICXX.Runtime.Cast",
@@ -538,6 +532,8 @@ buildProxyHs m =
       Ex.mkImport "Language.Haskell.TH.Syntax",
       Ex.mkImport "FFICXX.Runtime.CodeGen.Cxx"
     ]
+
+{-
     body
   where
     body = [] -- genProxyInstance

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -125,7 +125,7 @@ import Language.Haskell.Exts.Syntax
   ( Decl,
     Module,
   )
-import Language.Haskell.Syntax (HsModule, ModuleName)
+import Language.Haskell.Syntax (HsModule)
 import System.FilePath ((<.>), (</>))
 
 srcDir :: FilePath -> FilePath

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -106,6 +106,7 @@ import FFICXX.Generate.Type.PackageInterface
     PackageName (..),
   )
 import FFICXX.Generate.Util (firstUpper)
+import qualified FFICXX.Generate.Util.GHCExactPrint as Ex
 import FFICXX.Generate.Util.HaskellSrcExts
   ( eWildCard,
     emodule,
@@ -119,10 +120,12 @@ import FFICXX.Generate.Util.HaskellSrcExts
   )
 import FFICXX.Runtime.CodeGen.Cxx (HeaderName (..))
 import qualified FFICXX.Runtime.CodeGen.Cxx as R
+import GHC.Hs.Extension (GhcPs)
 import Language.Haskell.Exts.Syntax
   ( Decl,
     Module,
   )
+import Language.Haskell.Syntax (HsModule, ModuleName)
 import System.FilePath ((<.>), (</>))
 
 srcDir :: FilePath -> FilePath
@@ -515,25 +518,27 @@ buildImplementationHs amap m =
         <> concatMap genHsFrontInstVariables classes
         <> genTemplateMemberFunctions (cmCIH m)
 
-buildProxyHs :: ClassModule -> Module ()
+buildProxyHs :: ClassModule -> HsModule GhcPs
 buildProxyHs m =
-  mkModule
+  Ex.mkModule
     (cmModule m <.> "Proxy")
-    [ lang
+
+{-  [ Ex.lang
         [ "FlexibleInstances",
           "OverloadedStrings",
           "TemplateHaskell"
         ]
     ]
-    [ mkImport "Foreign.Ptr",
-      mkImport "FFICXX.Runtime.Cast",
-      mkImport "Language.Haskell.TH",
-      mkImport "Language.Haskell.TH.Syntax",
-      mkImport "FFICXX.Runtime.CodeGen.Cxx"
+    [ Ex.mkImport "Foreign.Ptr",
+      Ex.mkImport "FFICXX.Runtime.Cast",
+      Ex.mkImport "Language.Haskell.TH",
+      Ex.mkImport "Language.Haskell.TH.Syntax",
+      Ex.mkImport "FFICXX.Runtime.CodeGen.Cxx"
     ]
     body
   where
-    body = genProxyInstance
+    body = [] -- genProxyInstance
+-}
 
 buildTemplateHs :: TemplateClassModule -> Module ()
 buildTemplateHs m =

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -107,9 +107,9 @@ import FFICXX.Generate.Type.PackageInterface
   )
 import FFICXX.Generate.Util (firstUpper)
 import FFICXX.Generate.Util.HaskellSrcExts
-  ( eThingWith,
-    eWildCard,
+  ( eWildCard,
     emodule,
+    ethingwith,
     evar,
     lang,
     mkImport,
@@ -658,7 +658,7 @@ buildTopLevelTemplateHs modname tih =
       ]
     pkgExports =
       map
-        ( (\n -> eThingWith (eWildCard 1) n [])
+        ( (\n -> ethingwith (eWildCard 1) n [])
             . unqual
             . firstUpper
             . hsFrontNameForTopLevel

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -107,7 +107,9 @@ import FFICXX.Generate.Type.PackageInterface
   )
 import FFICXX.Generate.Util (firstUpper)
 import FFICXX.Generate.Util.HaskellSrcExts
-  ( emodule,
+  ( eThingWith,
+    eWildCard,
+    emodule,
     evar,
     lang,
     mkImport,
@@ -118,10 +120,8 @@ import FFICXX.Generate.Util.HaskellSrcExts
 import FFICXX.Runtime.CodeGen.Cxx (HeaderName (..))
 import qualified FFICXX.Runtime.CodeGen.Cxx as R
 import Language.Haskell.Exts.Syntax
-  ( Decl (..),
-    EWildcard (EWildcard),
-    ExportSpec (EThingWith),
-    Module (..),
+  ( Decl,
+    Module,
   )
 import System.FilePath ((<.>), (</>))
 
@@ -658,7 +658,7 @@ buildTopLevelTemplateHs modname tih =
       ]
     pkgExports =
       map
-        ( (\n -> EThingWith () (EWildcard () 1) n [])
+        ( (\n -> eThingWith (eWildCard 1) n [])
             . unqual
             . firstUpper
             . hsFrontNameForTopLevel

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -532,12 +532,9 @@ buildProxyHs m =
       Ex.mkImport "Language.Haskell.TH.Syntax",
       Ex.mkImport "FFICXX.Runtime.CodeGen.Cxx"
     ]
-
-{-
     body
   where
-    body = [] -- genProxyInstance
--}
+    body = genProxyInstance
 
 buildTemplateHs :: TemplateClassModule -> Module ()
 buildTemplateHs m =

--- a/fficxx/src/FFICXX/Generate/Util/DepGraph.hs
+++ b/fficxx/src/FFICXX/Generate/Util/DepGraph.hs
@@ -11,10 +11,8 @@ import FFICXX.Generate.Type.Class (TopLevel (..))
 import FFICXX.Generate.Type.Module (UClass)
 import Text.Dot (Dot, NodeId, attribute, node, showDot, (.->.))
 
-src, box, diamond :: String -> Dot NodeId
-src label = node $ [("shape", "none"), ("label", label)]
+box :: String -> Dot NodeId
 box label = node $ [("shape", "box"), ("style", "rounded"), ("label", label)]
-diamond label = node $ [("shape", "diamond"), ("label", label), ("fontsize", "10")]
 
 -- | Draw dependency graph of modules in graphviz dot format.
 drawDepGraph ::

--- a/fficxx/src/FFICXX/Generate/Util/GHCExactPrint.hs
+++ b/fficxx/src/FFICXX/Generate/Util/GHCExactPrint.hs
@@ -263,8 +263,8 @@ noAnnList = AnnList Nothing Nothing Nothing [] []
 noAnnListItem :: AnnListItem
 noAnnListItem = AnnListItem []
 
-mkLExpr :: HsExpr GhcPs -> LHsExpr GhcPs
-mkLExpr = L (mkRelSrcSpanAnn (-1) noAnnListItem)
+mkL :: Int -> a -> GenLocated SrcSpanAnnA a
+mkL nLines = L (mkRelSrcSpanAnn nLines noAnnListItem)
 
 --
 -- Modules
@@ -360,8 +360,8 @@ tyapp :: HsType GhcPs -> HsType GhcPs -> HsType GhcPs
 tyapp x y =
   HsAppTy noExtField lx ly
   where
-    lx = L (mkRelSrcSpanAnn (-1) (AnnListItem [])) x
-    ly = L (mkRelSrcSpanAnn 0 (AnnListItem [])) y
+    lx = mkL (-1) x
+    ly = mkL 0 y
 
 tylist :: HsType GhcPs -> HsType GhcPs
 tylist x =
@@ -373,7 +373,7 @@ tylist x =
           ap_open = EpaDelta (SameLine 0) [],
           ap_close = EpaDelta (SameLine 0) []
         }
-    lx = L (mkRelSrcSpanAnn (-1) (AnnListItem [])) x
+    lx = mkL (-1) x
 
 --
 -- Function
@@ -415,7 +415,7 @@ mkFunSig fname typ =
       HsSig
         noExtField
         (HsOuterImplicit noExtField)
-        (L (mkRelSrcSpanAnn (-1) noAnnListItem) typ)
+        (mkL (-1) typ)
 
 mkBind1 ::
   String ->
@@ -430,7 +430,7 @@ mkBind1 fname pats rhs mbinds =
     lid = L (mkRelSrcSpanAnn (-1) (NameAnnTrailing [])) id'
 
     lpats = [] -- fmap (L ) pats
-    lrhs = L (mkRelSrcSpanAnn (-1) noAnnListItem) rhs
+    lrhs = mkL (-1) rhs
     glrhs =
       let ann =
             mkRelEpAnn
@@ -450,7 +450,7 @@ mkBind1 fname pats rhs mbinds =
                 grhssLocalBinds = EmptyLocalBinds noExtField
               }
         }
-    lmatch = L (mkRelSrcSpanAnn (-1) noAnnListItem) match
+    lmatch = mkL (-1) match
     payload = MG FromSource (L (mkRelSrcSpanAnn (-1) noAnnList) [lmatch])
 
 --
@@ -461,8 +461,8 @@ app :: HsExpr GhcPs -> HsExpr GhcPs -> HsExpr GhcPs
 app x y =
   HsApp (mkRelEpAnn (-1) NoEpAnns) lx ly
   where
-    lx = L (mkRelSrcSpanAnn (-1) noAnnListItem) x
-    ly = L (mkRelSrcSpanAnn 0 noAnnListItem) y
+    lx = mkL (-1) x
+    ly = mkL 0 y
 
 -- NOTE: in ghc API, no difference between constructor and variable
 con :: String -> HsExpr GhcPs
@@ -500,9 +500,9 @@ inapp x o y =
   OpApp ann lx lo ly
   where
     ann = mkRelEpAnn (-1) []
-    lx = L (mkRelSrcSpanAnn (-1) noAnnListItem) x
-    lo = L (mkRelSrcSpanAnn (-1) noAnnListItem) o
-    ly = L (mkRelSrcSpanAnn (-1) noAnnListItem) y
+    lx = mkL (-1) x
+    lo = mkL (-1) o
+    ly = mkL (-1) y
 
 listE :: [HsExpr GhcPs] -> HsExpr GhcPs
 listE itms =
@@ -519,7 +519,7 @@ listE itms =
                 AddEpAnn AnnCloseS (EpaDelta (SameLine 0) [])
               ]
               []
-          litms = fmap (L (mkRelSrcSpanAnn (-1) noAnnListItem)) itms
+          litms = fmap (mkL (-1)) itms
        in ExplicitList (mkRelEpAnn (-1) ann) litms
   where
 
@@ -535,7 +535,7 @@ op = mkVar
 
 par :: HsExpr GhcPs -> HsExpr GhcPs
 par expr =
-  HsPar ann tokOpen (mkLExpr expr) tokClose
+  HsPar ann tokOpen (mkL (-1) expr) tokClose
   where
     ann = mkRelEpAnn (-1) NoEpAnns
     tokOpen = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
@@ -556,7 +556,7 @@ mkBodyStmt :: HsExpr GhcPs -> StmtLR GhcPs GhcPs (LHsExpr GhcPs)
 mkBodyStmt expr =
   BodyStmt noExtField body noExtField noExtField
   where
-    body = L (mkRelSrcSpanAnn (-1) noAnnListItem) expr
+    body = mkL (-1) expr
 
 --
 -- utilities

--- a/fficxx/src/FFICXX/Generate/Util/HaskellSrcExts.hs
+++ b/fficxx/src/FFICXX/Generate/Util/HaskellSrcExts.hs
@@ -1,4 +1,78 @@
-module FFICXX.Generate.Util.HaskellSrcExts where
+module FFICXX.Generate.Util.HaskellSrcExts
+  ( app,
+    app',
+    unqual,
+    tycon,
+    tyapp,
+    tyfun,
+    tylist,
+    unit_tycon,
+    conDecl,
+    qualConDecl,
+    recDecl,
+    lit,
+    mkVar,
+    con,
+    mkTVar,
+    mkPVar,
+    mkIVar,
+    mkPVarSig,
+    pbind,
+    pbind_,
+    mkTBind,
+    mkBind1,
+    mkFun,
+    mkFunSig,
+    mkClass,
+    dhead,
+    mkDeclHead,
+    mkInstance,
+    mkData,
+    mkNewtype,
+    mkForImpCcall,
+    mkModule,
+    mkModuleE,
+    mkImport,
+    mkImportExp,
+    mkImportSrc,
+    lang,
+    dot,
+    tyForall,
+    tyParen,
+    tyPtr,
+    tyForeignPtr,
+    classA,
+    cxEmpty,
+    cxTuple,
+    tySplice,
+    tyTupleBoxed,
+    parenSplice,
+    bracketExp,
+    typeBracket,
+    mkDeriving,
+    irule,
+    ihcon,
+    evar,
+    eabs,
+    ethingwith,
+    ethingall,
+    emodule,
+    nonamespace,
+    insType,
+    insDecl,
+    generator,
+    qualifier,
+    clsDecl,
+    unkindedVar,
+    op,
+    inapp,
+    if_,
+    urhs,
+    match,
+    eWildCard,
+    prettyPrint,
+  )
+where
 
 import Data.List (foldl')
 import Data.Maybe (maybeToList)
@@ -102,7 +176,6 @@ import Language.Haskell.Exts
         TyTuple,
         TyVar
       ),
-    unit_tycon,
   )
 import qualified Language.Haskell.Exts as LHE
 import Language.Haskell.Exts.Syntax (CName)
@@ -133,7 +206,7 @@ tylist :: Type () -> Type ()
 tylist = TyList ()
 
 unit_tycon :: Type ()
-unit_tycon = Language.Haskell.Exts.unit_tycon ()
+unit_tycon = LHE.unit_tycon ()
 
 conDecl :: String -> [Type ()] -> ConDecl ()
 conDecl n ys = ConDecl () (Ident () n) ys
@@ -355,9 +428,6 @@ urhs = UnGuardedRhs ()
 -- | case pattern match p -> e
 match :: Pat () -> Exp () -> Alt ()
 match p e = Alt () p (urhs e) Nothing
-
-eThingWith :: EWildcard () -> QName () -> [CName ()] -> ExportSpec ()
-eThingWith = EThingWith ()
 
 eWildCard :: Int -> EWildcard ()
 eWildCard = EWildcard ()

--- a/fficxx/src/FFICXX/Generate/Util/HaskellSrcExts.hs
+++ b/fficxx/src/FFICXX/Generate/Util/HaskellSrcExts.hs
@@ -99,12 +99,19 @@ import Language.Haskell.Exts
         TyList,
         TyParen,
         TySplice,
+        TyTuple,
         TyVar
       ),
-    app,
     unit_tycon,
   )
+import qualified Language.Haskell.Exts as LHE
 import Language.Haskell.Exts.Syntax (CName)
+
+app :: Exp () -> Exp () -> Exp ()
+app = LHE.app
+
+app' :: String -> String -> Exp ()
+app' x y = App () (mkVar x) (mkVar y)
 
 unqual :: String -> QName ()
 unqual = UnQual () . Ident ()
@@ -140,9 +147,6 @@ qualConDecl = QualConDecl ()
 
 recDecl :: String -> [FieldDecl ()] -> ConDecl ()
 recDecl n rs = RecDecl () (Ident () n) rs
-
-app' :: String -> String -> Exp ()
-app' x y = App () (mkVar x) (mkVar y)
 
 lit :: Literal () -> Exp ()
 lit = Lit ()
@@ -271,6 +275,9 @@ cxTuple = CxTuple ()
 tySplice :: Splice () -> Type ()
 tySplice = TySplice ()
 
+tyTupleBoxed :: [Type ()] -> Type ()
+tyTupleBoxed = TyTuple () LHE.Boxed
+
 parenSplice :: Exp () -> Splice ()
 parenSplice = ParenSplice ()
 
@@ -348,3 +355,12 @@ urhs = UnGuardedRhs ()
 -- | case pattern match p -> e
 match :: Pat () -> Exp () -> Alt ()
 match p e = Alt () p (urhs e) Nothing
+
+eThingWith :: EWildcard () -> QName () -> [CName ()] -> ExportSpec ()
+eThingWith = EThingWith ()
+
+eWildCard :: Int -> EWildcard ()
+eWildCard = EWildcard ()
+
+prettyPrint :: (LHE.Pretty a) => a -> String
+prettyPrint = LHE.prettyPrint


### PR DESCRIPTION
The simplest HsProxy is migrated. 
For the time being, haskell-src-exts and ghc+ghc-exactprint will coexist and haskell-src-exts will be faded away.