### PR TITLE
typeclass interface generation via ghc-exactprint

### DIFF
--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -169,8 +169,7 @@ simpleBuilder cfg sbc = do
       (postProcess $ exactPrint (C.buildFFIHsc m))
   --
   putStrLn "Generating Interface.hs"
-  for_ mods $ \m -> do
-    debugExactPrint (C.buildInterfaceHs mempty depCycles m)
+  for_ mods $ \m ->
     gen
       (cmModule m <.> "Interface" <.> "hs")
       (exactPrint (C.buildInterfaceHs mempty depCycles m))
@@ -182,10 +181,11 @@ simpleBuilder cfg sbc = do
       (exactPrint (C.buildCastHs m))
   --
   putStrLn "Generating Implementation.hs"
-  for_ mods $ \m ->
+  for_ mods $ \m -> do
+    debugExactPrint (C.buildImplementationHs mempty m)
     gen
       (cmModule m <.> "Implementation" <.> "hs")
-      (prettyPrint (C.buildImplementationHs mempty m))
+      (exactPrint (C.buildImplementationHs mempty m))
   --
   putStrLn "Generating Proxy.hs"
   for_ mods $ \m ->

--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -169,10 +169,11 @@ simpleBuilder cfg sbc = do
       (postProcess $ exactPrint (C.buildFFIHsc m))
   --
   putStrLn "Generating Interface.hs"
-  for_ mods $ \m ->
+  for_ mods $ \m -> do
+    debugExactPrint (C.buildInterfaceHs mempty depCycles m)
     gen
       (cmModule m <.> "Interface" <.> "hs")
-      (prettyPrint (C.buildInterfaceHs mempty depCycles m))
+      (exactPrint (C.buildInterfaceHs mempty depCycles m))
   --
   putStrLn "Generating Cast.hs"
   for_ mods $ \m ->
@@ -214,7 +215,7 @@ simpleBuilder cfg sbc = do
   for_ hsbootlst $ \m -> do
     gen
       (cmModule m <.> "Interface" <.> "hs-boot")
-      (hsBootHackClearEmptyContexts $ prettyPrint (C.buildInterfaceHsBoot depCycles m))
+      (hsBootHackClearEmptyContexts $ exactPrint (C.buildInterfaceHsBoot depCycles m))
   --
   putStrLn "Generating Module summary file"
   for_ mods $ \m ->

--- a/fficxx/src/FFICXX/Generate/Code/HsCommon.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsCommon.hs
@@ -1,32 +1,12 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-
 module FFICXX.Generate.Code.HsCommon
-  ( genExtraImport_,
-    genExtraImport,
-    genImportInCast_,
+  ( genExtraImport,
   )
 where
 
-import FFICXX.Generate.Name (subModuleName)
 import FFICXX.Generate.Type.Module (ClassModule (..))
-import qualified FFICXX.Generate.Util.GHCExactPrint as Ex
-import FFICXX.Generate.Util.HaskellSrcExts (mkImport)
-import qualified GHC.Hs as Ex
-import Language.Haskell.Exts.Syntax (ImportDecl)
+import FFICXX.Generate.Util.GHCExactPrint (mkImport)
+import GHC.Hs (GhcPs)
+import Language.Haskell.Syntax (ImportDecl)
 
--- TODO: Remove
-genExtraImport_ :: ClassModule -> [ImportDecl ()]
-genExtraImport_ cm = map mkImport (cmExtraImport cm)
-
--- This is the new version.
-genExtraImport :: ClassModule -> [Ex.ImportDecl Ex.GhcPs]
-genExtraImport cm = fmap Ex.mkImport (cmExtraImport cm)
-
--- OLD
--- TODO: Remove
-genImportInCast_ :: ClassModule -> [ImportDecl ()]
-genImportInCast_ m =
-  fmap (mkImport . subModuleName) $ cmImportedSubmodulesForCast m
+genExtraImport :: ClassModule -> [ImportDecl GhcPs]
+genExtraImport cm = fmap mkImport (cmExtraImport cm)

--- a/fficxx/src/FFICXX/Generate/Code/HsImplementation.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsImplementation.hs
@@ -47,28 +47,34 @@ import FFICXX.Generate.Type.Module
   ( ClassModule (..),
   )
 --
+
+import FFICXX.Generate.Util.GHCExactPrint
+  ( mkImport,
+  )
 import qualified FFICXX.Generate.Util.HaskellSrcExts as O
   ( cxEmpty,
     insDecl,
     mkBind1,
     mkFun,
-    mkImport,
     mkInstance,
     mkVar,
   )
+import GHC.Hs (GhcPs)
 import qualified Language.Haskell.Exts.Build as O (app)
 import qualified Language.Haskell.Exts.Syntax as O
   ( Decl,
-    ImportDecl,
+  )
+import Language.Haskell.Syntax
+  ( ImportDecl,
   )
 
 --
 -- import
 --
 
-genImportInImplementation :: ClassModule -> [O.ImportDecl ()]
+genImportInImplementation :: ClassModule -> [ImportDecl GhcPs]
 genImportInImplementation m =
-  fmap (O.mkImport . subModuleName) $ cmImportedSubmodulesForImplementation m
+  fmap (mkImport . subModuleName) $ cmImportedSubmodulesForImplementation m
 
 --
 -- functions

--- a/fficxx/src/FFICXX/Generate/Code/HsImplementation.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsImplementation.hs
@@ -20,7 +20,6 @@ import Control.Monad.Reader (Reader)
 import FFICXX.Generate.Code.Primitive
   ( accessorSignature,
     cxx2HsType,
-    functionSignature,
     functionSignature',
     hsFuncXformer,
   )
@@ -55,23 +54,8 @@ import FFICXX.Generate.Util.GHCExactPrint
     mkInstance,
     mkVar,
   )
-import qualified FFICXX.Generate.Util.HaskellSrcExts as O
-  ( cxEmpty,
-    insDecl,
-    mkBind1,
-    mkFun,
-    mkInstance,
-    mkVar,
-  )
 import GHC.Hs (GhcPs)
-import qualified Language.Haskell.Exts.Build as O (app)
-import qualified Language.Haskell.Exts.Syntax as O
-  ( Decl,
-  )
-import Language.Haskell.Syntax
-  ( HsDecl,
-    ImportDecl,
-  )
+import Language.Haskell.Syntax (HsDecl, ImportDecl)
 
 --
 -- import

--- a/fficxx/src/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Primitive.hs
@@ -1121,13 +1121,13 @@ accessorCFunSig :: Types -> Accessor -> CFunSig
 accessorCFunSig typ Getter = CFunSig [] typ
 accessorCFunSig typ Setter = CFunSig [Arg typ "x"] Void
 
-accessorSignature :: Class -> Variable -> Accessor -> Type ()
+accessorSignature :: Class -> Variable -> Accessor -> HsType GhcPs
 accessorSignature c v accessor =
   let csig = accessorCFunSig (arg_type (unVariable v)) accessor
-      HsFunSig typs assts = extractArgRetTypes (Just c) False csig
-      ctxt = cxTuple assts
-      arg0 = (mkTVar (fst (hsClassName c)) :)
-   in tyForall Nothing (Just ctxt) (foldr1 tyfun (arg0 typs))
+      HsFunSig' typs assts = extractArgRetTypes' (Just c) False csig
+      ctxt = Ex.cxTuple assts
+      arg0 = (Ex.mkTVar (fst (hsClassName c)) :)
+   in Ex.qualTy ctxt (foldr1 Ex.tyfun (arg0 typs))
 
 -- | old function. this is for FFI type.
 hsFFIFuncTyp :: Maybe (Selfness, Class) -> CFunSig -> Type ()

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -474,43 +474,42 @@ buildCastHs m =
       mapMaybe genHsFrontInstCastable classes
         <> mapMaybe genHsFrontInstCastableSelf classes
 
-buildImplementationHs :: AnnotateMap -> ClassModule -> Module ()
+buildImplementationHs :: AnnotateMap -> ClassModule -> HsModule GhcPs
 buildImplementationHs amap m =
-  mkModule
+  Ex.mkModule
     (cmModule m <.> "Implementation")
-    [ lang
-        [ "EmptyDataDecls",
-          "FlexibleContexts",
-          "FlexibleInstances",
-          "ForeignFunctionInterface",
-          "IncoherentInstances",
-          "MultiParamTypeClasses",
-          "OverlappingInstances",
-          "TemplateHaskell",
-          "TypeFamilies",
-          "TypeSynonymInstances"
-        ]
+    [ "EmptyDataDecls",
+      "FlexibleContexts",
+      "FlexibleInstances",
+      "ForeignFunctionInterface",
+      "IncoherentInstances",
+      "MultiParamTypeClasses",
+      "OverlappingInstances",
+      "TemplateHaskell",
+      "TypeFamilies",
+      "TypeSynonymInstances"
     ]
     implImports
-    implBody
+    [] -- implBody
   where
     classes = [cihClass (cmCIH m)]
     implImports =
-      [ mkImport "Data.Monoid", -- for template member
-        mkImport "Data.Word",
-        mkImport "Data.Int",
-        mkImport "Foreign.C",
-        mkImport "Foreign.Ptr",
-        mkImport "Language.Haskell.TH", -- for template member
-        mkImport "Language.Haskell.TH.Syntax", -- for template member
-        mkImport "System.IO.Unsafe",
-        mkImport "FFICXX.Runtime.Cast",
-        mkImport "FFICXX.Runtime.CodeGen.Cxx", -- for template member
-        mkImport "FFICXX.Runtime.TH" -- for template member
+      [ Ex.mkImport "Data.Monoid", -- for template member
+        Ex.mkImport "Data.Word",
+        Ex.mkImport "Data.Int",
+        Ex.mkImport "Foreign.C",
+        Ex.mkImport "Foreign.Ptr",
+        Ex.mkImport "Language.Haskell.TH", -- for template member
+        Ex.mkImport "Language.Haskell.TH.Syntax", -- for template member
+        Ex.mkImport "System.IO.Unsafe",
+        Ex.mkImport "FFICXX.Runtime.Cast",
+        Ex.mkImport "FFICXX.Runtime.CodeGen.Cxx", -- for template member
+        Ex.mkImport "FFICXX.Runtime.TH" -- for template member
       ]
         <> genImportInImplementation m
-        <> genExtraImport_ m
-    f :: Class -> [Decl ()]
+        <> genExtraImport m
+
+{-    f :: Class -> [Decl ()]
     f y = concatMap (flip genHsFrontInst y) (y : class_allparents y)
     implBody =
       concatMap f classes
@@ -519,6 +518,7 @@ buildImplementationHs amap m =
         <> concatMap genHsFrontInstStatic classes
         <> concatMap genHsFrontInstVariables classes
         <> genTemplateMemberFunctions (cmCIH m)
+-}
 
 buildProxyHs :: ClassModule -> HsModule GhcPs
 buildProxyHs m =

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -415,12 +415,10 @@ buildInterfaceHs amap depCycles m =
       ]
         <> genImportInInterface False depCycles m
         <> genExtraImport m
-    ifaceBody = []
-
-{-      runReader (mapM (genHsFrontDecl False) classes) amap
-        <> (concatMap genHsFrontUpcastClass . filter (not . isAbstractClass)) classes
-        <> (concatMap genHsFrontDowncastClass . filter (not . isAbstractClass)) classes
--}
+    ifaceBody =
+      runReader (mapM (genHsFrontDecl False) classes) amap
+--        <> (concatMap genHsFrontUpcastClass . filter (not . isAbstractClass)) classes
+--        <> (concatMap genHsFrontDowncastClass . filter (not . isAbstractClass)) classes
 
 buildInterfaceHsBoot :: DepCycles -> ClassModule -> HsModule GhcPs
 buildInterfaceHsBoot depCycles m =
@@ -449,9 +447,7 @@ buildInterfaceHsBoot depCycles m =
       ]
         <> genImportInInterface True depCycles m
         <> genExtraImport m
-    hsbootBody = []
-
--- runReader (mapM (genHsFrontDecl True) [c]) M.empty
+    hsbootBody = runReader (mapM (genHsFrontDecl True) [c]) M.empty
 
 buildCastHs :: ClassModule -> HsModule GhcPs
 buildCastHs m =

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -512,13 +512,11 @@ buildImplementationHs amap m =
     f y = concatMap (flip genHsFrontInst y) (y : class_allparents y)
     implBody =
       concatMap f classes
-
-{-        <> runReader (concat <$> mapM genHsFrontInstNew classes) amap
+        <> runReader (concat <$> mapM genHsFrontInstNew classes) amap
         <> concatMap genHsFrontInstNonVirtual classes
         <> concatMap genHsFrontInstStatic classes
         <> concatMap genHsFrontInstVariables classes
-        <> genTemplateMemberFunctions (cmCIH m)
--}
+--        <> genTemplateMemberFunctions (cmCIH m)
 
 buildProxyHs :: ClassModule -> HsModule GhcPs
 buildProxyHs m =

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -417,8 +417,8 @@ buildInterfaceHs amap depCycles m =
         <> genExtraImport m
     ifaceBody =
       runReader (mapM (genHsFrontDecl False) classes) amap
+        <> (concatMap genHsFrontUpcastClass . filter (not . isAbstractClass)) classes
 
---        <> (concatMap genHsFrontUpcastClass . filter (not . isAbstractClass)) classes
 --        <> (concatMap genHsFrontDowncastClass . filter (not . isAbstractClass)) classes
 
 buildInterfaceHsBoot :: DepCycles -> ClassModule -> HsModule GhcPs

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -418,8 +418,7 @@ buildInterfaceHs amap depCycles m =
     ifaceBody =
       runReader (mapM (genHsFrontDecl False) classes) amap
         <> (concatMap genHsFrontUpcastClass . filter (not . isAbstractClass)) classes
-
---        <> (concatMap genHsFrontDowncastClass . filter (not . isAbstractClass)) classes
+        <> (concatMap genHsFrontDowncastClass . filter (not . isAbstractClass)) classes
 
 buildInterfaceHsBoot :: DepCycles -> ClassModule -> HsModule GhcPs
 buildInterfaceHsBoot depCycles m =

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -516,6 +516,7 @@ buildImplementationHs amap m =
         <> concatMap genHsFrontInstNonVirtual classes
         <> concatMap genHsFrontInstStatic classes
         <> concatMap genHsFrontInstVariables classes
+
 --        <> genTemplateMemberFunctions (cmCIH m)
 
 buildProxyHs :: ClassModule -> HsModule GhcPs

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -36,7 +36,6 @@ import FFICXX.Generate.Code.HsCast
   )
 import FFICXX.Generate.Code.HsCommon
   ( genExtraImport,
-    genExtraImport_,
   )
 import FFICXX.Generate.Code.HsFFI
   ( genHsFFI,
@@ -490,7 +489,7 @@ buildImplementationHs amap m =
       "TypeSynonymInstances"
     ]
     implImports
-    [] -- implBody
+    implBody
   where
     classes = [cihClass (cmCIH m)]
     implImports =
@@ -509,11 +508,12 @@ buildImplementationHs amap m =
         <> genImportInImplementation m
         <> genExtraImport m
 
-{-    f :: Class -> [Decl ()]
+    f :: Class -> [HsDecl GhcPs]
     f y = concatMap (flip genHsFrontInst y) (y : class_allparents y)
     implBody =
       concatMap f classes
-        <> runReader (concat <$> mapM genHsFrontInstNew classes) amap
+
+{-        <> runReader (concat <$> mapM genHsFrontInstNew classes) amap
         <> concatMap genHsFrontInstNonVirtual classes
         <> concatMap genHsFrontInstStatic classes
         <> concatMap genHsFrontInstVariables classes

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -417,6 +417,7 @@ buildInterfaceHs amap depCycles m =
         <> genExtraImport m
     ifaceBody =
       runReader (mapM (genHsFrontDecl False) classes) amap
+
 --        <> (concatMap genHsFrontUpcastClass . filter (not . isAbstractClass)) classes
 --        <> (concatMap genHsFrontDowncastClass . filter (not . isAbstractClass)) classes
 

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -388,71 +388,70 @@ buildInterfaceHs ::
   AnnotateMap ->
   DepCycles ->
   ClassModule ->
-  Module ()
+  HsModule GhcPs
 buildInterfaceHs amap depCycles m =
-  mkModule
+  Ex.mkModule
     (cmModule m <.> "Interface")
-    [ lang
-        [ "EmptyDataDecls",
-          "ExistentialQuantification",
-          "FlexibleContexts",
-          "FlexibleInstances",
-          "ForeignFunctionInterface",
-          "MultiParamTypeClasses",
-          "ScopedTypeVariables",
-          "TypeFamilies",
-          "TypeSynonymInstances"
-        ]
+    [ "EmptyDataDecls",
+      "ExistentialQuantification",
+      "FlexibleContexts",
+      "FlexibleInstances",
+      "ForeignFunctionInterface",
+      "MultiParamTypeClasses",
+      "ScopedTypeVariables",
+      "TypeFamilies",
+      "TypeSynonymInstances"
     ]
     ifaceImports
     ifaceBody
   where
     classes = [cihClass (cmCIH m)]
     ifaceImports =
-      [ mkImport "Data.Word",
-        mkImport "Data.Int",
-        mkImport "Foreign.C",
-        mkImport "Foreign.Ptr",
-        mkImport "FFICXX.Runtime.Cast"
+      [ Ex.mkImport "Data.Word",
+        Ex.mkImport "Data.Int",
+        Ex.mkImport "Foreign.C",
+        Ex.mkImport "Foreign.Ptr",
+        Ex.mkImport "FFICXX.Runtime.Cast"
       ]
         <> genImportInInterface False depCycles m
-        <> genExtraImport_ m
-    ifaceBody =
-      runReader (mapM (genHsFrontDecl False) classes) amap
+        <> genExtraImport m
+    ifaceBody = []
+
+{-      runReader (mapM (genHsFrontDecl False) classes) amap
         <> (concatMap genHsFrontUpcastClass . filter (not . isAbstractClass)) classes
         <> (concatMap genHsFrontDowncastClass . filter (not . isAbstractClass)) classes
+-}
 
-buildInterfaceHsBoot :: DepCycles -> ClassModule -> Module ()
+buildInterfaceHsBoot :: DepCycles -> ClassModule -> HsModule GhcPs
 buildInterfaceHsBoot depCycles m =
-  mkModule
+  Ex.mkModule
     (cmModule m <.> "Interface")
-    [ lang
-        [ "EmptyDataDecls",
-          "ExistentialQuantification",
-          "FlexibleContexts",
-          "FlexibleInstances",
-          "ForeignFunctionInterface",
-          "MultiParamTypeClasses",
-          "ScopedTypeVariables",
-          "TypeFamilies",
-          "TypeSynonymInstances"
-        ]
+    [ "EmptyDataDecls",
+      "ExistentialQuantification",
+      "FlexibleContexts",
+      "FlexibleInstances",
+      "ForeignFunctionInterface",
+      "MultiParamTypeClasses",
+      "ScopedTypeVariables",
+      "TypeFamilies",
+      "TypeSynonymInstances"
     ]
     hsbootImports
     hsbootBody
   where
     c = cihClass (cmCIH m)
     hsbootImports =
-      [ mkImport "Data.Word",
-        mkImport "Data.Int",
-        mkImport "Foreign.C",
-        mkImport "Foreign.Ptr",
-        mkImport "FFICXX.Runtime.Cast"
+      [ Ex.mkImport "Data.Word",
+        Ex.mkImport "Data.Int",
+        Ex.mkImport "Foreign.C",
+        Ex.mkImport "Foreign.Ptr",
+        Ex.mkImport "FFICXX.Runtime.Cast"
       ]
         <> genImportInInterface True depCycles m
-        <> genExtraImport_ m
-    hsbootBody =
-      runReader (mapM (genHsFrontDecl True) [c]) M.empty
+        <> genExtraImport m
+    hsbootBody = []
+
+-- runReader (mapM (genHsFrontDecl True) [c]) M.empty
 
 buildCastHs :: ClassModule -> HsModule GhcPs
 buildCastHs m =

--- a/fficxx/src/FFICXX/Generate/Util/GHCExactPrint.hs
+++ b/fficxx/src/FFICXX/Generate/Util/GHCExactPrint.hs
@@ -37,6 +37,7 @@ module FFICXX.Generate.Util.GHCExactPrint
     cxEmpty,
     cxTuple,
     classA,
+    mkClass,
     mkInstance,
     mkTypeFamInst,
     instD,
@@ -71,7 +72,6 @@ module FFICXX.Generate.Util.GHCExactPrint
     pbind,
     pbind_,
     mkTBind,
-    mkClass,
     dhead,
     mkDeclHead,
     mkInstance,
@@ -224,6 +224,7 @@ import Language.Haskell.Syntax
     HsSigType (..),
     HsToken (..),
     HsTupleSort (..),
+    HsTyVarBndr,
     HsType (..),
     HsUniToken (..),
     HsWildCardBndrs (HsWC),
@@ -721,6 +722,29 @@ classA name typs = foldl' tyapp (tycon name) typs'
   where
     typs' = fmap tyParen typs
 
+mkClass ::
+  -- Context () ->
+  String ->
+  [HsTyVarBndr () GhcPs] ->
+  [HsBind GhcPs] ->
+  TyClDecl GhcPs
+mkClass {- ctxt -} name tbnds bnds =
+  ClassDecl
+    { tcdCExt = (mkRelEpAnn (-1) [], NoAnnSortKey),
+      tcdLayout = VirtualBraces 2,
+      tcdLName = mkLIdP (-1) name,
+      tcdTyVars = HsQTvs noExtField $ fmap (mkL (-1)) tbnds,
+      tcdFDs = [],
+      tcdSigs = [],
+      tcdMeths = listToBag $ fmap (mkL (-1)) bnds,
+      tcdATs = [],
+      tcdATDefs = [],
+      tcdDocs = []
+    }
+  where
+
+  --  (Just ctxt) (mkDeclHead n tbinds) [] (Just cdecls)
+
 mkInstance ::
   -- | Context
   HsContext GhcPs ->
@@ -1076,9 +1100,6 @@ pbind_ p e = pbind p e Nothing
 
 mkTBind :: String -> TyVarBind ()
 mkTBind = UnkindedVar () . Ident ()
-
-mkClass :: Context () -> String -> [TyVarBind ()] -> [ClassDecl ()] -> Decl ()
-mkClass ctxt n tbinds cdecls = ClassDecl () (Just ctxt) (mkDeclHead n tbinds) [] (Just cdecls)
 
 dhead :: String -> DeclHead ()
 dhead n = DHead () (Ident () n)


### PR DESCRIPTION
HsInterface and HsImplementation is fully converted.
Note: template member functions are disabled for now. will be reinstated in the following PRs.