### PR TITLE
Move top-level template codegen to HsTopLevel

### DIFF
--- a/fficxx/fficxx.cabal
+++ b/fficxx/fficxx.cabal
@@ -62,6 +62,7 @@ Library
                FFICXX.Generate.Code.HsInterface
                FFICXX.Generate.Code.HsProxy
                FFICXX.Generate.Code.HsRawType
+               FFICXX.Generate.Code.HsTH
                FFICXX.Generate.Code.HsTemplate
                FFICXX.Generate.Code.HsTopLevel
                FFICXX.Generate.Code.Cabal

--- a/fficxx/src/FFICXX/Generate/Code/HsImplementation.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsImplementation.hs
@@ -13,20 +13,29 @@ module FFICXX.Generate.Code.HsImplementation
     genHsFrontInstNonVirtual,
     genHsFrontInstStatic,
     genHsFrontInstVariables,
+
+    -- * template member functions
+    genTemplateMemberFunctions,
+    genTMFExp,
+    genTMFInstance,
   )
 where
 
 import Control.Monad.Reader (Reader)
+import qualified Data.List as L (foldr1)
 import FFICXX.Generate.Code.Primitive
   ( accessorSignature,
     cxx2HsType,
     functionSignature',
+    functionSignatureTMF,
     hsFuncXformer,
   )
 import FFICXX.Generate.Name
   ( accessorName,
     aliasedFuncName,
     hsFuncName,
+    hsTemplateMemberFunctionName,
+    hsTemplateMemberFunctionNameTH,
     hscAccessorName,
     hscFuncName,
     subModuleName,
@@ -36,6 +45,7 @@ import FFICXX.Generate.Type.Annotate (AnnotateMap)
 import FFICXX.Generate.Type.Class
   ( Accessor (..),
     Class (..),
+    TemplateMemberFunction (..),
     Types (..),
     isAbstractClass,
     isNewFunc,
@@ -43,7 +53,10 @@ import FFICXX.Generate.Type.Class
     staticFuncs,
     virtualFuncs,
   )
-import FFICXX.Generate.Type.Module (ClassModule (..))
+import FFICXX.Generate.Type.Module
+  ( ClassImportHeader (..),
+    ClassModule (..),
+  )
 import FFICXX.Generate.Util.GHCExactPrint
   ( app,
     cxEmpty,
@@ -54,7 +67,12 @@ import FFICXX.Generate.Util.GHCExactPrint
     mkInstance,
     mkVar,
   )
+import qualified FFICXX.Generate.Util.HaskellSrcExts as O hiding (app, doE, listE, qualStmt, strE)
+import FFICXX.Runtime.CodeGen.Cxx (HeaderName (..))
+import qualified FFICXX.Runtime.CodeGen.Cxx as R
 import GHC.Hs (GhcPs)
+import qualified Language.Haskell.Exts.Build as O hiding (op)
+import qualified Language.Haskell.Exts.Syntax as O
 import Language.Haskell.Syntax (HsDecl, ImportDecl)
 
 --
@@ -117,3 +135,121 @@ genHsFrontInstVariables c =
             (mkVar (hscAccessorName c v accessor))
      in mkFun (accessorName c v Getter) (accessorSignature c v Getter) [] (rhs Getter) Nothing
           <> mkFun (accessorName c v Setter) (accessorSignature c v Setter) [] (rhs Setter) Nothing
+
+--
+-- Template Member Function
+--
+
+genTemplateMemberFunctions :: ClassImportHeader -> [O.Decl ()]
+genTemplateMemberFunctions cih =
+  let c = cihClass cih
+   in concatMap (\f -> genTMFExp c f <> genTMFInstance cih f) (class_tmpl_funcs c)
+
+-- TODO: combine this with genTmplInstance
+genTMFExp :: Class -> TemplateMemberFunction -> [O.Decl ()]
+genTMFExp c f = O.mkFun nh sig (tvars_p ++ [p "suffix"]) rhs (Just bstmts)
+  where
+    nh = hsTemplateMemberFunctionNameTH c f
+    v = O.mkVar
+    p = O.mkPVar
+    itps = zip ([1 ..] :: [Int]) (tmf_params f)
+    tvars = map (\(i, _) -> "typ" ++ show i) itps
+    nparams = length itps
+    tparams = if nparams == 1 then O.tycon "Type" else O.tyTupleBoxed (replicate nparams (O.tycon "Type"))
+    sig = foldr1 O.tyfun [tparams, O.tycon "String", O.tyapp (O.tycon "Q") (O.tycon "Exp")]
+    tvars_p = if nparams == 1 then map p tvars else [O.pTuple (map p tvars)]
+    lit' = O.strE (hsTemplateMemberFunctionName c f <> "_")
+    lam = O.lamE [p "n"] (lit' `O.app` v "<>" `O.app` v "n")
+    rhs =
+      O.app (v "mkTFunc") $
+        let typs = if nparams == 1 then map v tvars else [O.tuple (map v tvars)]
+         in O.tuple (typs ++ [v "suffix", lam, v "tyf"])
+    sig' = functionSignatureTMF c f
+    tassgns = map (\(i, tp) -> O.pbind_ (p tp) (v "pure" `O.app` (v ("typ" ++ show i)))) itps
+    bstmts =
+      O.binds
+        [ O.mkBind1
+            "tyf"
+            [O.mkPVar "n"]
+            ( O.letE
+                tassgns
+                (O.bracketExp (O.typeBracket sig'))
+            )
+            Nothing
+        ]
+
+genTMFInstance :: ClassImportHeader -> TemplateMemberFunction -> [O.Decl ()]
+genTMFInstance cih f =
+  O.mkFun
+    fname
+    sig
+    [p "isCprim", O.pTuple [p "qtyp", p "param"]]
+    rhs
+    Nothing
+  where
+    c = cihClass cih
+    fname = "genInstanceFor_" <> hsTemplateMemberFunctionName c f
+    p = O.mkPVar
+    v = O.mkVar
+    sig =
+      O.tycon "IsCPrimitive"
+        `O.tyfun` O.tyTupleBoxed [O.tycon "Q" `O.tyapp` O.tycon "Type", O.tycon "TemplateParamInfo"]
+        `O.tyfun` (O.tycon "Q" `O.tyapp` O.tylist (O.tycon "Dec"))
+    rhs = O.doE [suffixstmt, qtypstmt, genstmt, foreignSrcStmt, O.letStmt lststmt, O.qualStmt retstmt]
+    suffixstmt = O.letStmt [O.pbind_ (p "suffix") (v "tpinfoSuffix" `O.app` v "param")]
+    qtypstmt = O.generator (p "typ") (v "qtyp")
+    genstmt =
+      O.generator
+        (p "f1")
+        ( v "mkMember"
+            `O.app` ( O.strE (hsTemplateMemberFunctionName c f <> "_")
+                        `O.app` v "<>"
+                        `O.app` v "suffix"
+                    )
+            `O.app` v (hsTemplateMemberFunctionNameTH c f)
+            `O.app` v "typ"
+            `O.app` v "suffix"
+        )
+    lststmt = [O.pbind_ (p "lst") (O.listE ([v "f1"]))]
+    retstmt = v "pure" `O.app` v "lst"
+    -- TODO: refactor out the following code.
+    foreignSrcStmt =
+      O.qualifier $
+        (v "addModFinalizer")
+          `O.app` ( v "addForeignSource"
+                      `O.app` O.con "LangCxx"
+                      `O.app` ( L.foldr1
+                                  (\x y -> O.inapp x (O.op "++") y)
+                                  [ includeStatic,
+                                    includeDynamic,
+                                    namespaceStr,
+                                    O.strE (hsTemplateMemberFunctionName c f),
+                                    O.strE "(",
+                                    v "suffix",
+                                    O.strE ")\n"
+                                  ]
+                              )
+                  )
+      where
+        includeStatic =
+          O.strE $
+            concatMap ((<> "\n") . R.renderCMacro . R.Include) $
+              [HdrName "MacroPatternMatch.h", cihSelfHeader cih]
+                <> cihIncludedHPkgHeadersInCPP cih
+                <> cihIncludedCPkgHeaders cih
+        includeDynamic =
+          O.letE
+            [ O.pbind_ (p "headers") (v "tpinfoCxxHeaders" `O.app` v "param"),
+              O.pbind_
+                (O.pApp (O.name "f") [p "x"])
+                (v "renderCMacro" `O.app` (O.con "Include" `O.app` v "x"))
+            ]
+            (v "concatMap" `O.app` v "f" `O.app` v "headers")
+        namespaceStr =
+          O.letE
+            [ O.pbind_ (p "nss") (v "tpinfoCxxNamespaces" `O.app` v "param"),
+              O.pbind_
+                (O.pApp (O.name "f") [p "x"])
+                (v "renderCStmt" `O.app` (O.con "UsingNamespace" `O.app` v "x"))
+            ]
+            (v "concatMap" `O.app` v "f" `O.app` v "nss")

--- a/fficxx/src/FFICXX/Generate/Code/HsTH.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTH.hs
@@ -1,0 +1,322 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module FFICXX.Generate.Code.HsTH
+  ( genImportInTH,
+    genTmplImplementation,
+    genTmplInstance,
+  )
+where
+
+import qualified Data.List as L (foldr1)
+import FFICXX.Generate.Code.Cpp
+  ( genTmplClassCpp,
+    genTmplFunCpp,
+    genTmplVarCpp,
+  )
+import FFICXX.Generate.Code.Primitive
+  ( functionSignatureTT,
+    tmplAccessorToTFun,
+  )
+import FFICXX.Generate.Dependency (calculateDependency)
+import FFICXX.Generate.Name
+  ( ffiTmplFuncName,
+    hsTmplFuncName,
+    hsTmplFuncNameTH,
+    subModuleName,
+    tmplAccessorName,
+    typeclassNameT,
+  )
+import FFICXX.Generate.Type.Class
+  ( Accessor (Getter, Setter),
+    Arg (..),
+    TemplateClass (..),
+    TemplateFunction (..),
+    Types (Void),
+    Variable (..),
+  )
+import FFICXX.Generate.Type.Module
+  ( TemplateClassImportHeader (..),
+    TemplateClassSubmoduleType (..),
+  )
+import FFICXX.Generate.Util.HaskellSrcExts
+  ( bracketExp,
+    con,
+    generator,
+    inapp,
+    match,
+    mkBind1,
+    mkFun,
+    mkImport,
+    mkPVar,
+    mkTBind,
+    mkVar,
+    op,
+    pbind_,
+    qualifier,
+    tyTupleBoxed,
+    tyapp,
+    tycon,
+    tyfun,
+    tylist,
+    typeBracket,
+  )
+import FFICXX.Runtime.CodeGen.Cxx (HeaderName (..))
+import qualified FFICXX.Runtime.CodeGen.Cxx as R
+import FFICXX.Runtime.TH (IsCPrimitive (CPrim, NonCPrim))
+import Language.Haskell.Exts.Build
+  ( app,
+    binds,
+    caseE,
+    doE,
+    lamE,
+    letE,
+    letStmt,
+    listE,
+    name,
+    pApp,
+    pTuple,
+    paren,
+    qualStmt,
+    strE,
+    tuple,
+    wildcard,
+  )
+import Language.Haskell.Exts.Syntax
+  ( Decl,
+    ImportDecl,
+  )
+
+genImportInTH :: TemplateClass -> [ImportDecl ()]
+genImportInTH t0 =
+  fmap (mkImport . subModuleName) $ calculateDependency $ Left (TCSTTH, t0)
+
+--
+-- implementation
+--
+
+genTmplImplementation :: TemplateClass -> [Decl ()]
+genTmplImplementation t =
+  concatMap gen (tclass_funcs t) ++ concatMap genV (tclass_vars t)
+  where
+    v = mkVar
+    p = mkPVar
+    itps = zip ([1 ..] :: [Int]) (tclass_params t)
+    tvars = map (\(i, _) -> "typ" ++ show i) itps
+    nparams = length itps
+    tparams = if nparams == 1 then tycon "Type" else tyTupleBoxed (replicate nparams (tycon "Type"))
+    sig = foldr1 tyfun [tparams, tycon "String", tyapp (tycon "Q") (tycon "Exp")]
+    tvars_p = if nparams == 1 then map p tvars else [pTuple (map p tvars)]
+    prefix = tclass_name t
+    gen f = mkFun nh sig (tvars_p ++ [p "suffix"]) rhs (Just bstmts)
+      where
+        nh = hsTmplFuncNameTH t f
+        nc = ffiTmplFuncName f
+        lit' = strE (prefix <> "_" <> nc)
+        lam = lamE [p "n"] (lit' `app` v "<>" `app` v "n")
+        rhs =
+          app (v "mkTFunc") $
+            let typs = if nparams == 1 then map v tvars else [tuple (map v tvars)]
+             in tuple (typs ++ [v "suffix", lam, v "tyf"])
+        sig' = functionSignatureTT t f
+        tassgns = map (\(i, tp) -> pbind_ (p tp) (v "pure" `app` (v ("typ" ++ show i)))) itps
+        bstmts =
+          binds
+            [ mkBind1
+                "tyf"
+                [wildcard]
+                ( letE
+                    tassgns
+                    (bracketExp (typeBracket sig'))
+                )
+                Nothing
+            ]
+    genV vf =
+      let f_g = tmplAccessorToTFun vf Getter
+          f_s = tmplAccessorToTFun vf Setter
+       in gen f_g ++ gen f_s
+
+genTmplInstance ::
+  TemplateClassImportHeader ->
+  [Decl ()]
+genTmplInstance tcih =
+  mkFun
+    fname
+    sig
+    (p "isCprim" : zipWith (\x y -> pTuple [p x, p y]) qtvars pvars)
+    rhs
+    Nothing
+  where
+    t = tcihTClass tcih
+    fs = tclass_funcs t
+    vfs = tclass_vars t
+    tname = tclass_name t
+    fname = "gen" <> tname <> "InstanceFor"
+    p = mkPVar
+    v = mkVar
+    itps = zip ([1 ..] :: [Int]) (tclass_params t)
+    tvars = map (\(i, _) -> "typ" ++ show i) itps
+    qtvars = map (\(i, _) -> "qtyp" ++ show i) itps
+    pvars = map (\(i, _) -> "param" ++ show i) itps
+    nparams = length itps
+    typs_v = if nparams == 1 then v (tvars !! 0) else tuple (map v tvars)
+    params_l = listE (map v pvars)
+    sig =
+      foldr1 tyfun $
+        [tycon "IsCPrimitive"]
+          ++ replicate
+            nparams
+            (tyTupleBoxed [tycon "Q" `tyapp` tycon "Type", tycon "TemplateParamInfo"])
+          ++ [tycon "Q" `tyapp` tylist (tycon "Dec")]
+    nfs = zip ([1 ..] :: [Int]) fs
+    nvfs = zip ([1 ..] :: [Int]) vfs
+    --------------------------
+    -- final RHS expression --
+    --------------------------
+    rhs =
+      doE
+        ( [paramsstmt, suffixstmt]
+            <> [ generator (p "callmod_") (v "fmap" `app` v "loc_module" `app` (v "location")),
+                 letStmt
+                   [ pbind_
+                       (p "callmod")
+                       (v "dot2_" `app` v "callmod_")
+                   ]
+               ]
+            <> map genqtypstmt (zip tvars qtvars)
+            <> map genstmt nfs
+            <> concatMap genvarstmt nvfs
+            <> [foreignSrcStmt, letStmt lststmt, qualStmt retstmt]
+        )
+    --------------------------
+    paramsstmt =
+      letStmt
+        [ pbind_
+            (p "params")
+            (v "map" `app` (v "tpinfoSuffix") `app` params_l)
+        ]
+    suffixstmt =
+      letStmt
+        [ pbind_
+            (p "suffix")
+            ( v "concatMap"
+                `app` (lamE [p "x"] (inapp (strE "_") (op "++") (v "tpinfoSuffix" `app` v "x")))
+                `app` params_l
+            )
+        ]
+    genqtypstmt (tvar, qtvar) = generator (p tvar) (v qtvar)
+    gen prefix nm f n =
+      generator
+        (p (prefix <> show n))
+        ( v nm
+            `app` strE (hsTmplFuncName t f)
+            `app` v (hsTmplFuncNameTH t f)
+            `app` typs_v
+            `app` v "suffix"
+        )
+    genstmt (n, f@TFun {}) = gen "f" "mkMember" f n
+    genstmt (n, f@TFunNew {}) = gen "f" "mkNew" f n
+    genstmt (n, f@TFunDelete) = gen "f" "mkDelete" f n
+    genstmt (n, f@TFunOp {}) = gen "f" "mkMember" f n
+    genvarstmt (n, vf) =
+      let Variable (Arg {..}) = vf
+          f_g =
+            TFun
+              { tfun_ret = arg_type,
+                tfun_name = tmplAccessorName vf Getter,
+                tfun_oname = tmplAccessorName vf Getter,
+                tfun_args = []
+              }
+          f_s =
+            TFun
+              { tfun_ret = Void,
+                tfun_name = tmplAccessorName vf Setter,
+                tfun_oname = tmplAccessorName vf Setter,
+                tfun_args = [Arg arg_type "value"]
+              }
+       in [ gen "vf" "mkMember" f_g (2 * n - 1),
+            gen "vf" "mkMember" f_s (2 * n)
+          ]
+    lststmt =
+      let mkElems prefix xs = map (v . (\n -> prefix <> show n) . fst) xs
+       in [ pbind_
+              (p "lst")
+              ( listE
+                  ( mkElems "f" nfs
+                      <> mkElems "vf" (concatMap (\(n, vf) -> [(2 * n - 1, vf), (2 * n, vf)]) nvfs)
+                  )
+              )
+          ]
+    -- TODO: refactor out the following code.
+    foreignSrcStmt =
+      qualifier $
+        (v "addModFinalizer")
+          `app` ( v "addForeignSource"
+                    `app` con "LangCxx"
+                    `app` ( L.foldr1
+                              (\x y -> inapp x (op "++") y)
+                              [ includeStatic,
+                                includeDynamic,
+                                namespaceStr,
+                                strE (tname <> "_instance"),
+                                paren $
+                                  caseE
+                                    (v "isCprim")
+                                    [ match (p "CPrim") (strE "_s"),
+                                      match (p "NonCPrim") (strE "")
+                                    ],
+                                strE "(",
+                                v "intercalate"
+                                  `app` strE ", "
+                                  `app` paren (inapp (v "callmod") (op ":") (v "params")),
+                                strE ")\n"
+                              ]
+                          )
+                )
+      where
+        -- temporary
+        body =
+          map R.renderCMacro $
+            map R.Include (tcihCxxHeaders tcih)
+              ++ map (genTmplFunCpp NonCPrim t) fs
+              ++ map (genTmplFunCpp CPrim t) fs
+              ++ concatMap (genTmplVarCpp NonCPrim t) vfs
+              ++ concatMap (genTmplVarCpp CPrim t) vfs
+              ++ [ genTmplClassCpp NonCPrim t (fs, vfs),
+                   genTmplClassCpp CPrim t (fs, vfs)
+                 ]
+        includeStatic =
+          strE $
+            concatMap
+              (<> "\n")
+              ( [R.renderCMacro (R.Include (HdrName "MacroPatternMatch.h"))]
+                  ++ body
+              )
+        cxxHeaders = v "concatMap" `app` (v "tpinfoCxxHeaders") `app` params_l
+        cxxNamespaces = v "concatMap" `app` (v "tpinfoCxxNamespaces") `app` params_l
+        includeDynamic =
+          letE
+            [ pbind_ (p "headers") cxxHeaders,
+              pbind_
+                (pApp (name "f") [p "x"])
+                (v "renderCMacro" `app` (con "Include" `app` v "x"))
+            ]
+            (v "concatMap" `app` v "f" `app` v "headers")
+        namespaceStr =
+          letE
+            [ pbind_ (p "nss") cxxNamespaces,
+              pbind_
+                (pApp (name "f") [p "x"])
+                (v "renderCStmt" `app` (con "UsingNamespace" `app` v "x"))
+            ]
+            (v "concatMap" `app` v "f" `app` v "nss")
+    retstmt =
+      v "pure"
+        `app` listE
+          [ v "mkInstance"
+              `app` listE []
+              `app` foldl1
+                (\f x -> con "AppT" `app` f `app` x)
+                (v "con" `app` strE (typeclassNameT t) : map v tvars)
+              `app` (v "lst")
+          ]

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -4,61 +4,38 @@
 module FFICXX.Generate.Code.HsTemplate
   ( genImportInTemplate,
     genTmplInterface,
-    genImportInTH,
-    genTmplImplementation,
-    genTmplInstance,
   )
 where
 
-import qualified Data.List as L (foldr1)
-import FFICXX.Generate.Code.Cpp
-  ( genTmplClassCpp,
-    genTmplFunCpp,
-    genTmplVarCpp,
-  )
 import FFICXX.Generate.Code.HsCast (castBody_)
 import FFICXX.Generate.Code.Primitive
   ( functionSignatureT,
-    functionSignatureTT,
     tmplAccessorToTFun,
   )
 import FFICXX.Generate.Dependency (calculateDependency)
 import FFICXX.Generate.Name
-  ( ffiTmplFuncName,
-    hsTemplateClassName,
+  ( hsTemplateClassName,
     hsTmplFuncName,
-    hsTmplFuncNameTH,
     subModuleName,
-    tmplAccessorName,
     typeclassNameT,
   )
 import FFICXX.Generate.Type.Class
   ( Accessor (Getter, Setter),
-    Arg (..),
     TemplateClass (..),
-    TemplateFunction (..),
-    Types (Void),
-    Variable (..),
   )
 import FFICXX.Generate.Type.Module
-  ( TemplateClassImportHeader (..),
-    TemplateClassSubmoduleType (..),
+  ( TemplateClassSubmoduleType (..),
   )
 import FFICXX.Generate.Util.HaskellSrcExts
-  ( bracketExp,
-    clsDecl,
+  ( clsDecl,
     con,
     conDecl,
     cxEmpty,
-    generator,
-    inapp,
     insDecl,
     insType,
-    match,
     mkBind1,
     mkClass,
     mkData,
-    mkFun,
     mkFunSig,
     mkImport,
     mkInstance,
@@ -67,59 +44,23 @@ import FFICXX.Generate.Util.HaskellSrcExts
     mkTBind,
     mkTVar,
     mkVar,
-    op,
-    pbind_,
     qualConDecl,
-    qualifier,
     tyPtr,
-    tyTupleBoxed,
     tyapp,
     tycon,
-    tyfun,
-    tylist,
-    typeBracket,
   )
-import FFICXX.Runtime.CodeGen.Cxx (HeaderName (..))
-import qualified FFICXX.Runtime.CodeGen.Cxx as R
-import FFICXX.Runtime.TH (IsCPrimitive (CPrim, NonCPrim))
 import Language.Haskell.Exts.Build
-  ( app,
-    binds,
-    caseE,
-    doE,
-    lamE,
-    letE,
-    letStmt,
-    listE,
-    name,
+  ( name,
     pApp,
-    pTuple,
-    paren,
-    qualStmt,
-    strE,
-    tuple,
-    wildcard,
   )
 import Language.Haskell.Exts.Syntax
   ( Decl,
     ImportDecl,
   )
 
---
--- imports
---
-
 genImportInTemplate :: TemplateClass -> [ImportDecl ()]
 genImportInTemplate t0 =
   fmap (mkImport . subModuleName) $ calculateDependency $ Left (TCSTTemplate, t0)
-
-genImportInTH :: TemplateClass -> [ImportDecl ()]
-genImportInTH t0 =
-  fmap (mkImport . subModuleName) $ calculateDependency $ Left (TCSTTH, t0)
-
---
--- interface
---
 
 genTmplInterface :: TemplateClass -> [Decl ()]
 genTmplInterface t =
@@ -151,233 +92,3 @@ genTmplInterface t =
         insDecl (mkBind1 "get_fptr" [pApp (name hname) [mkPVar "ptr"]] (mkVar "ptr") Nothing),
         insDecl (mkBind1 "cast_fptr_to_obj" [] (con hname) Nothing)
       ]
-
---
--- implementation
---
-
-genTmplImplementation :: TemplateClass -> [Decl ()]
-genTmplImplementation t =
-  concatMap gen (tclass_funcs t) ++ concatMap genV (tclass_vars t)
-  where
-    v = mkVar
-    p = mkPVar
-    itps = zip ([1 ..] :: [Int]) (tclass_params t)
-    tvars = map (\(i, _) -> "typ" ++ show i) itps
-    nparams = length itps
-    tparams = if nparams == 1 then tycon "Type" else tyTupleBoxed (replicate nparams (tycon "Type"))
-    sig = foldr1 tyfun [tparams, tycon "String", tyapp (tycon "Q") (tycon "Exp")]
-    tvars_p = if nparams == 1 then map p tvars else [pTuple (map p tvars)]
-    prefix = tclass_name t
-    gen f = mkFun nh sig (tvars_p ++ [p "suffix"]) rhs (Just bstmts)
-      where
-        nh = hsTmplFuncNameTH t f
-        nc = ffiTmplFuncName f
-        lit' = strE (prefix <> "_" <> nc)
-        lam = lamE [p "n"] (lit' `app` v "<>" `app` v "n")
-        rhs =
-          app (v "mkTFunc") $
-            let typs = if nparams == 1 then map v tvars else [tuple (map v tvars)]
-             in tuple (typs ++ [v "suffix", lam, v "tyf"])
-        sig' = functionSignatureTT t f
-        tassgns = map (\(i, tp) -> pbind_ (p tp) (v "pure" `app` (v ("typ" ++ show i)))) itps
-        bstmts =
-          binds
-            [ mkBind1
-                "tyf"
-                [wildcard]
-                ( letE
-                    tassgns
-                    (bracketExp (typeBracket sig'))
-                )
-                Nothing
-            ]
-    genV vf =
-      let f_g = tmplAccessorToTFun vf Getter
-          f_s = tmplAccessorToTFun vf Setter
-       in gen f_g ++ gen f_s
-
-genTmplInstance ::
-  TemplateClassImportHeader ->
-  [Decl ()]
-genTmplInstance tcih =
-  mkFun
-    fname
-    sig
-    (p "isCprim" : zipWith (\x y -> pTuple [p x, p y]) qtvars pvars)
-    rhs
-    Nothing
-  where
-    t = tcihTClass tcih
-    fs = tclass_funcs t
-    vfs = tclass_vars t
-    tname = tclass_name t
-    fname = "gen" <> tname <> "InstanceFor"
-    p = mkPVar
-    v = mkVar
-    itps = zip ([1 ..] :: [Int]) (tclass_params t)
-    tvars = map (\(i, _) -> "typ" ++ show i) itps
-    qtvars = map (\(i, _) -> "qtyp" ++ show i) itps
-    pvars = map (\(i, _) -> "param" ++ show i) itps
-    nparams = length itps
-    typs_v = if nparams == 1 then v (tvars !! 0) else tuple (map v tvars)
-    params_l = listE (map v pvars)
-    sig =
-      foldr1 tyfun $
-        [tycon "IsCPrimitive"]
-          ++ replicate
-            nparams
-            (tyTupleBoxed [tycon "Q" `tyapp` tycon "Type", tycon "TemplateParamInfo"])
-          ++ [tycon "Q" `tyapp` tylist (tycon "Dec")]
-    nfs = zip ([1 ..] :: [Int]) fs
-    nvfs = zip ([1 ..] :: [Int]) vfs
-    --------------------------
-    -- final RHS expression --
-    --------------------------
-    rhs =
-      doE
-        ( [paramsstmt, suffixstmt]
-            <> [ generator (p "callmod_") (v "fmap" `app` v "loc_module" `app` (v "location")),
-                 letStmt
-                   [ pbind_
-                       (p "callmod")
-                       (v "dot2_" `app` v "callmod_")
-                   ]
-               ]
-            <> map genqtypstmt (zip tvars qtvars)
-            <> map genstmt nfs
-            <> concatMap genvarstmt nvfs
-            <> [foreignSrcStmt, letStmt lststmt, qualStmt retstmt]
-        )
-    --------------------------
-    paramsstmt =
-      letStmt
-        [ pbind_
-            (p "params")
-            (v "map" `app` (v "tpinfoSuffix") `app` params_l)
-        ]
-    suffixstmt =
-      letStmt
-        [ pbind_
-            (p "suffix")
-            ( v "concatMap"
-                `app` (lamE [p "x"] (inapp (strE "_") (op "++") (v "tpinfoSuffix" `app` v "x")))
-                `app` params_l
-            )
-        ]
-    genqtypstmt (tvar, qtvar) = generator (p tvar) (v qtvar)
-    gen prefix nm f n =
-      generator
-        (p (prefix <> show n))
-        ( v nm
-            `app` strE (hsTmplFuncName t f)
-            `app` v (hsTmplFuncNameTH t f)
-            `app` typs_v
-            `app` v "suffix"
-        )
-    genstmt (n, f@TFun {}) = gen "f" "mkMember" f n
-    genstmt (n, f@TFunNew {}) = gen "f" "mkNew" f n
-    genstmt (n, f@TFunDelete) = gen "f" "mkDelete" f n
-    genstmt (n, f@TFunOp {}) = gen "f" "mkMember" f n
-    genvarstmt (n, vf) =
-      let Variable (Arg {..}) = vf
-          f_g =
-            TFun
-              { tfun_ret = arg_type,
-                tfun_name = tmplAccessorName vf Getter,
-                tfun_oname = tmplAccessorName vf Getter,
-                tfun_args = []
-              }
-          f_s =
-            TFun
-              { tfun_ret = Void,
-                tfun_name = tmplAccessorName vf Setter,
-                tfun_oname = tmplAccessorName vf Setter,
-                tfun_args = [Arg arg_type "value"]
-              }
-       in [ gen "vf" "mkMember" f_g (2 * n - 1),
-            gen "vf" "mkMember" f_s (2 * n)
-          ]
-    lststmt =
-      let mkElems prefix xs = map (v . (\n -> prefix <> show n) . fst) xs
-       in [ pbind_
-              (p "lst")
-              ( listE
-                  ( mkElems "f" nfs
-                      <> mkElems "vf" (concatMap (\(n, vf) -> [(2 * n - 1, vf), (2 * n, vf)]) nvfs)
-                  )
-              )
-          ]
-    -- TODO: refactor out the following code.
-    foreignSrcStmt =
-      qualifier $
-        (v "addModFinalizer")
-          `app` ( v "addForeignSource"
-                    `app` con "LangCxx"
-                    `app` ( L.foldr1
-                              (\x y -> inapp x (op "++") y)
-                              [ includeStatic,
-                                includeDynamic,
-                                namespaceStr,
-                                strE (tname <> "_instance"),
-                                paren $
-                                  caseE
-                                    (v "isCprim")
-                                    [ match (p "CPrim") (strE "_s"),
-                                      match (p "NonCPrim") (strE "")
-                                    ],
-                                strE "(",
-                                v "intercalate"
-                                  `app` strE ", "
-                                  `app` paren (inapp (v "callmod") (op ":") (v "params")),
-                                strE ")\n"
-                              ]
-                          )
-                )
-      where
-        -- temporary
-        body =
-          map R.renderCMacro $
-            map R.Include (tcihCxxHeaders tcih)
-              ++ map (genTmplFunCpp NonCPrim t) fs
-              ++ map (genTmplFunCpp CPrim t) fs
-              ++ concatMap (genTmplVarCpp NonCPrim t) vfs
-              ++ concatMap (genTmplVarCpp CPrim t) vfs
-              ++ [ genTmplClassCpp NonCPrim t (fs, vfs),
-                   genTmplClassCpp CPrim t (fs, vfs)
-                 ]
-        includeStatic =
-          strE $
-            concatMap
-              (<> "\n")
-              ( [R.renderCMacro (R.Include (HdrName "MacroPatternMatch.h"))]
-                  ++ body
-              )
-        cxxHeaders = v "concatMap" `app` (v "tpinfoCxxHeaders") `app` params_l
-        cxxNamespaces = v "concatMap" `app` (v "tpinfoCxxNamespaces") `app` params_l
-        includeDynamic =
-          letE
-            [ pbind_ (p "headers") cxxHeaders,
-              pbind_
-                (pApp (name "f") [p "x"])
-                (v "renderCMacro" `app` (con "Include" `app` v "x"))
-            ]
-            (v "concatMap" `app` v "f" `app` v "headers")
-        namespaceStr =
-          letE
-            [ pbind_ (p "nss") cxxNamespaces,
-              pbind_
-                (pApp (name "f") [p "x"])
-                (v "renderCStmt" `app` (con "UsingNamespace" `app` v "x"))
-            ]
-            (v "concatMap" `app` v "f" `app` v "nss")
-    retstmt =
-      v "pure"
-        `app` listE
-          [ v "mkInstance"
-              `app` listE []
-              `app` foldl1
-                (\f x -> con "AppT" `app` f `app` x)
-                (v "con" `app` strE (typeclassNameT t) : map v tvars)
-              `app` (v "lst")
-          ]

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -1,20 +1,27 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module FFICXX.Generate.Code.HsTemplate where
+module FFICXX.Generate.Code.HsTemplate
+  ( genTemplateMemberFunctions,
+    genTMFExp,
+    genTMFInstance,
+    genImportInTemplate,
+    genTmplInterface,
+    genImportInTH,
+    genTmplImplementation,
+    genTmplInstance,
+  )
+where
 
 import qualified Data.List as L (foldr1)
 import FFICXX.Generate.Code.Cpp
-  ( genTLTmplFunCpp,
-    genTmplClassCpp,
+  ( genTmplClassCpp,
     genTmplFunCpp,
     genTmplVarCpp,
   )
 import FFICXX.Generate.Code.HsCast (castBody_)
 import FFICXX.Generate.Code.Primitive
-  ( convertCpp2HS,
-    convertCpp2HS4Tmpl,
-    functionSignatureT,
+  ( functionSignatureT,
     functionSignatureTMF,
     functionSignatureTT,
     tmplAccessorToTFun,
@@ -35,7 +42,6 @@ import FFICXX.Generate.Type.Class
   ( Accessor (Getter, Setter),
     Arg (..),
     Class (..),
-    TLTemplate (..),
     TemplateClass (..),
     TemplateFunction (..),
     TemplateMemberFunction (..),
@@ -46,9 +52,7 @@ import FFICXX.Generate.Type.Module
   ( ClassImportHeader (..),
     TemplateClassImportHeader (..),
     TemplateClassSubmoduleType (..),
-    TopLevelImportHeader (..),
   )
-import FFICXX.Generate.Util (firstUpper)
 import FFICXX.Generate.Util.HaskellSrcExts
   ( bracketExp,
     clsDecl,
@@ -73,12 +77,10 @@ import FFICXX.Generate.Util.HaskellSrcExts
     mkTVar,
     mkVar,
     op,
-    parenSplice,
     pbind_,
     qualConDecl,
     qualifier,
     tyPtr,
-    tySplice,
     tyTupleBoxed,
     tyapp,
     tycon,
@@ -496,212 +498,5 @@ genTmplInstance tcih =
               `app` foldl1
                 (\f x -> con "AppT" `app` f `app` x)
                 (v "con" `app` strE (typeclassNameT t) : map v tvars)
-              `app` (v "lst")
-          ]
-
----------------
--- top-level --
----------------
-
-genTLTemplateInterface :: TLTemplate -> [Decl ()]
-genTLTemplateInterface t =
-  [ mkClass cxEmpty (firstUpper (topleveltfunc_name t)) (map mkTBind tps) methods
-  ]
-  where
-    tps = topleveltfunc_params t
-    ctyp = convertCpp2HS Nothing (topleveltfunc_ret t)
-    lst = map (convertCpp2HS Nothing . arg_type) (topleveltfunc_args t)
-    sigdecl = mkFunSig (topleveltfunc_name t) $ foldr1 tyfun (lst <> [tyapp (tycon "IO") ctyp])
-    methods = [clsDecl sigdecl]
-
-genTLTemplateImplementation :: TLTemplate -> [Decl ()]
-genTLTemplateImplementation t =
-  mkFun nh sig (tvars_p ++ [p "suffix"]) rhs (Just bstmts)
-  where
-    v = mkVar
-    p = mkPVar
-    itps = zip ([1 ..] :: [Int]) (topleveltfunc_params t)
-    tvars = map (\(i, _) -> "typ" ++ show i) itps
-    nparams = length itps
-    tparams = if nparams == 1 then tycon "Type" else tyTupleBoxed (replicate nparams (tycon "Type"))
-    sig = foldr1 tyfun [tparams, tycon "String", tyapp (tycon "Q") (tycon "Exp")]
-    tvars_p = if nparams == 1 then map p tvars else [pTuple (map p tvars)]
-    prefix = "TL"
-    nh = "t_" <> topleveltfunc_name t
-    nc = topleveltfunc_name t
-    lit' = strE (prefix <> "_" <> nc)
-    lam = lamE [p "n"] (lit' `app` v "<>" `app` v "n")
-    rhs =
-      app (v "mkTFunc") $
-        let typs = if nparams == 1 then map v tvars else [tuple (map v tvars)]
-         in tuple (typs ++ [v "suffix", lam, v "tyf"])
-    sig' =
-      let e = error "genTLTemplateImplementation"
-          spls = map (tySplice . parenSplice . mkVar) $ topleveltfunc_params t
-          ctyp = convertCpp2HS4Tmpl e Nothing spls (topleveltfunc_ret t)
-          lst = map (convertCpp2HS4Tmpl e Nothing spls . arg_type) (topleveltfunc_args t)
-       in foldr1 tyfun (lst <> [tyapp (tycon "IO") ctyp])
-    tassgns = map (\(i, tp) -> pbind_ (p tp) (v "pure" `app` (v ("typ" ++ show i)))) itps
-    bstmts =
-      binds
-        [ mkBind1
-            "tyf"
-            [wildcard]
-            ( letE
-                tassgns
-                (bracketExp (typeBracket sig'))
-            )
-            Nothing
-        ]
-
-genTLTemplateInstance ::
-  TopLevelImportHeader ->
-  TLTemplate ->
-  [Decl ()]
-genTLTemplateInstance tih t =
-  mkFun
-    fname
-    sig
-    (p "isCprim" : zipWith (\x y -> pTuple [p x, p y]) qtvars pvars)
-    rhs
-    Nothing
-  where
-    p = mkPVar
-    v = mkVar
-    tcname = firstUpper (topleveltfunc_name t)
-    fname = "gen" <> tcname <> "InstanceFor"
-    itps = zip ([1 ..] :: [Int]) (topleveltfunc_params t)
-    tvars = map (\(i, _) -> "typ" ++ show i) itps
-    qtvars = map (\(i, _) -> "qtyp" ++ show i) itps
-    pvars = map (\(i, _) -> "param" ++ show i) itps
-    nparams = length itps
-    typs_v = if nparams == 1 then v (tvars !! 0) else tuple (map v tvars)
-    params_l = listE (map v pvars)
-    sig =
-      foldr1 tyfun $
-        [tycon "IsCPrimitive"]
-          ++ replicate
-            nparams
-            (tyTupleBoxed [tycon "Q" `tyapp` tycon "Type", tycon "TemplateParamInfo"])
-          ++ [tycon "Q" `tyapp` tylist (tycon "Dec")]
-    -- nvfs = zip ([1..] :: [Int]) vfs
-
-    --------------------------
-    -- final RHS expression --
-    --------------------------
-    rhs =
-      doE
-        ( [paramsstmt, suffixstmt]
-            <> [ generator (p "callmod_") (v "fmap" `app` v "loc_module" `app` (v "location")),
-                 letStmt
-                   [ pbind_
-                       (p "callmod")
-                       (v "dot2_" `app` v "callmod_")
-                   ]
-               ]
-            <> map genqtypstmt (zip tvars qtvars)
-            <> [genstmt "f" (1 :: Int)]
-            <> [ foreignSrcStmt,
-                 letStmt lststmt,
-                 qualStmt retstmt
-               ]
-        )
-    --------------------------
-    paramsstmt =
-      letStmt
-        [ pbind_
-            (p "params")
-            (v "map" `app` (v "tpinfoSuffix") `app` params_l)
-        ]
-    suffixstmt =
-      letStmt
-        [ pbind_
-            (p "suffix")
-            ( v "concatMap"
-                `app` (lamE [p "x"] (inapp (strE "_") (op "++") (v "tpinfoSuffix" `app` v "x")))
-                `app` params_l
-            )
-        ]
-    genqtypstmt (tvar, qtvar) = generator (p tvar) (v qtvar)
-    genstmt prefix n =
-      generator
-        (p (prefix <> show n))
-        ( v "mkFunc"
-            `app` strE (topleveltfunc_name t)
-            `app` v ("t_" <> topleveltfunc_name t)
-            `app` typs_v
-            `app` v "suffix"
-        )
-    lststmt = [pbind_ (p "lst") (listE [v "f1"])]
-    -- TODO: refactor out the following code.
-    foreignSrcStmt =
-      qualifier $
-        (v "addModFinalizer")
-          `app` ( v "addForeignSource"
-                    `app` con "LangCxx"
-                    `app` ( L.foldr1
-                              (\x y -> inapp x (op "++") y)
-                              [ includeStatic,
-                                {-                        , includeDynamic
-                                                        , namespaceStr -}
-                                strE (tcname <> "_instance"),
-                                paren $
-                                  caseE
-                                    (v "isCprim")
-                                    [ match (p "CPrim") (strE "_s"),
-                                      match (p "NonCPrim") (strE "")
-                                    ],
-                                strE "(",
-                                v "intercalate"
-                                  `app` strE ", "
-                                  `app` paren (inapp (v "callmod") (op ":") (v "params")),
-                                strE ")\n"
-                              ]
-                          )
-                )
-      where
-        -- temporary
-        includeStatic =
-          strE $
-            concatMap
-              (<> "\n")
-              ( [R.renderCMacro (R.Include (HdrName "MacroPatternMatch.h"))]
-                  ++ map
-                    R.renderCMacro
-                    ( map R.Include (tihExtraHeadersInCPP tih)
-                        ++ [genTLTmplFunCpp CPrim t, genTLTmplFunCpp NonCPrim t]
-                    )
-              )
-    {-
-    cxxHeaders = v "concatMap" `app` (v "tpinfoCxxHeaders") `app` params_l
-    cxxNamespaces = v "concatMap" `app` (v "tpinfoCxxNamespaces") `app` params_l
-
-    includeDynamic =
-      letE
-        [ pbind_ (p "headers") cxxHeaders,
-          pbind_
-            (pApp (name "f") [p "x"])
-            (v "renderCMacro" `app` (con "Include" `app` v "x"))
-        ]
-        (v "concatMap" `app` v "f" `app` v "headers")
-
-    namespaceStr =
-      letE
-        [ pbind_ (p "nss") cxxNamespaces,
-          pbind_
-            (pApp (name "f") [p "x"])
-            (v "renderCStmt" `app` (con "UsingNamespace" `app` v "x"))
-        ]
-        (v "concatMap" `app` v "f" `app` v "nss")
-    -}
-    retstmt =
-      v "pure"
-        `app` listE
-          [ v "mkInstance"
-              `app` listE []
-              -- `app` (v "con" `app` strE tcname)
-              `app` foldl1
-                (\f x -> con "AppT" `app` f `app` x)
-                (v "con" `app` strE tcname : map v tvars)
               `app` (v "lst")
           ]

--- a/fficxx/src/FFICXX/Generate/Code/HsTopLevel.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTopLevel.hs
@@ -15,15 +15,24 @@ module FFICXX.Generate.Code.HsTopLevel
     genTopLevelDef,
     genImportForTLOrdinary,
     genImportForTLTemplate,
+
+    -- * toplevel template
+    genTLTemplateInterface,
+    genTLTemplateImplementation,
+    genTLTemplateInstance,
   )
 where
 
 import Data.Either (lefts, rights)
 import qualified Data.List as L
+import FFICXX.Generate.Code.Cpp
+  ( genTLTmplFunCpp,
+  )
 import FFICXX.Generate.Code.Primitive
   ( CFunSig (..),
     HsFunSig (..),
     convertCpp2HS,
+    convertCpp2HS4Tmpl,
     extractArgRetTypes,
   )
 import FFICXX.Generate.Dependency
@@ -40,10 +49,19 @@ import FFICXX.Generate.Name
     hsFrontNameForTopLevel,
     typeclassName,
   )
-import FFICXX.Generate.Type.Class
+{- import FFICXX.Generate.Type.Class
   ( Class (..),
+    TemplateClass (..),
+    TemplateFunction (..),
+    TemplateMemberFunction (..),
+    Types (Void),
+    Variable (..),
+  ) -}
+import FFICXX.Generate.Type.Class
+  ( Arg (..),
+    Class (..),
     TLOrdinary (..),
-    TLTemplate,
+    TLTemplate (..),
     TopLevel (TLOrdinary),
     constructorFuncs,
     isAbstractClass,
@@ -54,25 +72,64 @@ import FFICXX.Generate.Type.Class
 import FFICXX.Generate.Type.Module
   ( ClassModule (..),
     TemplateClassModule (..),
+    TopLevelImportHeader (..),
   )
-import FFICXX.Generate.Util (toLowers)
+import FFICXX.Generate.Util (firstUpper, toLowers)
 --
 import FFICXX.Generate.Util.HaskellSrcExts
-  ( cxTuple,
+  ( bracketExp,
+    clsDecl,
+    con,
+    cxEmpty,
+    cxTuple,
     eabs,
     ethingall,
     evar,
+    generator,
+    inapp,
+    listE,
+    match,
+    mkBind1,
+    mkClass,
     mkFun,
+    mkFunSig,
     mkImport,
+    mkPVar,
+    mkTBind,
     mkVar,
     nonamespace,
+    op,
+    parenSplice,
+    pbind_,
+    qualifier,
+    strE,
     tyForall,
+    tySplice,
+    tyTupleBoxed,
     tyapp,
     tycon,
     tyfun,
+    tylist,
+    typeBracket,
     unqual,
   )
-import Language.Haskell.Exts.Build (app)
+import FFICXX.Runtime.CodeGen.Cxx (HeaderName (..))
+import qualified FFICXX.Runtime.CodeGen.Cxx as R
+import FFICXX.Runtime.TH (IsCPrimitive (CPrim, NonCPrim))
+import Language.Haskell.Exts.Build
+  ( app,
+    binds,
+    caseE,
+    doE,
+    lamE,
+    letE,
+    letStmt,
+    pTuple,
+    paren,
+    qualStmt,
+    tuple,
+    wildcard,
+  )
 import Language.Haskell.Exts.Syntax
   ( Decl,
     ExportSpec,
@@ -191,3 +248,210 @@ genImportForTLTemplate f =
       tmods = L.nub $ map getTClassModuleBase $ lefts ecs
    in concatMap (\x -> map (\y -> mkImport (x <.> y)) ["RawType", "Cast", "Interface"]) cmods
         <> concatMap (\x -> map (\y -> mkImport (x <.> y)) ["Template"]) tmods
+
+--
+-- top-level template
+--
+
+genTLTemplateInterface :: TLTemplate -> [Decl ()]
+genTLTemplateInterface t =
+  [ mkClass cxEmpty (firstUpper (topleveltfunc_name t)) (map mkTBind tps) methods
+  ]
+  where
+    tps = topleveltfunc_params t
+    ctyp = convertCpp2HS Nothing (topleveltfunc_ret t)
+    lst = map (convertCpp2HS Nothing . arg_type) (topleveltfunc_args t)
+    sigdecl = mkFunSig (topleveltfunc_name t) $ foldr1 tyfun (lst <> [tyapp (tycon "IO") ctyp])
+    methods = [clsDecl sigdecl]
+
+genTLTemplateImplementation :: TLTemplate -> [Decl ()]
+genTLTemplateImplementation t =
+  mkFun nh sig (tvars_p ++ [p "suffix"]) rhs (Just bstmts)
+  where
+    v = mkVar
+    p = mkPVar
+    itps = zip ([1 ..] :: [Int]) (topleveltfunc_params t)
+    tvars = map (\(i, _) -> "typ" ++ show i) itps
+    nparams = length itps
+    tparams = if nparams == 1 then tycon "Type" else tyTupleBoxed (replicate nparams (tycon "Type"))
+    sig = foldr1 tyfun [tparams, tycon "String", tyapp (tycon "Q") (tycon "Exp")]
+    tvars_p = if nparams == 1 then map p tvars else [pTuple (map p tvars)]
+    prefix = "TL"
+    nh = "t_" <> topleveltfunc_name t
+    nc = topleveltfunc_name t
+    lit' = strE (prefix <> "_" <> nc)
+    lam = lamE [p "n"] (lit' `app` v "<>" `app` v "n")
+    rhs =
+      app (v "mkTFunc") $
+        let typs = if nparams == 1 then map v tvars else [tuple (map v tvars)]
+         in tuple (typs ++ [v "suffix", lam, v "tyf"])
+    sig' =
+      let e = error "genTLTemplateImplementation"
+          spls = map (tySplice . parenSplice . mkVar) $ topleveltfunc_params t
+          ctyp = convertCpp2HS4Tmpl e Nothing spls (topleveltfunc_ret t)
+          lst = map (convertCpp2HS4Tmpl e Nothing spls . arg_type) (topleveltfunc_args t)
+       in foldr1 tyfun (lst <> [tyapp (tycon "IO") ctyp])
+    tassgns = map (\(i, tp) -> pbind_ (p tp) (v "pure" `app` (v ("typ" ++ show i)))) itps
+    bstmts =
+      binds
+        [ mkBind1
+            "tyf"
+            [wildcard]
+            ( letE
+                tassgns
+                (bracketExp (typeBracket sig'))
+            )
+            Nothing
+        ]
+
+genTLTemplateInstance ::
+  TopLevelImportHeader ->
+  TLTemplate ->
+  [Decl ()]
+genTLTemplateInstance tih t =
+  mkFun
+    fname
+    sig
+    (p "isCprim" : zipWith (\x y -> pTuple [p x, p y]) qtvars pvars)
+    rhs
+    Nothing
+  where
+    p = mkPVar
+    v = mkVar
+    tcname = firstUpper (topleveltfunc_name t)
+    fname = "gen" <> tcname <> "InstanceFor"
+    itps = zip ([1 ..] :: [Int]) (topleveltfunc_params t)
+    tvars = map (\(i, _) -> "typ" ++ show i) itps
+    qtvars = map (\(i, _) -> "qtyp" ++ show i) itps
+    pvars = map (\(i, _) -> "param" ++ show i) itps
+    nparams = length itps
+    typs_v = if nparams == 1 then v (tvars !! 0) else tuple (map v tvars)
+    params_l = listE (map v pvars)
+    sig =
+      foldr1 tyfun $
+        [tycon "IsCPrimitive"]
+          ++ replicate
+            nparams
+            (tyTupleBoxed [tycon "Q" `tyapp` tycon "Type", tycon "TemplateParamInfo"])
+          ++ [tycon "Q" `tyapp` tylist (tycon "Dec")]
+    -- nvfs = zip ([1..] :: [Int]) vfs
+
+    --------------------------
+    -- final RHS expression --
+    --------------------------
+    rhs =
+      doE
+        ( [paramsstmt, suffixstmt]
+            <> [ generator (p "callmod_") (v "fmap" `app` v "loc_module" `app` (v "location")),
+                 letStmt
+                   [ pbind_
+                       (p "callmod")
+                       (v "dot2_" `app` v "callmod_")
+                   ]
+               ]
+            <> map genqtypstmt (zip tvars qtvars)
+            <> [genstmt "f" (1 :: Int)]
+            <> [ foreignSrcStmt,
+                 letStmt lststmt,
+                 qualStmt retstmt
+               ]
+        )
+    --------------------------
+    paramsstmt =
+      letStmt
+        [ pbind_
+            (p "params")
+            (v "map" `app` (v "tpinfoSuffix") `app` params_l)
+        ]
+    suffixstmt =
+      letStmt
+        [ pbind_
+            (p "suffix")
+            ( v "concatMap"
+                `app` (lamE [p "x"] (inapp (strE "_") (op "++") (v "tpinfoSuffix" `app` v "x")))
+                `app` params_l
+            )
+        ]
+    genqtypstmt (tvar, qtvar) = generator (p tvar) (v qtvar)
+    genstmt prefix n =
+      generator
+        (p (prefix <> show n))
+        ( v "mkFunc"
+            `app` strE (topleveltfunc_name t)
+            `app` v ("t_" <> topleveltfunc_name t)
+            `app` typs_v
+            `app` v "suffix"
+        )
+    lststmt = [pbind_ (p "lst") (listE [v "f1"])]
+    -- TODO: refactor out the following code.
+    foreignSrcStmt =
+      qualifier $
+        (v "addModFinalizer")
+          `app` ( v "addForeignSource"
+                    `app` con "LangCxx"
+                    `app` ( L.foldr1
+                              (\x y -> inapp x (op "++") y)
+                              [ includeStatic,
+                                {-                        , includeDynamic
+                                                        , namespaceStr -}
+                                strE (tcname <> "_instance"),
+                                paren $
+                                  caseE
+                                    (v "isCprim")
+                                    [ match (p "CPrim") (strE "_s"),
+                                      match (p "NonCPrim") (strE "")
+                                    ],
+                                strE "(",
+                                v "intercalate"
+                                  `app` strE ", "
+                                  `app` paren (inapp (v "callmod") (op ":") (v "params")),
+                                strE ")\n"
+                              ]
+                          )
+                )
+      where
+        -- temporary
+        includeStatic =
+          strE $
+            concatMap
+              (<> "\n")
+              ( [R.renderCMacro (R.Include (HdrName "MacroPatternMatch.h"))]
+                  ++ map
+                    R.renderCMacro
+                    ( map R.Include (tihExtraHeadersInCPP tih)
+                        ++ [genTLTmplFunCpp CPrim t, genTLTmplFunCpp NonCPrim t]
+                    )
+              )
+    {-
+    cxxHeaders = v "concatMap" `app` (v "tpinfoCxxHeaders") `app` params_l
+    cxxNamespaces = v "concatMap" `app` (v "tpinfoCxxNamespaces") `app` params_l
+
+    includeDynamic =
+      letE
+        [ pbind_ (p "headers") cxxHeaders,
+          pbind_
+            (pApp (name "f") [p "x"])
+            (v "renderCMacro" `app` (con "Include" `app` v "x"))
+        ]
+        (v "concatMap" `app` v "f" `app` v "headers")
+
+    namespaceStr =
+      letE
+        [ pbind_ (p "nss") cxxNamespaces,
+          pbind_
+            (pApp (name "f") [p "x"])
+            (v "renderCStmt" `app` (con "UsingNamespace" `app` v "x"))
+        ]
+        (v "concatMap" `app` v "f" `app` v "nss")
+    -}
+    retstmt =
+      v "pure"
+        `app` listE
+          [ v "mkInstance"
+              `app` listE []
+              -- `app` (v "con" `app` strE tcname)
+              `app` foldl1
+                (\f x -> con "AppT" `app` f `app` x)
+                (v "con" `app` strE tcname : map v tvars)
+              `app` (v "lst")
+          ]

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -61,9 +61,6 @@ import FFICXX.Generate.Code.HsRawType (hsClassRawType)
 import FFICXX.Generate.Code.HsTemplate
   ( genImportInTH,
     genImportInTemplate,
-    genTLTemplateImplementation,
-    genTLTemplateInstance,
-    genTLTemplateInterface,
     genTemplateMemberFunctions,
     genTmplImplementation,
     genTmplInstance,
@@ -75,6 +72,9 @@ import FFICXX.Generate.Code.HsTopLevel
     genImportForTLTemplate,
     genImportInModule,
     genImportInTopLevel,
+    genTLTemplateImplementation,
+    genTLTemplateInstance,
+    genTLTemplateInterface,
     genTopLevelDef,
   )
 import FFICXX.Generate.Dependency

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -49,6 +49,7 @@ import FFICXX.Generate.Code.HsImplementation
     genHsFrontInstStatic,
     genHsFrontInstVariables,
     genImportInImplementation,
+    genTemplateMemberFunctions,
   )
 import FFICXX.Generate.Code.HsInterface
   ( genHsFrontDecl,
@@ -61,7 +62,6 @@ import FFICXX.Generate.Code.HsRawType (hsClassRawType)
 import FFICXX.Generate.Code.HsTemplate
   ( genImportInTH,
     genImportInTemplate,
-    genTemplateMemberFunctions,
     genTmplImplementation,
     genTmplInstance,
     genTmplInterface,
@@ -127,10 +127,7 @@ import FFICXX.Generate.Util.HaskellSrcExts
 import FFICXX.Runtime.CodeGen.Cxx (HeaderName (..))
 import qualified FFICXX.Runtime.CodeGen.Cxx as R
 import GHC.Hs.Extension (GhcPs)
-import Language.Haskell.Exts.Syntax
-  ( Decl,
-    Module,
-  )
+import Language.Haskell.Exts.Syntax (Module)
 import Language.Haskell.Syntax
   ( HsDecl (ForD),
     HsModule,

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -59,11 +59,13 @@ import FFICXX.Generate.Code.HsInterface
   )
 import FFICXX.Generate.Code.HsProxy (genProxyInstance)
 import FFICXX.Generate.Code.HsRawType (hsClassRawType)
-import FFICXX.Generate.Code.HsTemplate
+import FFICXX.Generate.Code.HsTH
   ( genImportInTH,
-    genImportInTemplate,
     genTmplImplementation,
     genTmplInstance,
+  )
+import FFICXX.Generate.Code.HsTemplate
+  ( genImportInTemplate,
     genTmplInterface,
   )
 import FFICXX.Generate.Code.HsTopLevel


### PR DESCRIPTION
Moved top-level template codegen to HsTopLevel, TMF codegen to HsImplementation and split HsTemplate to HsTH and HsTemplate.
