### PR TITLE
Template and TH codegen via ghc-exactprint 

### DIFF
--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -203,7 +203,7 @@ simpleBuilder cfg sbc = do
   for_ tcms $ \m ->
     gen
       (tcmModule m <.> "TH" <.> "hs")
-      (prettyPrint (C.buildTHHs m))
+      (exactPrint (C.buildTHHs m))
   --
   -- TODO: Template.hs-boot need to be generated as well
   putStrLn "Generating hs-boot file"

--- a/fficxx/src/FFICXX/Generate/Builder.hs
+++ b/fficxx/src/FFICXX/Generate/Builder.hs
@@ -197,7 +197,7 @@ simpleBuilder cfg sbc = do
   for_ tcms $ \m ->
     gen
       (tcmModule m <.> "Template" <.> "hs")
-      (prettyPrint (C.buildTemplateHs m))
+      (exactPrint (C.buildTemplateHs m))
   --
   putStrLn "Generating TH.hs"
   for_ tcms $ \m ->

--- a/fficxx/src/FFICXX/Generate/Code/HsCast.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsCast.hs
@@ -60,11 +60,6 @@ genImportInCast m =
 --
 -- code
 --
-castBody_ :: [O.InstDecl ()]
-castBody_ =
-  [ O.insDecl (O.mkBind1 "cast" [O.mkPVar "x", O.mkPVar "f"] (O.app (O.mkVar "f") (O.app (O.mkVar "castPtr") (O.app (O.mkVar "get_fptr") (O.mkVar "x")))) Nothing),
-    O.insDecl (O.mkBind1 "uncast" [O.mkPVar "x", O.mkPVar "f"] (O.app (O.mkVar "f") (O.app (O.mkVar "cast_fptr_to_obj") (O.app (O.mkVar "castPtr") (O.mkVar "x")))) Nothing)
-  ]
 
 castBody :: [HsBind GhcPs]
 castBody =

--- a/fficxx/src/FFICXX/Generate/Code/HsCast.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsCast.hs
@@ -4,7 +4,6 @@ module FFICXX.Generate.Code.HsCast
 
     -- * code
     castBody,
-    castBody_,
     genHsFrontInstCastable,
     genHsFrontInstCastableSelf,
   )
@@ -34,15 +33,7 @@ import FFICXX.Generate.Util.GHCExactPrint
     tyapp,
     tycon,
   )
-import qualified FFICXX.Generate.Util.HaskellSrcExts as O
-  ( app,
-    insDecl,
-    mkBind1,
-    mkPVar,
-    mkVar,
-  )
 import GHC.Hs (GhcPs)
-import qualified Language.Haskell.Exts.Syntax as O (InstDecl)
 import Language.Haskell.Syntax
   ( HsBind,
     HsDecl,

--- a/fficxx/src/FFICXX/Generate/Code/HsImplementation.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsImplementation.hs
@@ -24,7 +24,7 @@ import qualified Data.List as L (foldr1)
 import FFICXX.Generate.Code.Primitive
   ( accessorSignature,
     cxx2HsType,
-    functionSignature',
+    functionSignature,
     functionSignatureTMF,
     hsFuncXformer,
   )
@@ -132,13 +132,13 @@ genHsFrontInstNew c = do
         -- cann = maybe "" id $ M.lookup (PkgMethod, constructorName c) amap
         -- newfuncann = mkComment 0 cann
         rhs = app (mkVar (hsFuncXformer f)) (mkVar (hscFuncName c f))
-     in mkFun_ (aliasedFuncName c f) (functionSignature' c f) [] rhs
+     in mkFun_ (aliasedFuncName c f) (functionSignature c f) [] rhs
 
 genHsFrontInstNonVirtual :: Class -> [HsDecl GhcPs]
 genHsFrontInstNonVirtual c =
   flip concatMap nonvirtualFuncs $ \f ->
     let rhs = app (mkVar (hsFuncXformer f)) (mkVar (hscFuncName c f))
-     in mkFun_ (aliasedFuncName c f) (functionSignature' c f) [] rhs
+     in mkFun_ (aliasedFuncName c f) (functionSignature c f) [] rhs
   where
     nonvirtualFuncs = nonVirtualNotNewFuncs (class_funcs c)
 
@@ -146,7 +146,7 @@ genHsFrontInstStatic :: Class -> [HsDecl GhcPs]
 genHsFrontInstStatic c =
   flip concatMap (staticFuncs (class_funcs c)) $ \f ->
     let rhs = app (mkVar (hsFuncXformer f)) (mkVar (hscFuncName c f))
-     in mkFun_ (aliasedFuncName c f) (functionSignature' c f) [] rhs
+     in mkFun_ (aliasedFuncName c f) (functionSignature c f) [] rhs
 
 genHsFrontInstVariables :: Class -> [HsDecl GhcPs]
 genHsFrontInstVariables c =

--- a/fficxx/src/FFICXX/Generate/Code/HsInterface.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsInterface.hs
@@ -21,7 +21,7 @@ import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import FFICXX.Generate.Code.Primitive
   ( classConstraints,
-    functionSignature',
+    functionSignature,
   )
 import FFICXX.Generate.Dependency.Graph
   ( getCyclicDepSubmodules,
@@ -111,7 +111,7 @@ genHsFrontDecl isHsBoot c = do
   let cdecl = TyClD noExtField (mkClass (classConstraints c) (typeclassName c) [mkTBind "a"] body)
       -- for hs-boot, we only have instance head.
       cdecl' = TyClD noExtField (mkClass (cxTuple []) (typeclassName c) [mkTBind "a"] [])
-      sigdecl f = mkFunSig (hsFuncName c f) (functionSignature' c f)
+      sigdecl f = mkFunSig (hsFuncName c f) (functionSignature c f)
       body = map sigdecl . virtualFuncs . class_funcs $ c
   if isHsBoot
     then return cdecl'

--- a/fficxx/src/FFICXX/Generate/Code/HsRawType.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsRawType.hs
@@ -32,11 +32,12 @@ import Language.Haskell.Syntax
 
 hsClassRawType :: Class -> [HsDecl GhcPs]
 hsClassRawType c =
-  [ TyClD noExtField (mkData rawname [] []),
+  [ TyClD noExtField (mkData rawname [] [] []),
     TyClD
       noExtField
       ( mkNewtype
           highname
+          []
           (conDecl highname [tyapp tyPtr rawtype])
           deriv
       ),

--- a/fficxx/src/FFICXX/Generate/Code/HsTH.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTH.hs
@@ -15,7 +15,7 @@ import FFICXX.Generate.Code.Cpp
     genTmplVarCpp,
   )
 import FFICXX.Generate.Code.Primitive
-  ( functionSignatureTT',
+  ( functionSignatureTT,
     tmplAccessorToTFun,
   )
 import FFICXX.Generate.Dependency (calculateDependency)
@@ -115,7 +115,7 @@ genTmplImplementation t =
           app (v "mkTFunc") $
             let typs = if nparams == 1 then map v tvars else [tupleE (map v tvars)]
              in tupleE (typs ++ [v "suffix", lam, v "tyf"])
-        sig' = functionSignatureTT' t f
+        sig' = functionSignatureTT t f
         tassgns =
           fmap
             (\(i, tp) -> pbind_ (p tp) (v "pure" `app` (v ("typ" ++ show i))))

--- a/fficxx/src/FFICXX/Generate/Code/HsTH.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTH.hs
@@ -4,7 +4,7 @@
 module FFICXX.Generate.Code.HsTH
   ( genImportInTH,
     genTmplImplementation,
-    -- genTmplInstance,
+    genTmplInstance,
   )
 where
 
@@ -42,19 +42,18 @@ import FFICXX.Generate.Type.Module
 import FFICXX.Generate.Util.GHCExactPrint
   ( app,
     bracketExp,
+    caseE,
     con,
-    -- binds,
-    -- caseE,
     doE,
     inapp,
     lamE,
     letE,
     listE,
-    mkBind1,
     mkBind1_,
     mkBindStmt,
     mkBodyStmt,
     mkFun,
+    mkFun_,
     mkImport,
     mkLetStmt,
     mkPVar,
@@ -137,17 +136,15 @@ genTmplImplementation t =
           f_s = tmplAccessorToTFun vf Setter
        in gen f_g ++ gen f_s
 
-{-
 genTmplInstance ::
   TemplateClassImportHeader ->
-  [Decl ()]
+  [HsDecl GhcPs]
 genTmplInstance tcih =
-  mkFun
+  mkFun_
     fname
     sig
     (p "isCprim" : zipWith (\x y -> pTuple [p x, p y]) qtvars pvars)
     rhs
-    Nothing
   where
     t = tcihTClass tcih
     fs = tclass_funcs t
@@ -161,7 +158,7 @@ genTmplInstance tcih =
     qtvars = map (\(i, _) -> "qtyp" ++ show i) itps
     pvars = map (\(i, _) -> "param" ++ show i) itps
     nparams = length itps
-    typs_v = if nparams == 1 then v (tvars !! 0) else tuple (map v tvars)
+    typs_v = if nparams == 1 then v (tvars !! 0) else tupleE (map v tvars)
     params_l = listE (map v pvars)
     sig =
       foldr1 tyfun $
@@ -178,27 +175,27 @@ genTmplInstance tcih =
     rhs =
       doE
         ( [paramsstmt, suffixstmt]
-            <> [ generator (p "callmod_") (v "fmap" `app` v "loc_module" `app` (v "location")),
-                 letStmt
+            <> [ mkBindStmt (p "callmod_") (v "fmap" `app` v "loc_module" `app` (v "location")),
+                 mkLetStmt
                    [ pbind_
                        (p "callmod")
                        (v "dot2_" `app` v "callmod_")
                    ]
                ]
-            <> map genqtypstmt (zip tvars qtvars)
-            <> map genstmt nfs
+            <> fmap genqtypstmt (zip tvars qtvars)
+            <> fmap genstmt nfs
             <> concatMap genvarstmt nvfs
-            <> [foreignSrcStmt, letStmt lststmt, qualStmt retstmt]
+            <> [foreignSrcStmt, mkLetStmt lststmt, mkBodyStmt retstmt]
         )
     --------------------------
     paramsstmt =
-      letStmt
+      mkLetStmt
         [ pbind_
             (p "params")
             (v "map" `app` (v "tpinfoSuffix") `app` params_l)
         ]
     suffixstmt =
-      letStmt
+      mkLetStmt
         [ pbind_
             (p "suffix")
             ( v "concatMap"
@@ -206,9 +203,9 @@ genTmplInstance tcih =
                 `app` params_l
             )
         ]
-    genqtypstmt (tvar, qtvar) = generator (p tvar) (v qtvar)
+    genqtypstmt (tvar, qtvar) = mkBindStmt (p tvar) (v qtvar)
     gen prefix nm f n =
-      generator
+      mkBindStmt
         (p (prefix <> show n))
         ( v nm
             `app` strE (hsTmplFuncName t f)
@@ -251,30 +248,32 @@ genTmplInstance tcih =
           ]
     -- TODO: refactor out the following code.
     foreignSrcStmt =
-      qualifier $
+      mkBodyStmt $
         (v "addModFinalizer")
-          `app` ( v "addForeignSource"
-                    `app` con "LangCxx"
-                    `app` ( L.foldr1
-                              (\x y -> inapp x (op "++") y)
-                              [ includeStatic,
-                                includeDynamic,
-                                namespaceStr,
-                                strE (tname <> "_instance"),
-                                paren $
-                                  caseE
-                                    (v "isCprim")
-                                    [ match (p "CPrim") (strE "_s"),
-                                      match (p "NonCPrim") (strE "")
-                                    ],
-                                strE "(",
-                                v "intercalate"
-                                  `app` strE ", "
-                                  `app` paren (inapp (v "callmod") (op ":") (v "params")),
-                                strE ")\n"
-                              ]
-                          )
-                )
+          `app` par
+            ( v "addForeignSource"
+                `app` con "LangCxx"
+                `app` par
+                  ( L.foldr1
+                      (\x y -> inapp x (op "++") y)
+                      [ includeStatic,
+                        par includeDynamic,
+                        par namespaceStr,
+                        strE (tname <> "_instance"),
+                        par $
+                          caseE
+                            (v "isCprim")
+                            [ (p "CPrim", strE "_s"),
+                              (p "NonCPrim", strE "")
+                            ],
+                        strE "(",
+                        v "intercalate"
+                          `app` strE ", "
+                          `app` par (inapp (v "callmod") (op ":") (v "params")),
+                        strE ")\n"
+                      ]
+                  )
+            )
       where
         -- temporary
         body =
@@ -298,28 +297,35 @@ genTmplInstance tcih =
         cxxNamespaces = v "concatMap" `app` (v "tpinfoCxxNamespaces") `app` params_l
         includeDynamic =
           letE
-            [ pbind_ (p "headers") cxxHeaders,
-              pbind_
-                (pApp (name "f") [p "x"])
-                (v "renderCMacro" `app` (con "Include" `app` v "x"))
-            ]
+            ( toLocalBinds False $
+                valBinds $
+                  [ pbind_ (p "headers") cxxHeaders,
+                    pbind_
+                      (pApp "f" [p "x"])
+                      (v "renderCMacro" `app` par (con "Include" `app` v "x"))
+                  ]
+            )
             (v "concatMap" `app` v "f" `app` v "headers")
         namespaceStr =
           letE
-            [ pbind_ (p "nss") cxxNamespaces,
-              pbind_
-                (pApp (name "f") [p "x"])
-                (v "renderCStmt" `app` (con "UsingNamespace" `app` v "x"))
-            ]
+            ( toLocalBinds False $
+                valBinds $
+                  [ pbind_ (p "nss") cxxNamespaces,
+                    pbind_
+                      (pApp "f" [p "x"])
+                      (v "renderCStmt" `app` (par (con "UsingNamespace" `app` v "x")))
+                  ]
+            )
             (v "concatMap" `app` v "f" `app` v "nss")
     retstmt =
       v "pure"
         `app` listE
           [ v "mkInstance"
               `app` listE []
-              `app` foldl1
-                (\f x -> con "AppT" `app` f `app` x)
-                (v "con" `app` strE (typeclassNameT t) : map v tvars)
+              `app` par
+                ( foldl1
+                    (\f x -> con "AppT" `app` f `app` x)
+                    (par (v "con" `app` strE (typeclassNameT t)) : map v tvars)
+                )
               `app` (v "lst")
           ]
--}

--- a/fficxx/src/FFICXX/Generate/Code/HsTH.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTH.hs
@@ -324,7 +324,7 @@ genTmplInstance tcih =
               `app` listE []
               `app` par
                 ( foldl1
-                    (\f x -> con "AppT" `app` f `app` x)
+                    (\f x -> par (con "AppT" `app` f `app` x))
                     (par (v "con" `app` strE (typeclassNameT t)) : map v tvars)
                 )
               `app` (v "lst")

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -50,29 +50,6 @@ import FFICXX.Generate.Util.GHCExactPrint
     tyapp,
     tycon,
   )
-import qualified FFICXX.Generate.Util.HaskellSrcExts as O
-  ( clsDecl,
-    con,
-    conDecl,
-    cxEmpty,
-    insDecl,
-    insType,
-    mkBind1,
-    mkClass,
-    mkData,
-    mkFunSig,
-    mkImport,
-    mkInstance,
-    mkNewtype,
-    mkPVar,
-    mkTBind,
-    mkTVar,
-    mkVar,
-    qualConDecl,
-    tyPtr,
-    tyapp,
-    tycon,
-  )
 import GHC.Hs (GhcPs)
 import Language.Haskell.Syntax
   ( HsDecl (TyClD),

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -9,7 +9,7 @@ where
 
 import FFICXX.Generate.Code.HsCast (castBody)
 import FFICXX.Generate.Code.Primitive
-  ( functionSignatureT',
+  ( functionSignatureT,
     tmplAccessorToTFun,
   )
 import FFICXX.Generate.Dependency (calculateDependency)
@@ -84,7 +84,7 @@ genTmplInterface t =
     vfs = tclass_vars t
     rawtype = foldl1 tyapp (tycon rname : map mkTVar tps)
     hightype = foldl1 tyapp (tycon hname : map mkTVar tps)
-    sigdecl f = mkFunSig (hsTmplFuncName t f) (functionSignatureT' t f)
+    sigdecl f = mkFunSig (hsTmplFuncName t f) (functionSignatureT t f)
     sigdeclV vf =
       let f_g = tmplAccessorToTFun vf Getter
           f_s = tmplAccessorToTFun vf Setter

--- a/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
+++ b/fficxx/src/FFICXX/Generate/Code/HsTemplate.hs
@@ -7,9 +7,9 @@ module FFICXX.Generate.Code.HsTemplate
   )
 where
 
-import FFICXX.Generate.Code.HsCast (castBody_)
+import FFICXX.Generate.Code.HsCast (castBody)
 import FFICXX.Generate.Code.Primitive
-  ( functionSignatureT,
+  ( functionSignatureT',
     tmplAccessorToTFun,
   )
 import FFICXX.Generate.Dependency (calculateDependency)
@@ -26,7 +26,31 @@ import FFICXX.Generate.Type.Class
 import FFICXX.Generate.Type.Module
   ( TemplateClassSubmoduleType (..),
   )
-import FFICXX.Generate.Util.HaskellSrcExts
+import FFICXX.Generate.Util.GHCExactPrint
+  ( con,
+    conDecl,
+    cxEmpty,
+    instD,
+    mkBind1_,
+    mkClass,
+    mkData,
+    mkFunSig,
+    mkImport,
+    mkInstance,
+    mkNewtype,
+    mkPVar,
+    mkTBind,
+    mkTVar,
+    mkTypeFamInst,
+    mkVar,
+    pApp,
+    parP,
+    tyParen,
+    tyPtr,
+    tyapp,
+    tycon,
+  )
+import qualified FFICXX.Generate.Util.HaskellSrcExts as O
   ( clsDecl,
     con,
     conDecl,
@@ -49,30 +73,32 @@ import FFICXX.Generate.Util.HaskellSrcExts
     tyapp,
     tycon,
   )
-import Language.Haskell.Exts.Build
-  ( name,
-    pApp,
-  )
-import Language.Haskell.Exts.Syntax
-  ( Decl,
+import GHC.Hs (GhcPs)
+import Language.Haskell.Syntax
+  ( HsDecl (TyClD),
     ImportDecl,
+    noExtField,
   )
 
-genImportInTemplate :: TemplateClass -> [ImportDecl ()]
+genImportInTemplate :: TemplateClass -> [ImportDecl GhcPs]
 genImportInTemplate t0 =
   fmap (mkImport . subModuleName) $ calculateDependency $ Left (TCSTTemplate, t0)
 
-genTmplInterface :: TemplateClass -> [Decl ()]
+genTmplInterface :: TemplateClass -> [HsDecl GhcPs]
 genTmplInterface t =
-  [ mkData rname (map mkTBind tps) [] Nothing,
-    mkNewtype
-      hname
-      (map mkTBind tps)
-      [qualConDecl Nothing Nothing (conDecl hname [tyapp tyPtr rawtype])]
-      Nothing,
-    mkClass cxEmpty (typeclassNameT t) (map mkTBind tps) methods,
-    mkInstance cxEmpty "FPtr" [hightype] fptrbody,
-    mkInstance cxEmpty "Castable" [hightype, tyapp tyPtr rawtype] castBody_
+  [ TyClD noExtField (mkData rname (fmap mkTBind tps) [] []),
+    TyClD noExtField $
+      mkNewtype
+        hname
+        (fmap mkTBind tps)
+        (conDecl hname [tyParen (tyapp tyPtr (tyParen rawtype))])
+        [],
+    TyClD noExtField $
+      mkClass cxEmpty (typeclassNameT t) (fmap mkTBind tps) methods,
+    instD $
+      mkInstance cxEmpty "FPtr" [hightype] fptrfam fptrbody,
+    instD $
+      mkInstance cxEmpty "Castable" [hightype, tyapp tyPtr (tyParen rawtype)] [] castBody
   ]
   where
     (hname, rname) = hsTemplateClassName t
@@ -81,14 +107,20 @@ genTmplInterface t =
     vfs = tclass_vars t
     rawtype = foldl1 tyapp (tycon rname : map mkTVar tps)
     hightype = foldl1 tyapp (tycon hname : map mkTVar tps)
-    sigdecl f = mkFunSig (hsTmplFuncName t f) (functionSignatureT t f)
+    sigdecl f = mkFunSig (hsTmplFuncName t f) (functionSignatureT' t f)
     sigdeclV vf =
       let f_g = tmplAccessorToTFun vf Getter
           f_s = tmplAccessorToTFun vf Setter
        in [sigdecl f_g, sigdecl f_s]
-    methods = map (clsDecl . sigdecl) fs ++ (map clsDecl . concatMap sigdeclV) vfs
+    methods = fmap sigdecl fs ++ concatMap sigdeclV vfs
+    fptrfam = [mkTypeFamInst "Raw" [tyParen hightype] rawtype]
     fptrbody =
-      [ insType (tyapp (tycon "Raw") hightype) rawtype,
-        insDecl (mkBind1 "get_fptr" [pApp (name hname) [mkPVar "ptr"]] (mkVar "ptr") Nothing),
-        insDecl (mkBind1 "cast_fptr_to_obj" [] (con hname) Nothing)
+      [ mkBind1_
+          "get_fptr"
+          [parP (pApp hname [mkPVar "ptr"])]
+          (mkVar "ptr"),
+        mkBind1_
+          "cast_fptr_to_obj"
+          []
+          (con hname)
       ]

--- a/fficxx/src/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Primitive.hs
@@ -1150,7 +1150,7 @@ functionSignatureTT t f = foldr1 tyfun (lst <> [tyapp (tycon "IO") ctyp])
 
 -- NEW
 functionSignatureTT' :: TemplateClass -> TemplateFunction -> HsType GhcPs
-functionSignatureTT' t f = foldr1 Ex.tyfun (lst <> [Ex.tyapp (Ex.tycon "IO") ctyp])
+functionSignatureTT' t f = foldr1 Ex.tyfun (lst <> [Ex.tyapp (Ex.tycon "IO") (Ex.tyParen ctyp)])
   where
     (hname, _) = hsTemplateClassName t
     ctyp = case f of

--- a/fficxx/src/FFICXX/Generate/Code/Primitive.hs
+++ b/fficxx/src/FFICXX/Generate/Code/Primitive.hs
@@ -1054,24 +1054,8 @@ extractArgRetTypes' mc isvirtual (CFunSig args ret) =
         Void -> pure Ex.unit_tycon
         _ -> error ("No such c type : " <> show typ)
 
--- OLD
-functionSignature :: Class -> Function -> Type ()
+functionSignature :: Class -> Function -> HsType GhcPs
 functionSignature c f =
-  let HsFunSig typs assts =
-        extractArgRetTypes
-          (Just c)
-          (isVirtualFunc f)
-          (CFunSig (genericFuncArgs f) (genericFuncRet f))
-      ctxt = cxTuple assts
-      arg0
-        | isVirtualFunc f = (mkTVar "a" :)
-        | isNonVirtualFunc f = (mkTVar (fst (hsClassName c)) :)
-        | otherwise = id
-   in tyForall Nothing (Just ctxt) (foldr1 tyfun (arg0 typs))
-
--- NEW
-functionSignature' :: Class -> Function -> HsType GhcPs
-functionSignature' c f =
   let HsFunSig' typs assts =
         extractArgRetTypes'
           (Just c)
@@ -1084,44 +1068,22 @@ functionSignature' c f =
         | otherwise = id
    in Ex.qualTy ctxt (foldr1 Ex.tyfun (arg0 typs))
 
--- OLD
-functionSignatureT :: TemplateClass -> TemplateFunction -> Type ()
-functionSignatureT t TFun {..} =
-  let (hname, _) = hsTemplateClassName t
-      slf = foldl1 tyapp (tycon hname : map mkTVar (tclass_params t))
-      ctyp = convertCpp2HS Nothing tfun_ret
-      lst = slf : map (convertCpp2HS Nothing . arg_type) tfun_args
-   in foldr1 tyfun (lst <> [tyapp (tycon "IO") ctyp])
-functionSignatureT t TFunNew {..} =
-  let ctyp = convertCpp2HS Nothing (TemplateType t)
-      lst = map (convertCpp2HS Nothing . arg_type) tfun_new_args
-   in foldr1 tyfun (lst <> [tyapp (tycon "IO") ctyp])
-functionSignatureT t TFunDelete =
-  let ctyp = convertCpp2HS Nothing (TemplateType t)
-   in ctyp `tyfun` (tyapp (tycon "IO") unit_tycon)
-functionSignatureT t TFunOp {..} =
-  let (hname, _) = hsTemplateClassName t
-      slf = foldl1 tyapp (tycon hname : map mkTVar (tclass_params t))
-      ctyp = convertCpp2HS Nothing tfun_ret
-      lst = slf : map (convertCpp2HS Nothing . arg_type) (argsFromOpExp tfun_opexp)
-   in foldr1 tyfun (lst <> [tyapp (tycon "IO") ctyp])
-
 -- NEW
-functionSignatureT' :: TemplateClass -> TemplateFunction -> HsType GhcPs
-functionSignatureT' t TFun {..} =
+functionSignatureT :: TemplateClass -> TemplateFunction -> HsType GhcPs
+functionSignatureT t TFun {..} =
   let (hname, _) = hsTemplateClassName t
       slf = foldl1 Ex.tyapp (Ex.tycon hname : map Ex.mkTVar (tclass_params t))
       ctyp = cxx2HsType Nothing tfun_ret
       lst = slf : map (cxx2HsType Nothing . arg_type) tfun_args
    in foldr1 Ex.tyfun (lst <> [Ex.tyapp (Ex.tycon "IO") (Ex.tyParen ctyp)])
-functionSignatureT' t TFunNew {..} =
+functionSignatureT t TFunNew {..} =
   let ctyp = cxx2HsType Nothing (TemplateType t)
       lst = map (cxx2HsType Nothing . arg_type) tfun_new_args
    in foldr1 Ex.tyfun (lst <> [Ex.tyapp (Ex.tycon "IO") (Ex.tyParen ctyp)])
-functionSignatureT' t TFunDelete =
+functionSignatureT t TFunDelete =
   let ctyp = cxx2HsType Nothing (TemplateType t)
    in ctyp `Ex.tyfun` (Ex.tyapp (Ex.tycon "IO") Ex.unit_tycon)
-functionSignatureT' t TFunOp {..} =
+functionSignatureT t TFunOp {..} =
   let (hname, _) = hsTemplateClassName t
       slf = foldl1 Ex.tyapp (Ex.tycon hname : fmap Ex.mkTVar (tclass_params t))
       ctyp = cxx2HsType Nothing tfun_ret
@@ -1129,28 +1091,8 @@ functionSignatureT' t TFunOp {..} =
    in foldr1 Ex.tyfun (lst <> [Ex.tyapp (Ex.tycon "IO") (Ex.tyParen ctyp)])
 
 -- TODO: rename this and combine this with functionSignatureTMF
--- OLD
-functionSignatureTT :: TemplateClass -> TemplateFunction -> Type ()
-functionSignatureTT t f = foldr1 tyfun (lst <> [tyapp (tycon "IO") ctyp])
-  where
-    (hname, _) = hsTemplateClassName t
-    ctyp = case f of
-      TFun {..} -> convertCpp2HS4Tmpl e Nothing spls tfun_ret
-      TFunNew {} -> convertCpp2HS4Tmpl e Nothing spls (TemplateType t)
-      TFunDelete -> unit_tycon
-      TFunOp {..} -> convertCpp2HS4Tmpl e Nothing spls tfun_ret
-    e = foldl1 tyapp (tycon hname : spls)
-    spls = map (tySplice . parenSplice . mkVar) $ tclass_params t
-    lst =
-      case f of
-        TFun {..} -> e : map (convertCpp2HS4Tmpl e Nothing spls . arg_type) tfun_args
-        TFunNew {..} -> map (convertCpp2HS4Tmpl e Nothing spls . arg_type) tfun_new_args
-        TFunDelete -> [e]
-        TFunOp {..} -> e : map (convertCpp2HS4Tmpl e Nothing spls . arg_type) (argsFromOpExp tfun_opexp)
-
--- NEW
-functionSignatureTT' :: TemplateClass -> TemplateFunction -> HsType GhcPs
-functionSignatureTT' t f = foldr1 Ex.tyfun (lst <> [Ex.tyapp (Ex.tycon "IO") (Ex.tyParen ctyp)])
+functionSignatureTT :: TemplateClass -> TemplateFunction -> HsType GhcPs
+functionSignatureTT t f = foldr1 Ex.tyfun (lst <> [Ex.tyapp (Ex.tycon "IO") (Ex.tyParen ctyp)])
   where
     (hname, _) = hsTemplateClassName t
     ctyp = case f of
@@ -1168,7 +1110,6 @@ functionSignatureTT' t f = foldr1 Ex.tyfun (lst <> [Ex.tyapp (Ex.tycon "IO") (Ex
         TFunOp {..} -> e : map (cxx2HsType4Tmpl e Nothing spls . arg_type) (argsFromOpExp tfun_opexp)
 
 -- TODO: rename this and combine this with functionSignatureTT
--- NEW
 functionSignatureTMF :: Class -> TemplateMemberFunction -> HsType GhcPs
 functionSignatureTMF c f =
   foldr1 Ex.tyfun (lst <> [Ex.tyapp (Ex.tycon "IO") ctyp])

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -62,7 +62,7 @@ import FFICXX.Generate.Code.HsRawType (hsClassRawType)
 import FFICXX.Generate.Code.HsTH
   ( genImportInTH,
     genTmplImplementation,
-    genTmplInstance,
+    -- genTmplInstance,
   )
 import FFICXX.Generate.Code.HsTemplate
   ( genImportInTemplate,
@@ -122,7 +122,6 @@ import FFICXX.Generate.Util.HaskellSrcExts
     evar,
     lang,
     mkImport,
-    mkModule,
     mkModuleE,
     unqual,
   )
@@ -556,20 +555,20 @@ buildTemplateHs m =
         <> genImportInTemplate t
     body = genTmplInterface t
 
-buildTHHs :: TemplateClassModule -> Module ()
+buildTHHs :: TemplateClassModule -> HsModule GhcPs
 buildTHHs m =
-  mkModule
+  Ex.mkModule
     (tcmModule m <.> "TH")
-    [lang ["TemplateHaskell"]]
-    ( [ mkImport "Data.Char",
-        mkImport "Data.List",
-        mkImport "Data.Monoid",
-        mkImport "Foreign.C.Types",
-        mkImport "Foreign.Ptr",
-        mkImport "Language.Haskell.TH",
-        mkImport "Language.Haskell.TH.Syntax",
-        mkImport "FFICXX.Runtime.CodeGen.Cxx",
-        mkImport "FFICXX.Runtime.TH"
+    ["TemplateHaskell"]
+    ( [ Ex.mkImport "Data.Char",
+        Ex.mkImport "Data.List",
+        Ex.mkImport "Data.Monoid",
+        Ex.mkImport "Foreign.C.Types",
+        Ex.mkImport "Foreign.Ptr",
+        Ex.mkImport "Language.Haskell.TH",
+        Ex.mkImport "Language.Haskell.TH.Syntax",
+        Ex.mkImport "FFICXX.Runtime.CodeGen.Cxx",
+        Ex.mkImport "FFICXX.Runtime.TH"
       ]
         <> imports
     )
@@ -577,11 +576,11 @@ buildTHHs m =
   where
     t = tcihTClass $ tcmTCIH m
     imports =
-      [mkImport (tcmModule m <.> "Template")]
+      [Ex.mkImport (tcmModule m <.> "Template")]
         <> genImportInTH t
     body = tmplImpls <> tmplInsts
     tmplImpls = genTmplImplementation t
-    tmplInsts = genTmplInstance (tcmTCIH m)
+    tmplInsts = [] -- genTmplInstance (tcmTCIH m)
 
 buildModuleHs :: ClassModule -> Module ()
 buildModuleHs m = mkModuleE (cmModule m) [] (genExport c) (genImportInModule c) []

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -535,25 +535,23 @@ buildProxyHs m =
   where
     body = genProxyInstance
 
-buildTemplateHs :: TemplateClassModule -> Module ()
+buildTemplateHs :: TemplateClassModule -> HsModule GhcPs
 buildTemplateHs m =
-  mkModule
+  Ex.mkModule
     (tcmModule m <.> "Template")
-    [ lang
-        [ "EmptyDataDecls",
-          "FlexibleInstances",
-          "MultiParamTypeClasses",
-          "TypeFamilies"
-        ]
+    [ "EmptyDataDecls",
+      "FlexibleInstances",
+      "MultiParamTypeClasses",
+      "TypeFamilies"
     ]
     imports
     body
   where
     t = tcihTClass $ tcmTCIH m
     imports =
-      [ mkImport "Foreign.C.Types",
-        mkImport "Foreign.Ptr",
-        mkImport "FFICXX.Runtime.Cast"
+      [ Ex.mkImport "Foreign.C.Types",
+        Ex.mkImport "Foreign.Ptr",
+        Ex.mkImport "FFICXX.Runtime.Cast"
       ]
         <> genImportInTemplate t
     body = genTmplInterface t

--- a/fficxx/src/FFICXX/Generate/ContentMaker.hs
+++ b/fficxx/src/FFICXX/Generate/ContentMaker.hs
@@ -62,7 +62,7 @@ import FFICXX.Generate.Code.HsRawType (hsClassRawType)
 import FFICXX.Generate.Code.HsTH
   ( genImportInTH,
     genTmplImplementation,
-    -- genTmplInstance,
+    genTmplInstance,
   )
 import FFICXX.Generate.Code.HsTemplate
   ( genImportInTemplate,
@@ -580,7 +580,7 @@ buildTHHs m =
         <> genImportInTH t
     body = tmplImpls <> tmplInsts
     tmplImpls = genTmplImplementation t
-    tmplInsts = [] -- genTmplInstance (tcmTCIH m)
+    tmplInsts = genTmplInstance (tcmTCIH m)
 
 buildModuleHs :: ClassModule -> Module ()
 buildModuleHs m = mkModuleE (cmModule m) [] (genExport c) (genImportInModule c) []

--- a/fficxx/src/FFICXX/Generate/Util/GHCExactPrint.hs
+++ b/fficxx/src/FFICXX/Generate/Util/GHCExactPrint.hs
@@ -59,6 +59,7 @@ module FFICXX.Generate.Util.GHCExactPrint
 
     -- * expr
     app,
+    caseE,
     con,
     doE,
     inapp,
@@ -135,6 +136,7 @@ import GHC.Data.Bag (emptyBag, listToBag)
 import GHC.Hs
   ( AnnSig (..),
     AnnsModule (..),
+    EpAnnHsCase (..),
     GhcPs,
     GrhsAnn (..),
     XImportDeclPass (..),
@@ -233,7 +235,7 @@ import Language.Haskell.Syntax
     HsLit (..),
     HsLocalBinds,
     HsLocalBindsLR (..),
-    HsMatchContext (FunRhs, LambdaExpr),
+    HsMatchContext (CaseAlt, FunRhs, LambdaExpr),
     HsModule (..),
     HsOuterTyVarBndrs (HsOuterImplicit),
     HsPatSigType (..),
@@ -790,8 +792,22 @@ mkBind1_ ::
   HsBind GhcPs
 mkBind1_ fname pats rhs = mkBind1 fname pats rhs (EmptyLocalBinds noExtField)
 
+listSep :: (EpaLocation -> TrailingAnn) -> [a] -> [GenLocated SrcSpanAnnA a]
+listSep _ [] = []
+listSep _ (x : []) = [mkL (-1) x]
+listSep sep xs =
+  let xs' = init xs
+      lastX = last xs
+      xs'' =
+        fmap
+          (L (mkRelSrcSpanAnn 0 (AnnListItem [sep (mkEpaDelta (-1))])))
+          xs'
+   in (xs'' ++ [mkL 0 lastX])
+
 tupleAnn :: [a] -> [GenLocated SrcSpanAnnA a]
-tupleAnn [] = []
+tupleAnn = listSep AddCommaAnn
+
+{- tupleAnn [] = []
 tupleAnn (x : []) = [mkL (-1) x]
 tupleAnn xs =
   let xs' = init xs
@@ -801,6 +817,7 @@ tupleAnn xs =
           (L (mkRelSrcSpanAnn 0 (AnnListItem [AddCommaAnn (mkEpaDelta (-1))])))
           xs'
    in (xs'' ++ [mkL 0 lastX])
+-}
 
 --
 -- Typeclass
@@ -992,6 +1009,28 @@ app x y =
     lx = mkL (-1) x
     ly = mkL 0 y
 
+caseE :: HsExpr GhcPs -> [(Pat GhcPs, HsExpr GhcPs)] -> HsExpr GhcPs
+caseE expr matches =
+  HsCase (mkRelEpAnn (-1) ann) (mkL 0 expr) grp
+  where
+    ann =
+      EpAnnHsCase
+        { hsCaseAnnCase = mkEpaDelta (-1),
+          hsCaseAnnOf = mkEpaDelta 0,
+          hsCaseAnnsRest = []
+        }
+    grp = MG FromSource (L (mkRelSrcSpanAnn (-1) ann') matches')
+    ann' =
+      AnnList
+        Nothing
+        (Just (AddEpAnn AnnOpenC (mkEpaDelta (-1))))
+        (Just (AddEpAnn AnnCloseC (mkEpaDelta (-1))))
+        []
+        []
+    matches' =
+      listSep AddSemiAnn $
+        fmap (\(p, e) -> mkMatch CaseAlt [p] e (EmptyLocalBinds noExtField)) matches
+
 -- NOTE: in ghc API, no difference between constructor and variable
 con :: String -> HsExpr GhcPs
 con = mkVar
@@ -1060,6 +1099,7 @@ mkMatch mctxt pats rhs bnds =
     glrhs =
       let ann = case mctxt of
             LambdaExpr -> AnnRarrow
+            CaseAlt -> AnnRarrow
             _ -> AnnEqual
           ann' =
             mkRelEpAnn
@@ -1078,7 +1118,7 @@ lamE pats expr =
         Nothing
         (Just (AddEpAnn AnnOpenP (mkEpaDelta (-1))))
         (Just (AddEpAnn AnnCloseP (mkEpaDelta (-1))))
-        [] -- [AddEpAnn AnnLam (mkEpaDelta (-1))]
+        []
         []
     match = mkMatch LambdaExpr pats expr (EmptyLocalBinds noExtField)
 
@@ -1102,7 +1142,7 @@ listE itms =
               (Just (AddEpAnn AnnCloseS (mkEpaDelta (-1))))
               []
               []
-          litms = fmap (mkL (-1)) itms
+          litms = tupleAnn itms
        in ExplicitList (mkRelEpAnn (-1) ann) litms
   where
 
@@ -1344,16 +1384,6 @@ app = LHE.app
 app' :: String -> String -> Exp ()
 app' x y = App () (mkVar x) (mkVar y)
 
-unqual :: String -> QName ()
-unqual = UnQual () . Ident ()
-
-qualConDecl ::
-  Maybe [TyVarBind ()] ->
-  Maybe (Context ()) ->
-  ConDecl () ->
-  QualConDecl ()
-qualConDecl = QualConDecl ()
-
 recDecl :: String -> [FieldDecl ()] -> ConDecl ()
 recDecl n rs = RecDecl () (Ident () n) rs
 
@@ -1387,9 +1417,6 @@ x `dot` y = x `app` mkVar "." `app` y
 tyForeignPtr :: Type ()
 tyForeignPtr = tycon "ForeignPtr"
 
-typeBracket :: Type () -> Bracket ()
-typeBracket = TypeBracket ()
-
 evar :: QName () -> ExportSpec ()
 evar = EVar ()
 
@@ -1412,24 +1439,11 @@ emodule nm = EModuleContents () (ModuleName () nm)
 nonamespace :: Namespace ()
 nonamespace = NoNamespace ()
 
-generator :: Pat () -> Exp () -> Stmt ()
-generator = Generator ()
-
-qualifier :: Exp () -> Stmt ()
-qualifier = Qualifier ()
-
-unkindedVar :: Name () -> TyVarBind ()
-unkindedVar = UnkindedVar ()
-
 if_ :: Exp () -> Exp () -> Exp () -> Exp ()
 if_ = If ()
 
 urhs :: Exp () -> Rhs ()
 urhs = UnGuardedRhs ()
-
--- | case pattern match p -> e
-match :: Pat () -> Exp () -> Alt ()
-match p e = Alt () p (urhs e) Nothing
 
 eWildCard :: Int -> EWildcard ()
 eWildCard = EWildcard ()

--- a/fficxx/src/FFICXX/Generate/Util/GHCExactPrint.hs
+++ b/fficxx/src/FFICXX/Generate/Util/GHCExactPrint.hs
@@ -617,17 +617,17 @@ mkTBind name = UserTyVar (mkRelEpAnn (-1) []) () (mkLIdP (-1) name)
 mkData ::
   -- | data type name
   String ->
-  -- [TyVarBind ()] ->
+  [HsTyVarBndr () GhcPs] ->
   [ConDecl GhcPs] ->
   HsDeriving GhcPs ->
   TyClDecl GhcPs
-mkData name {- tbinds -} cdecls deriv =
+mkData name tbinds cdecls deriv =
   DataDecl (mkRelEpAnn (-1) annos) (mkLIdP 0 name) qty Prefix dfn
   where
     annos =
       [ AddEpAnn AnnData (mkEpaDelta (-1))
       ]
-    qty = HsQTvs noExtField []
+    qty = HsQTvs noExtField $ fmap (mkL 0) tbinds
     dfn =
       HsDataDefn
         { dd_ext = noExtField,
@@ -641,18 +641,18 @@ mkData name {- tbinds -} cdecls deriv =
 mkNewtype ::
   -- | newtype name
   String ->
-  -- [TyVarBind ()] ->
+  [HsTyVarBndr () GhcPs] ->
   ConDecl GhcPs ->
   HsDeriving GhcPs ->
   TyClDecl GhcPs
-mkNewtype name {- tbinds -} cdecl deriv =
+mkNewtype name tbinds cdecl deriv =
   DataDecl (mkRelEpAnn (-1) annos) (mkLIdP 0 name) qty Prefix dfn
   where
     annos =
       [ AddEpAnn AnnNewtype (mkEpaDelta (-1)),
         AddEpAnn AnnEqual (mkEpaDelta 0)
       ]
-    qty = HsQTvs noExtField []
+    qty = HsQTvs noExtField $ fmap (mkL 0) tbinds
     dfn =
       HsDataDefn
         { dd_ext = noExtField,

--- a/fficxx/src/FFICXX/Generate/Util/GHCExactPrint.hs
+++ b/fficxx/src/FFICXX/Generate/Util/GHCExactPrint.hs
@@ -55,6 +55,7 @@ module FFICXX.Generate.Util.GHCExactPrint
     pApp,
     pTuple,
     parP,
+    wildcard,
 
     -- * expr
     app,
@@ -976,6 +977,9 @@ parP p =
     (L (tokLoc (-1)) HsTok)
     (mkL (-1) p)
     (L (tokLoc (-1)) HsTok)
+
+wildcard :: Pat GhcPs
+wildcard = WildPat noExtField
 
 --
 -- Expr


### PR DESCRIPTION
and now only top-level function generations are left.